### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **Vue 3 / Quasar Framework SPA** (portfolio site with photography gallery, Game Timer, and Movie Vote features). There is no backend server or database — it is entirely client-side.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev server | `npx quasar dev` (serves at `http://localhost:9000/`) |
+| Lint | `npm run lint` |
+| Format | `npm run format` |
+| Unit tests | `npm test` |
+| Build | `npm run build` (runs `prebuild` → thumbnail generation first) |
+
+### Caveats
+
+- **Photo assets use Git LFS.** Without LFS checkout the files are ~132-byte pointer stubs and the photography gallery shows blank. The app still functions; only images are missing.
+- **TMDB API keys are optional.** Movie Vote movie search requires `VITE_TMDB_READ_ACCESS_TOKEN` or `VITE_TMDB_API_KEY` in a `.env` file (see `.env.example`). Without them the rest of the app works fine.
+- **`npm run build` requires Sharp** to generate photo thumbnails via `prebuild`. The dev server (`quasar dev`) does **not** need thumbnails and starts fine without them.
+- **Package manager:** Use `npm` — the lockfile is `package-lock.json`. `pnpm` and `yarn` are listed in engines but not actively used.
+- **`postinstall` runs `quasar prepare`** automatically after `npm install`, which generates `.quasar/` typings needed for linting and IDE support.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, including:

- Quick reference table for common commands (install, dev, lint, test, build)
- Caveats about Git LFS photo assets, optional TMDB API keys, Sharp dependency for builds, and package manager choice

### Demo

[portfolio_site_demo.mp4](https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_demo.mp4)

The Quasar dev server starts at `http://localhost:9000/` with full interactivity — navigation, Game Timer (adding players, running timers), and all Vue/Quasar components rendering correctly.

[Homepage loaded](https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Game Timer page](https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgame_timer_page.webp)
[Player added to game](https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayer_added.webp)
[Timer running](https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimer_running.webp)

### Environment verification

| Check | Result |
|-------|--------|
| `npm install` | All 527 packages installed |
| `npm run lint` | Clean (no warnings/errors) |
| `npm test` | 6/6 tests passed |
| `npx quasar dev` | Dev server at localhost:9000 |
| Browser interaction | Game Timer: added player, started timer |

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-387b463e-3f53-47b2-967f-be02c982d027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-387b463e-3f53-47b2-967f-be02c982d027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

