### PR TITLE
Fix link preview / onebox metadata for hash-routed apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,18 @@
       content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>"
     />
 
+    <!-- Open Graph / Twitter defaults. Per-route overrides are written by
+         scripts/generate-share-pages.mjs at build time. -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="<%= productName %>" />
+    <meta property="og:title" content="<%= productName %>" />
+    <meta property="og:description" content="<%= productDescription %>" />
+    <meta property="og:image" content="icons/favicon-default.svg" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="<%= productName %>" />
+    <meta name="twitter:description" content="<%= productDescription %>" />
+    <meta name="twitter:image" content="icons/favicon-default.svg" />
+
     <link id="portfolio-favicon" rel="icon" type="image/svg+xml" href="icons/favicon-default.svg" />
     <link rel="icon" href="favicon.ico" sizes="48x48" />
   </head>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "portfolio-site",
   "version": "0.0.1",
-  "description": "A Quasar Project",
-  "productName": "Portfolio Site",
+  "description": "Portfolio site for David J. Perry — photography, writing, and small web apps.",
+  "productName": "David J. Perry",
   "author": "David Perry <enmaku@gmail.com>",
   "type": "module",
   "private": true,
@@ -12,8 +12,10 @@
     "test": "node --test src/features/movie-vote/irv.test.js",
     "dev": "quasar dev",
     "generate-thumbs": "node ./scripts/generate-photo-thumbs.mjs",
+    "generate-share-pages": "node ./scripts/generate-share-pages.mjs",
     "prebuild": "npm run generate-thumbs",
     "build": "quasar build",
+    "postbuild": "npm run generate-share-pages",
     "postinstall": "quasar prepare"
   },
   "dependencies": {

--- a/scripts/generate-share-pages.mjs
+++ b/scripts/generate-share-pages.mjs
@@ -1,0 +1,151 @@
+/**
+ * Emit per-route HTML entry points into `dist/spa/` so link-preview crawlers
+ * see route-specific <title>, description, and Open Graph tags even though
+ * the app itself is a hash-routed SPA.
+ *
+ * Each generated page:
+ *   1. Ships the correct meta tags for that route.
+ *   2. Includes an inline redirect that sends real browsers to the equivalent
+ *      hash URL so the SPA router takes over.
+ *
+ * Uses `GH_PAGES_BASE` (same env the Quasar build reads) so OG URLs and the
+ * redirect target respect the GitHub Pages project base path. Uses
+ * `SITE_ORIGIN` (defaults to https://enmaku.github.io) to build absolute OG
+ * URLs, since most preview crawlers require absolute URLs.
+ */
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { SHAREABLE_ROUTES, SHARE_METADATA } from '../src/share-metadata.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.join(__dirname, '..')
+const DIST = path.join(ROOT, 'dist/spa')
+const INDEX_HTML = path.join(DIST, 'index.html')
+
+const SITE_ORIGIN = (process.env.SITE_ORIGIN || 'https://enmaku.github.io').replace(/\/+$/, '')
+const PAGES_BASE = normalizeBase(process.env.GH_PAGES_BASE || '/')
+
+function normalizeBase(value) {
+  if (!value) return '/'
+  const withLeading = value.startsWith('/') ? value : `/${value}`
+  return withLeading.endsWith('/') ? withLeading : `${withLeading}/`
+}
+
+/** @param {string} relPath */
+function absoluteUrl(relPath) {
+  const cleaned = String(relPath).replace(/^\/+/, '')
+  return `${SITE_ORIGIN}${PAGES_BASE}${cleaned}`
+}
+
+/** @param {string} value */
+function escapeAttr(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/** @param {string} value */
+function escapeJs(value) {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+/**
+ * Remove any `<meta attrName="keyValue" ...>` tags, tolerating Quasar/Vite's
+ * minified output which drops quotes around simple attribute values.
+ *
+ * @param {string} html
+ * @param {'name' | 'property'} attrName
+ * @param {string} keyValue
+ */
+function removeMeta(html, attrName, keyValue) {
+  return html.replace(/<meta\b[^>]*>/gi, (match) => {
+    const pattern = new RegExp(`\\b${attrName}=(?:"${keyValue}"|${keyValue})(?=[\\s>])`, 'i')
+    return pattern.test(match) ? '' : match
+  })
+}
+
+/**
+ * @param {string} html
+ * @param {'name' | 'property'} attrName
+ * @param {string} keyValue
+ * @param {string} content
+ */
+function setMeta(html, attrName, keyValue, content) {
+  const stripped = removeMeta(html, attrName, keyValue)
+  const tag = `<meta ${attrName}="${keyValue}" content="${escapeAttr(content)}" />`
+  return stripped.replace('</head>', `    ${tag}\n  </head>`)
+}
+
+/** @param {string} html @param {string} title */
+function setTitle(html, title) {
+  const next = `<title>${escapeAttr(title)}</title>`
+  if (/<title>[\s\S]*?<\/title>/i.test(html)) {
+    return html.replace(/<title>[\s\S]*?<\/title>/i, next)
+  }
+  return html.replace('</head>', `    ${next}\n  </head>`)
+}
+
+/**
+ * @param {string} html
+ * @param {import('../src/share-metadata.js').ShareMetadata} entry
+ */
+function buildShareHtml(html, entry) {
+  const shareUrl = absoluteUrl(entry.shareSlug)
+  const ogImageUrl = absoluteUrl(entry.ogImage)
+  const hashTarget =
+    entry.routePath === '/' ? `${PAGES_BASE}#/` : `${PAGES_BASE}#${entry.routePath}`
+
+  let output = html
+
+  output = setTitle(output, entry.title)
+  output = setMeta(output, 'name', 'description', entry.description)
+  output = setMeta(output, 'property', 'og:title', entry.title)
+  output = setMeta(output, 'property', 'og:description', entry.description)
+  output = setMeta(output, 'property', 'og:image', ogImageUrl)
+  output = setMeta(output, 'property', 'og:url', shareUrl)
+  output = setMeta(output, 'name', 'twitter:title', entry.title)
+  output = setMeta(output, 'name', 'twitter:description', entry.description)
+  output = setMeta(output, 'name', 'twitter:image', ogImageUrl)
+
+  const redirectTag = `<script>(function(){if(!window.location.hash){window.location.replace('${escapeJs(hashTarget)}');}})();</script>`
+  output = output.replace(/<body(\s[^>]*)?>/i, (match) => `${match}\n    ${redirectTag}`)
+
+  return output
+}
+
+async function main() {
+  let baseHtml
+  try {
+    baseHtml = await fs.readFile(INDEX_HTML, 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      console.warn('generate-share-pages: dist/spa/index.html not found, skipping')
+      return
+    }
+    throw e
+  }
+
+  const rootHtml = buildShareHtml(baseHtml, SHARE_METADATA.root)
+  await fs.writeFile(INDEX_HTML, rootHtml, 'utf8')
+  console.log(`generate-share-pages: updated ${path.relative(ROOT, INDEX_HTML)}`)
+
+  for (const entry of SHAREABLE_ROUTES) {
+    const outDir = path.join(DIST, entry.shareSlug)
+    const outFile = path.join(outDir, 'index.html')
+    await fs.mkdir(outDir, { recursive: true })
+    await fs.writeFile(outFile, buildShareHtml(baseHtml, entry), 'utf8')
+    console.log(`generate-share-pages: wrote ${path.relative(ROOT, outFile)}`)
+  }
+
+  console.log(
+    `generate-share-pages: site origin ${SITE_ORIGIN}, pages base ${PAGES_BASE}`,
+  )
+}
+
+main().catch((e) => {
+  console.error('generate-share-pages failed:', e)
+  process.exitCode = 1
+})

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -43,8 +43,10 @@ function applyRouteSharePreview(to) {
   setMetaContent('name', 'description', entry.description)
   setMetaContent('property', 'og:title', entry.title)
   setMetaContent('property', 'og:description', entry.description)
+  setMetaContent('property', 'og:image', entry.ogImage)
   setMetaContent('name', 'twitter:title', entry.title)
   setMetaContent('name', 'twitter:description', entry.description)
+  setMetaContent('name', 'twitter:image', entry.ogImage)
 }
 
 /**

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import {
   createWebHashHistory,
 } from 'vue-router'
 import routes, { portfolioDocumentTitle } from './routes'
+import { SHARE_METADATA } from '../share-metadata.js'
 
 const FAVICON_IDS = new Set(['default', 'photo', 'info', 'timer', 'movie'])
 
@@ -23,6 +24,39 @@ function applyRouteFavicon(to) {
   const el = document.getElementById('portfolio-favicon')
   if (el instanceof HTMLLinkElement && el.getAttribute('href') !== href) {
     el.setAttribute('href', href)
+  }
+}
+
+/**
+ * Keeps description + OG/Twitter tags aligned as users navigate within the SPA.
+ * Crawlers still read the per-route HTML emitted by `scripts/generate-share-pages.mjs`,
+ * this just prevents drift for users who already have the page open.
+ *
+ * @param {import('vue-router').RouteLocationNormalized} to
+ */
+function applyRouteSharePreview(to) {
+  if (typeof document === 'undefined') return
+  const key = typeof to.meta.shareKey === 'string' ? to.meta.shareKey : null
+  const entry = key ? SHARE_METADATA[key] : null
+  if (!entry) return
+
+  setMetaContent('name', 'description', entry.description)
+  setMetaContent('property', 'og:title', entry.title)
+  setMetaContent('property', 'og:description', entry.description)
+  setMetaContent('name', 'twitter:title', entry.title)
+  setMetaContent('name', 'twitter:description', entry.description)
+}
+
+/**
+ * @param {'name' | 'property'} attr
+ * @param {string} key
+ * @param {string} value
+ */
+function setMetaContent(attr, key, value) {
+  const selector = `meta[${attr}="${key}"]`
+  const el = document.querySelector(selector)
+  if (el instanceof HTMLMetaElement) {
+    el.setAttribute('content', value)
   }
 }
 
@@ -47,6 +81,7 @@ export default defineRouter(function (/* { store, ssrContext } */) {
     const title = to.meta.title
     document.title = typeof title === 'string' ? title : portfolioDocumentTitle
     applyRouteFavicon(to)
+    applyRouteSharePreview(to)
   })
 
   return Router

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,8 +1,10 @@
+import { SHARE_METADATA, SITE_NAME } from '../share-metadata.js'
+
 /**
  * Default `document.title` when a route omits `meta.title`.
  * @type {string}
  */
-export const portfolioDocumentTitle = 'David J. Perry'
+export const portfolioDocumentTitle = SITE_NAME
 
 /** @type {import('vue-router').RouteRecordRaw[]} */
 const routes = [
@@ -13,12 +15,20 @@ const routes = [
       {
         path: '',
         component: () => import('pages/IndexPage.vue'),
-        meta: { title: portfolioDocumentTitle, favicon: 'photo' },
+        meta: {
+          title: SHARE_METADATA.root.title,
+          favicon: SHARE_METADATA.root.favicon,
+          shareKey: 'root',
+        },
       },
       {
         path: 'about',
         component: () => import('pages/AboutPage.vue'),
-        meta: { title: portfolioDocumentTitle, favicon: 'info' },
+        meta: {
+          title: SHARE_METADATA.about.title,
+          favicon: SHARE_METADATA.about.favicon,
+          shareKey: 'about',
+        },
       },
     ],
   },
@@ -29,7 +39,11 @@ const routes = [
       {
         path: '',
         component: () => import('pages/projects/GameTimerPage.vue'),
-        meta: { title: 'Game Timer', favicon: 'timer' },
+        meta: {
+          title: SHARE_METADATA.gameTimer.title,
+          favicon: SHARE_METADATA.gameTimer.favicon,
+          shareKey: 'gameTimer',
+        },
       },
     ],
   },
@@ -40,7 +54,11 @@ const routes = [
       {
         path: '',
         component: () => import('pages/projects/MovieVotePage.vue'),
-        meta: { title: 'Movie Vote', favicon: 'movie' },
+        meta: {
+          title: SHARE_METADATA.movieVote.title,
+          favicon: SHARE_METADATA.movieVote.favicon,
+          shareKey: 'movieVote',
+        },
       },
     ],
   },

--- a/src/share-metadata.js
+++ b/src/share-metadata.js
@@ -6,9 +6,6 @@
  * - `scripts/generate-share-pages.mjs` (build-time per-route HTML copies so
  *   link previews on Discord/Slack/etc. see correct titles even though the
  *   site is a hash-routed SPA)
- *
- * IMPORTANT: this module must work in both Node and the browser, so it uses
- * only plain ESM with no Vue/Vite/quasar imports.
  */
 
 export const SITE_NAME = 'David J. Perry'
@@ -69,12 +66,3 @@ export const SHAREABLE_ROUTES = [
   SHARE_METADATA.movieVote,
   SHARE_METADATA.about,
 ]
-
-/** @param {string} path */
-export function findShareMetadataByRoute(path) {
-  const normalized = path.replace(/\/+$/, '') || '/'
-  for (const entry of Object.values(SHARE_METADATA)) {
-    if (entry.routePath === normalized) return entry
-  }
-  return null
-}

--- a/src/share-metadata.js
+++ b/src/share-metadata.js
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for shareable HTML metadata.
+ *
+ * Consumed by:
+ * - the Vue router (browser tab titles + client-side OG tag sync)
+ * - `scripts/generate-share-pages.mjs` (build-time per-route HTML copies so
+ *   link previews on Discord/Slack/etc. see correct titles even though the
+ *   site is a hash-routed SPA)
+ *
+ * IMPORTANT: this module must work in both Node and the browser, so it uses
+ * only plain ESM with no Vue/Vite/quasar imports.
+ */
+
+export const SITE_NAME = 'David J. Perry'
+
+const DEFAULT_OG_IMAGE = 'icons/favicon-default.svg'
+
+/**
+ * @typedef {object} ShareMetadata
+ * @property {string} title           Browser tab title AND preview title.
+ * @property {string} description     Preview description.
+ * @property {string} routePath       Router path (no hash, no publicPath).
+ * @property {string} shareSlug       Directory slug under dist/spa for the generated HTML (empty = root).
+ * @property {string} ogImage         Path (relative to publicPath) to an OG image.
+ * @property {string} favicon         Favicon id used by applyRouteFavicon.
+ */
+
+/** @type {Record<string, ShareMetadata>} */
+export const SHARE_METADATA = {
+  root: {
+    title: SITE_NAME,
+    description: 'Portfolio site for David J. Perry — photography, writing, and small web apps.',
+    routePath: '/',
+    shareSlug: '',
+    ogImage: DEFAULT_OG_IMAGE,
+    favicon: 'photo',
+  },
+  about: {
+    title: `About — ${SITE_NAME}`,
+    description: 'About David J. Perry.',
+    routePath: '/about',
+    shareSlug: 'about',
+    ogImage: 'icons/favicon-info.svg',
+    favicon: 'info',
+  },
+  gameTimer: {
+    title: 'Game Timer',
+    description:
+      'Shared multiplayer countdown timers for tabletop games. Host a room, share the code, keep everyone in sync.',
+    routePath: '/projects/game-timer',
+    shareSlug: 'projects/game-timer',
+    ogImage: 'icons/favicon-timer.svg',
+    favicon: 'timer',
+  },
+  movieVote: {
+    title: 'Movie Vote',
+    description:
+      'Collaboratively pick a movie with friends. Nominate titles, rank your favorites, and let instant-runoff voting decide.',
+    routePath: '/projects/movie-vote',
+    shareSlug: 'projects/movie-vote',
+    ogImage: 'icons/favicon-movie.svg',
+    favicon: 'movie',
+  },
+}
+
+/** Ordered list of routes that should get their own generated preview HTML. */
+export const SHAREABLE_ROUTES = [
+  SHARE_METADATA.gameTimer,
+  SHARE_METADATA.movieVote,
+  SHARE_METADATA.about,
+]
+
+/** @param {string} path */
+export function findShareMetadataByRoute(path) {
+  const normalized = path.replace(/\/+$/, '') || '/'
+  for (const entry of Object.values(SHARE_METADATA)) {
+    if (entry.routePath === normalized) return entry
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Shared links to **Game Timer**, **Movie Vote**, and **About** previously surfaced generic site title and description in Slack, Discord, and other fetchers. The app is a single-page app on GitHub Pages with hash routing, so crawlers only ever loaded the root `index.html`.

## What changed

- **`src/share-metadata.js`** — Central definitions for default and per-route title, description, and Open Graph / Twitter tags.
- **`index.html`** — Adds default OG/Twitter meta so even the root document has reasonable fallbacks.
- **`src/router/index.js`** and **`src/router/routes.js`** — On client navigation, keep document title and meta tags aligned with the active route using the same metadata source as the build.
- **`scripts/generate-share-pages.mjs`** — Post-build step invoked from **`package.json`** that writes route-specific HTML entry points (e.g. under `projects/` and `about/`) with correct OG tags and a small inline redirect into the hash URL so real browsers still land in the SPA.
- Branch includes **`main`** merged so `.gitignore` stays current with upstream.

## Testing notes

- Build completes with the new postbuild step; spot-check generated HTML and a shared link preview for timer, movie vote, and about routes.

Fixes #5