### PR TITLE
Harden P2P sessions for disconnects and identity (game timer + movie vote)

### DIFF
--- a/src/features/game-timer/p2p/protocol.js
+++ b/src/features/game-timer/p2p/protocol.js
@@ -18,6 +18,11 @@ export const MSG_HOST_PING = 'gt-p'
 /** Hub → guest: host tab visibility (`document.visibilityState`) for UX / liveness hints. */
 export const MSG_HOST_VISIBILITY = 'gt-v'
 
+/** Guest → hub: stable client identity presented immediately after `open` so
+ *  the host can drop a stale `DataConnection` left over from a previous
+ *  session for the same guest. */
+export const MSG_GUEST_HELLO = 'gt-hi'
+
 /**
  * @param {unknown} data
  * @returns {data is { type: string, snapshot?: GameTimerSyncPayload, seq?: number }}
@@ -118,6 +123,24 @@ export function parseGuestMessage(data) {
  */
 export function isHostEndedNotice(data) {
   return isRecord(data) && data.type === MSG_HOST_ENDED
+}
+
+/**
+ * @param {string} stableId
+ * @returns {{ type: typeof MSG_GUEST_HELLO, stableId: string }}
+ */
+export function encodeGuestHello(stableId) {
+  return { type: MSG_GUEST_HELLO, stableId }
+}
+
+/**
+ * @param {unknown} data
+ * @returns {{ stableId: string } | null}
+ */
+export function parseGuestHello(data) {
+  if (!isRecord(data) || data.type !== MSG_GUEST_HELLO) return null
+  if (typeof data.stableId !== 'string' || !data.stableId) return null
+  return { stableId: data.stableId }
 }
 
 /**

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -12,7 +12,11 @@ import { Notify } from 'quasar'
 import Peer from 'peerjs'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { classifyPeerError, isUnavailableIdError } from '../../p2p/errors.js'
+import { deriveStableHostSuffix, getStableClientId } from '../../p2p/identity.js'
+import { reconnectDelayMs as sharedReconnectDelayMs } from '../../p2p/reconnect.js'
 import {
+  encodeGuestHello,
   encodeGuestUpdate,
   encodeHostPing,
   encodeHostSnapshot,
@@ -20,6 +24,7 @@ import {
   isHostEndedNotice,
   isHostPing,
   MSG_HOST_ENDED,
+  parseGuestHello,
   parseGuestMessage,
   parseHostMessage,
   parseHostVisibility,
@@ -30,6 +35,8 @@ import {
   isValidRoomSuffix,
   normalizeRoomSuffixInput,
 } from './roomId.js'
+
+const STABLE_HOST_SUFFIX_APP = 'gametimer'
 
 /**
  * @typedef {object} GameTimerP2PHandlers
@@ -55,6 +62,19 @@ let peer = null
 
 /** @type {Set<import('peerjs').DataConnection>} */
 const hubConnections = new Set()
+
+/**
+ * Stable client id → currently-open hub DataConnection for that guest.
+ * Lets the host close a stale `DataConnection` left over from a previous
+ * session when the same browser reconnects (same room code, same tab after
+ * wifi drop, etc.), so orphan conns don't linger and fan out duplicate
+ * snapshots to a closed transport.
+ * @type {Map<string, import('peerjs').DataConnection>}
+ */
+const stableIdToConn = new Map()
+
+/** @type {Map<import('peerjs').DataConnection, string>} */
+const connToStableId = new Map()
 
 /** @type {import('peerjs').DataConnection | null} */
 let guestHubConn = null
@@ -260,6 +280,8 @@ function destroyWireOnly() {
     } catch { void 0 }
   }
   hubConnections.clear()
+  stableIdToConn.clear()
+  connToStableId.clear()
   if (guestHubConn) {
     try {
       guestHubConn.close()
@@ -282,11 +304,10 @@ function destroyWireOnly() {
  * @returns {number}
  */
 function reconnectDelayMs(attemptAfterFirst) {
-  const exp = Math.min(
-    RECONNECT_BASE_DELAY_MS * 2 ** attemptAfterFirst,
-    RECONNECT_MAX_DELAY_MS,
-  )
-  return exp + Math.floor(Math.random() * 400)
+  return sharedReconnectDelayMs(attemptAfterFirst, {
+    baseMs: RECONNECT_BASE_DELAY_MS,
+    maxMs: RECONNECT_MAX_DELAY_MS,
+  })
 }
 
 /**
@@ -340,8 +361,34 @@ function attachHubConnectionHandlers(p) {
     conn.on('data', (data) => handleHubInbound(conn, data))
     conn.on('close', () => {
       hubConnections.delete(conn)
+      const sid = connToStableId.get(conn)
+      if (sid && stableIdToConn.get(sid) === conn) stableIdToConn.delete(sid)
+      connToStableId.delete(conn)
     })
   })
+}
+
+/**
+ * Register a guest's stable client id and close any orphan `DataConnection`
+ * still registered to that id (common when the same browser reconnects after
+ * a drop).
+ * @param {import('peerjs').DataConnection} conn
+ * @param {string} stableId
+ */
+function onGuestHello(conn, stableId) {
+  if (connToStableId.has(conn)) return
+  const orphan = stableIdToConn.get(stableId)
+  if (orphan && orphan !== conn) {
+    try {
+      connToStableId.delete(orphan)
+      orphan.close()
+    } catch {
+      void 0
+    }
+    hubConnections.delete(orphan)
+  }
+  stableIdToConn.set(stableId, conn)
+  connToStableId.set(conn, stableId)
 }
 
 /**
@@ -410,6 +457,12 @@ async function establishGuestSession(suffix, opts = {}) {
   startGuestHostWatch()
 
   try {
+    conn.send(encodeGuestHello(getStableClientId()))
+  } catch {
+    void 0
+  }
+
+  try {
     useGameTimerRoomSessionStore().setGuest(suffix)
   } catch { void 0 }
 }
@@ -430,6 +483,11 @@ export function bindGameTimerP2PHandlers(h) {
  * @returns {void}
  */
 function handleHubInbound(conn, raw) {
+  const hello = parseGuestHello(raw)
+  if (hello) {
+    onGuestHello(conn, hello.stableId)
+    return
+  }
   const msg = parseGuestMessage(raw)
   if (!msg) return
   try {
@@ -485,12 +543,27 @@ function handleGuestInbound(raw) {
 }
 
 /**
- * Forwards PeerJS `error` events to host or guest disconnect handling.
+ * Forwards PeerJS `error` events to host or guest disconnect handling. Fatal
+ * errors (per {@link classifyPeerError}) skip the reconnect loop and go
+ * straight to a clean teardown so the UI surfaces the real problem instead of
+ * spinning a doomed retry loop.
  * @param {import('peerjs').Peer} p
  * @returns {void}
  */
 function wirePeerErrors(p) {
-  p.on('error', () => {
+  p.on('error', (err) => {
+    const severity = classifyPeerError(err)
+    if (severity === 'fatal') {
+      reconnectGeneration += 1
+      clearRoomPersistence()
+      const msg =
+        err && typeof err === 'object' && 'type' in err
+          ? `P2P error: ${/** @type {{type:string}} */ (err).type}`
+          : 'P2P error'
+      notifyP2P(msg, 'negative')
+      teardownSession()
+      return
+    }
     if (isHost) {
       onHostDisconnected()
     } else {
@@ -704,9 +777,11 @@ export async function startAsHost(maxAttempts = 12) {
   teardownSession()
   sessionPhase.value = 'connecting'
 
+  const preferredSuffix = deriveStableHostSuffix(STABLE_HOST_SUFFIX_APP, 6)
+
   let lastErr = /** @type {Error | null} */ (null)
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const suffix = generateRoomSuffix(6)
+    const suffix = attempt === 0 ? preferredSuffix : generateRoomSuffix(6)
     const fullId = fullPeerIdFromSuffix(suffix)
 
     try {
@@ -716,6 +791,9 @@ export async function startAsHost(maxAttempts = 12) {
       return { suffix }
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e))
+      if (attempt === 0 && !isUnavailableIdError(e)) {
+        continue
+      }
     }
   }
 

--- a/src/features/movie-vote/p2p/protocol.js
+++ b/src/features/movie-vote/p2p/protocol.js
@@ -9,6 +9,11 @@ export const MSG_MV_HOST_VISIBILITY = 'mv-v'
 export const MSG_MV_WELCOME = 'mv-w'
 export const MSG_MV_STATE = 'mv-s'
 
+/** Guest → host: stable client identity presented right after `open` so the
+ *  host can remap this connection onto an existing participant slot instead of
+ *  allocating a new one on every reconnect. */
+export const MSG_MV_HELLO = 'mv-hi'
+
 /** Guest → host: draft picks + ready flag */
 export const MSG_MV_DRAFT = 'mv-d'
 /** Guest → host: final IRV ranking */
@@ -61,20 +66,41 @@ export function parseHostVisibility(data) {
 }
 
 /**
- * @param {string} participantId
+ * @param {string} stableId
  */
-export function encodeWelcome(participantId) {
-  return { v: 1, type: MSG_MV_WELCOME, participantId }
+export function encodeHello(stableId) {
+  return { v: 1, type: MSG_MV_HELLO, stableId }
 }
 
 /**
  * @param {unknown} data
- * @returns {{ participantId: string } | null}
+ * @returns {{ stableId: string } | null}
+ */
+export function parseHello(data) {
+  if (!isRecord(data) || data.type !== MSG_MV_HELLO) return null
+  if (typeof data.stableId !== 'string' || !data.stableId) return null
+  return { stableId: data.stableId }
+}
+
+/**
+ * @param {string} participantId
+ * @param {boolean} [resumed] True if host reused an existing participant slot.
+ */
+export function encodeWelcome(participantId, resumed = false) {
+  return { v: 1, type: MSG_MV_WELCOME, participantId, resumed: Boolean(resumed) }
+}
+
+/**
+ * @param {unknown} data
+ * @returns {{ participantId: string, resumed: boolean } | null}
  */
 export function parseWelcome(data) {
   if (!isRecord(data) || data.type !== MSG_MV_WELCOME) return null
   if (typeof data.participantId !== 'string' || !data.participantId) return null
-  return { participantId: data.participantId }
+  return {
+    participantId: data.participantId,
+    resumed: data.resumed === true,
+  }
 }
 
 /**

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -11,8 +11,12 @@ import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
 import { HOST_PARTICIPANT_ID, compileBallotMovies, uniqueTmdbCountInPicks } from '../core.js'
 import { runIrv } from '../irv.js'
+import { classifyPeerError, isUnavailableIdError } from '../../p2p/errors.js'
+import { deriveStableHostSuffix, getStableClientId } from '../../p2p/identity.js'
+import { reconnectDelayMs as sharedReconnectDelayMs } from '../../p2p/reconnect.js'
 import {
   encodeDraft,
+  encodeHello,
   encodeHostPing,
   encodeHostVisibility,
   encodeState,
@@ -22,6 +26,7 @@ import {
   isHostPing,
   MSG_MV_HOST_ENDED,
   parseDraft,
+  parseHello,
   parseHostVisibility,
   parseState,
   parseVote,
@@ -34,6 +39,8 @@ import {
   isValidRoomSuffix,
   normalizeRoomSuffixInput,
 } from './roomId.js'
+
+const STABLE_HOST_SUFFIX_APP = 'movievote'
 
 /** @type {import('peerjs').Peer | null} */
 let peer = null
@@ -56,10 +63,36 @@ let reconnectGeneration = 0
 const connToParticipant = new Map()
 
 /**
+ * Stable client id → participant id.
+ *
+ * Populated when a guest sends a `hello` message after their `DataConnection`
+ * opens, and kept across that guest's reconnects so their existing slot (and
+ * any vote they've already cast) is preserved. Entries are cleared only when
+ * the host session tears down.
+ * @type {Map<string, string>}
+ */
+const stableIdToParticipant = new Map()
+
+/**
+ * Participant id → open DataConnection currently serving that participant.
+ * Used to close an orphan connection when the same stable id reconnects.
+ * @type {Map<string, import('peerjs').DataConnection>}
+ */
+const participantToConn = new Map()
+
+/**
  * Guest drafts keyed by participant id (host tab uses store only).
  * @type {Map<string, { picks: import('../types.js').MoviePick[], ready: boolean }>}
  */
 const guestDrafts = new Map()
+
+/**
+ * Pending participant-removal timers keyed by participant id. Scheduled when a
+ * guest's connection closes; cleared when they reconnect within the grace
+ * window. See {@link GUEST_REMOVAL_GRACE_MS}.
+ * @type {Map<string, ReturnType<typeof setTimeout>>}
+ */
+const pendingRemovalTimers = new Map()
 
 /** Reactive session UI state for multiplayer (Vue ref; safe to use outside components). */
 export const sessionPhase = ref(/** @type {import('./types.js').MovieVoteSessionPhase} */ ('idle'))
@@ -88,6 +121,14 @@ const RECONNECT_PEER_TIMEOUT_MS = 8000
 const HEARTBEAT_INTERVAL_MS = 3000
 const HEARTBEAT_STALE_MS = 12_000
 const HEARTBEAT_GUEST_CHECK_MS = 2000
+
+/**
+ * When a guest's `DataConnection` closes, keep their participant slot (drafts,
+ * votes, ready flag) around for this long so that a quick reconnect can reuse
+ * it. Long enough for brief wifi/bluetooth glitches, short enough that a
+ * truly-departed voter doesn't block a room from advancing to the next phase.
+ */
+const GUEST_REMOVAL_GRACE_MS = 45_000
 
 /** Minimum distinct TMDB titles across the room before anyone can mark ready (matches ballot dedupe). */
 const MIN_DISTINCT_SUGGESTIONS_FOR_READY = 2
@@ -223,7 +264,11 @@ function destroyWireOnly() {
   }
   hubConnections.clear()
   connToParticipant.clear()
+  participantToConn.clear()
+  stableIdToParticipant.clear()
   guestDrafts.clear()
+  for (const t of pendingRemovalTimers.values()) clearTimeout(t)
+  pendingRemovalTimers.clear()
   if (guestHubConn) {
     try {
       guestHubConn.close()
@@ -246,8 +291,10 @@ function destroyWireOnly() {
 }
 
 function reconnectDelayMs(attemptAfterFirst) {
-  const exp = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** attemptAfterFirst, RECONNECT_MAX_DELAY_MS)
-  return exp + Math.floor(Math.random() * 400)
+  return sharedReconnectDelayMs(attemptAfterFirst, {
+    baseMs: RECONNECT_BASE_DELAY_MS,
+    maxMs: RECONNECT_MAX_DELAY_MS,
+  })
 }
 
 /**
@@ -430,6 +477,12 @@ function normalizePicks(picks) {
  * @param {unknown} raw
  */
 function handleHubInbound(conn, raw) {
+  const hello = parseHello(raw)
+  if (hello) {
+    onGuestHello(conn, hello.stableId)
+    return
+  }
+
   const store = useMovieVoteStore()
   const expectedPid = connToParticipant.get(conn)
   if (!expectedPid) return
@@ -489,6 +542,10 @@ function handleGuestInbound(raw) {
   if (welcome) {
     touchGuestHostActivity()
     useMovieVoteStore().setMyParticipantId(welcome.participantId)
+    // Re-push our drafts so the host picks them up even if they refreshed and
+    // lost all participant state. Cheap; the host is idempotent on incoming
+    // draft messages.
+    movieVoteGuestPushDraft()
     return
   }
   const st = parseState(raw)
@@ -500,7 +557,19 @@ function handleGuestInbound(raw) {
 }
 
 function wirePeerErrors(p) {
-  p.on('error', () => {
+  p.on('error', (err) => {
+    const severity = classifyPeerError(err)
+    if (severity === 'fatal') {
+      reconnectGeneration += 1
+      clearRoomPersistence()
+      const msg =
+        err && typeof err === 'object' && 'type' in err
+          ? `P2P error: ${/** @type {{type:string}} */ (err).type}`
+          : 'P2P error'
+      notifyP2P(msg, 'negative')
+      teardownSession()
+      return
+    }
     if (isHost) {
       onHostDisconnected()
     } else {
@@ -636,30 +705,121 @@ function attachHubConnectionHandlers(p) {
   p.on('connection', (conn) => {
     conn.on('open', () => {
       hubConnections.add(conn)
-      const pid = generateAnonymousVoterId()
-      connToParticipant.set(conn, pid)
-      guestDrafts.set(pid, { picks: [], ready: false })
-      try {
-        conn.send(encodeWelcome(pid))
-        const payload = buildPublicPayload()
-        if (nextSeq < 1) nextSeq = 1
-        conn.send(encodeState(payload, nextSeq))
-        if (typeof document !== 'undefined') {
-          conn.send(encodeHostVisibility(document.visibilityState === 'visible'))
-        }
-      } catch {
-        conn.close()
-      }
     })
     conn.on('data', (data) => handleHubInbound(conn, data))
     conn.on('close', () => {
       const pid = connToParticipant.get(conn)
       hubConnections.delete(conn)
       connToParticipant.delete(conn)
-      if (pid) guestDrafts.delete(pid)
+      if (pid && participantToConn.get(pid) === conn) {
+        participantToConn.delete(pid)
+        scheduleParticipantRemoval(pid)
+      }
       hostBroadcastState()
     })
   })
+}
+
+/**
+ * Schedule removal of a participant slot after {@link GUEST_REMOVAL_GRACE_MS}
+ * unless a matching guest reconnects first. No-op if the slot is already
+ * actively connected or already scheduled.
+ * @param {string} pid
+ */
+function scheduleParticipantRemoval(pid) {
+  if (!guestDrafts.has(pid)) return
+  if (participantToConn.has(pid)) return
+  const existing = pendingRemovalTimers.get(pid)
+  if (existing) clearTimeout(existing)
+  const t = setTimeout(() => {
+    pendingRemovalTimers.delete(pid)
+    if (participantToConn.has(pid)) return
+    guestDrafts.delete(pid)
+    for (const [sid, mapped] of stableIdToParticipant) {
+      if (mapped === pid) {
+        stableIdToParticipant.delete(sid)
+        break
+      }
+    }
+    if (isHost && sessionPhase.value === 'hosting') {
+      tryCompileBallot()
+      tryFinishVoting()
+      hostBroadcastState()
+    }
+  }, GUEST_REMOVAL_GRACE_MS)
+  pendingRemovalTimers.set(pid, t)
+}
+
+/**
+ * Cancel any pending removal for `pid` (guest is back before the grace period
+ * expired).
+ * @param {string} pid
+ */
+function cancelParticipantRemoval(pid) {
+  const t = pendingRemovalTimers.get(pid)
+  if (t) {
+    clearTimeout(t)
+    pendingRemovalTimers.delete(pid)
+  }
+}
+
+/**
+ * Completes the hello handshake for a new guest connection by picking (or
+ * reusing) the participant slot, wiring up the new conn, dropping any orphan
+ * conn that used to serve the same guest, and sending the initial welcome /
+ * state bootstrap.
+ *
+ * @param {import('peerjs').DataConnection} conn
+ * @param {string} stableId
+ */
+function onGuestHello(conn, stableId) {
+  if (connToParticipant.has(conn)) return
+
+  const existingPid = stableIdToParticipant.get(stableId)
+  const pid = existingPid ?? generateAnonymousVoterId()
+  const resumed = Boolean(existingPid)
+
+  if (!existingPid) {
+    stableIdToParticipant.set(stableId, pid)
+    guestDrafts.set(pid, { picks: [], ready: false })
+  } else {
+    cancelParticipantRemoval(pid)
+  }
+
+  const orphan = participantToConn.get(pid)
+  if (orphan && orphan !== conn) {
+    try {
+      connToParticipant.delete(orphan)
+      orphan.close()
+    } catch {
+      void 0
+    }
+    hubConnections.delete(orphan)
+  }
+
+  connToParticipant.set(conn, pid)
+  participantToConn.set(pid, conn)
+
+  try {
+    conn.send(encodeWelcome(pid, resumed))
+    const payload = buildPublicPayload()
+    if (nextSeq < 1) nextSeq = 1
+    conn.send(encodeState(payload, nextSeq))
+    if (typeof document !== 'undefined') {
+      conn.send(encodeHostVisibility(document.visibilityState === 'visible'))
+    }
+  } catch {
+    try {
+      conn.close()
+    } catch {
+      void 0
+    }
+    return
+  }
+
+  if (resumed) {
+    hostBroadcastState()
+  }
 }
 
 /**
@@ -730,6 +890,12 @@ async function establishGuestSession(suffix, opts = {}) {
   startGuestHostWatch()
 
   try {
+    conn.send(encodeHello(getStableClientId()))
+  } catch {
+    void 0
+  }
+
+  try {
     useMovieVoteRoomSessionStore().setGuest(suffix)
   } catch {
     void 0
@@ -795,9 +961,11 @@ export async function startAsHost(maxAttempts = 12) {
   teardownSession()
   sessionPhase.value = 'connecting'
 
+  const preferredSuffix = deriveStableHostSuffix(STABLE_HOST_SUFFIX_APP, 6)
+
   let lastErr = /** @type {Error | null} */ (null)
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const suffix = generateRoomSuffix(6)
+    const suffix = attempt === 0 ? preferredSuffix : generateRoomSuffix(6)
     const fullId = fullPeerIdFromSuffix(suffix)
 
     try {
@@ -807,6 +975,9 @@ export async function startAsHost(maxAttempts = 12) {
       return { suffix }
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e))
+      if (attempt === 0 && !isUnavailableIdError(e)) {
+        continue
+      }
     }
   }
 

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -742,6 +742,7 @@ function scheduleParticipantRemoval(pid) {
       }
     }
     if (isHost && sessionPhase.value === 'hosting') {
+      useMovieVoteStore().removeParticipantFromVote(pid)
       tryCompileBallot()
       tryFinishVoting()
       hostBroadcastState()

--- a/src/features/p2p/errors.js
+++ b/src/features/p2p/errors.js
@@ -1,0 +1,81 @@
+/**
+ * PeerJS error classification shared by every app that uses the `peerjs`
+ * client.
+ *
+ * PeerJS surfaces wildly different `type` strings on its `error` event — some
+ * are fatal to the underlying {@link Peer} instance, others are transient and
+ * expected during normal reconnect loops. Callers should branch on
+ * {@link classifyPeerError} rather than treating every error as a
+ * "disconnected" signal, which tends to blow away healthy sessions.
+ *
+ * Reference:
+ * - https://peerjs.com/docs/#peer-events-error
+ * - https://github.com/peers/peerjs/blob/master/lib/enums.ts (PeerErrorType)
+ */
+
+/**
+ * @typedef {'fatal' | 'transient' | 'unknown'} PeerErrorSeverity
+ */
+
+/**
+ * Errors that destroy the `Peer` instance per the PeerJS contract, or indicate
+ * configuration/environment problems that won't fix themselves by retrying.
+ * @type {ReadonlySet<string>}
+ */
+const FATAL_TYPES = new Set([
+  'browser-incompatible',
+  'invalid-id',
+  'invalid-key',
+  'ssl-unavailable',
+])
+
+/**
+ * Errors that are routinely recoverable via the app's reconnect loop (the
+ * signaling server blipped, the data channel failed ICE, the peer id is still
+ * releasing server-side, etc.).
+ * @type {ReadonlySet<string>}
+ */
+const TRANSIENT_TYPES = new Set([
+  'disconnected',
+  'network',
+  'peer-unavailable',
+  'server-error',
+  'socket-error',
+  'socket-closed',
+  'unavailable-id',
+  'webrtc',
+])
+
+/**
+ * @param {unknown} err
+ * @returns {string}
+ */
+function errorTypeOf(err) {
+  if (err && typeof err === 'object' && 'type' in err) {
+    const t = /** @type {{type: unknown}} */ (err).type
+    if (typeof t === 'string') return t
+  }
+  return ''
+}
+
+/**
+ * @param {unknown} err
+ * @returns {PeerErrorSeverity}
+ */
+export function classifyPeerError(err) {
+  const type = errorTypeOf(err)
+  if (FATAL_TYPES.has(type)) return 'fatal'
+  if (TRANSIENT_TYPES.has(type)) return 'transient'
+  return 'unknown'
+}
+
+/**
+ * True when a host's attempt to claim a broker id failed because someone (often
+ * a stale instance of the host itself) still holds it. Host-start/resume loops
+ * should retry on this error.
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isUnavailableIdError(err) {
+  return errorTypeOf(err) === 'unavailable-id'
+}

--- a/src/features/p2p/identity.js
+++ b/src/features/p2p/identity.js
@@ -1,0 +1,107 @@
+/**
+ * Stable per-browser client identity used to survive reconnects in every P2P
+ * app on the site.
+ *
+ * WebRTC gives each new {@link Peer} a different transport-level id, so if a
+ * guest refreshes or drops their connection the host sees them as a brand new
+ * participant — inflating voter counts, losing votes, etc. Persisting a short
+ * opaque id in `localStorage` lets the host recognize the returning client and
+ * remap them onto their existing slot.
+ */
+
+const STORAGE_KEY = 'portfolio-p2p-client-id'
+
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+const ID_LENGTH = 16
+
+/** @type {string | null} */
+let cached = null
+
+function generate() {
+  const bytes = new Uint8Array(ID_LENGTH)
+  crypto.getRandomValues(bytes)
+  let s = ''
+  for (let i = 0; i < ID_LENGTH; i++) s += ALPHABET[bytes[i] % ALPHABET.length]
+  return s
+}
+
+/**
+ * @param {string} raw
+ * @returns {boolean}
+ */
+function isWellFormed(raw) {
+  return typeof raw === 'string' && /^[0-9A-Z]{8,64}$/.test(raw)
+}
+
+/**
+ * Returns an opaque, per-browser stable identity. Generates and persists one on
+ * first call. Uses an in-memory cache so repeated calls within a session are
+ * cheap and stable even if storage is flaky.
+ * @returns {string}
+ */
+export function getStableClientId() {
+  if (cached) return cached
+
+  try {
+    const existing = window.localStorage.getItem(STORAGE_KEY)
+    if (existing && isWellFormed(existing)) {
+      cached = existing
+      return cached
+    }
+  } catch {
+    void 0
+  }
+
+  const fresh = generate()
+  try {
+    window.localStorage.setItem(STORAGE_KEY, fresh)
+  } catch {
+    void 0
+  }
+  cached = fresh
+  return cached
+}
+
+/** Test-only / "forget me" helper. Not wired into any UI today. */
+export function __resetStableClientIdForTests() {
+  cached = null
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    void 0
+  }
+}
+
+/**
+ * Deterministic per-browser room suffix for hosts, so "last week's link still
+ * works this week" — each device always tries to claim the same room id for a
+ * given app, and only falls back to a fresh random suffix if the broker
+ * reports that id is currently held by someone else.
+ *
+ * Uses a simple 32-bit xxhash-style mixer seeded with `stableId:app`; it is
+ * not cryptographic, just stable and well-distributed over the base-32
+ * alphabet used by every room id in the site.
+ *
+ * @param {string} app Short app tag, e.g. `'movievote'` or `'gametimer'`.
+ * @param {number} [length=6]
+ * @returns {string}
+ */
+export function deriveStableHostSuffix(app, length = 6) {
+  const seed = getStableClientId() + ':' + app
+  let h1 = 0xdeadbeef
+  let h2 = 0x41c6ce57
+  for (let i = 0; i < seed.length; i++) {
+    const c = seed.charCodeAt(i)
+    h1 = Math.imul(h1 ^ c, 2654435761)
+    h2 = Math.imul(h2 ^ c, 1597334677)
+  }
+  let out = ''
+  for (let i = 0; i < length; i++) {
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+    h2 = Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+    const idx = (h1 ^ h2) >>> 0
+    out += ALPHABET[idx % ALPHABET.length]
+  }
+  return out
+}

--- a/src/features/p2p/reconnect.js
+++ b/src/features/p2p/reconnect.js
@@ -1,0 +1,17 @@
+/**
+ * Shared reconnect timing helpers for every P2P session on the site.
+ */
+
+/**
+ * Exponential backoff with jitter.
+ * @param {number} attemptAfterFirst Zero-based: delay before attempt 2 uses index 0.
+ * @param {{ baseMs?: number, maxMs?: number, jitterMs?: number }} [opts]
+ * @returns {number}
+ */
+export function reconnectDelayMs(attemptAfterFirst, opts = {}) {
+  const base = opts.baseMs ?? 800
+  const max = opts.maxMs ?? 5000
+  const jitter = opts.jitterMs ?? 400
+  const exp = Math.min(base * 2 ** attemptAfterFirst, max)
+  return exp + Math.floor(Math.random() * jitter)
+}

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -152,6 +152,12 @@ export const useMovieVoteStore = defineStore('movieVote', {
       this.setUniqueSuggestedMovieCount(
         typeof p.uniqueSuggestedMovieCount === 'number' ? p.uniqueSuggestedMovieCount : 0,
       )
+
+      const pid = this.myParticipantId
+      if (pid) {
+        const row = this.participants.find((x) => x.id === pid)
+        if (row) this.setReadyToVote(row.ready)
+      }
     },
 
     /** Host / solo: enter voting with compiled ballot */
@@ -278,7 +284,19 @@ export const useMovieVoteStore = defineStore('movieVote', {
 
   persist: {
     key: 'portfolio-movie-vote',
-    pick: ['myDraftPicks'],
+    pick: [
+      'myDraftPicks',
+      'phase',
+      'readyToVote',
+      'ballotMovies',
+      'ballotOrderIds',
+      'myRanking',
+      'myVoteSubmitted',
+      'voterIds',
+      'votesByParticipant',
+      'voteProgress',
+      'irvResult',
+    ],
   },
 })
 

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -194,6 +194,22 @@ export const useMovieVoteStore = defineStore('movieVote', {
       this._updateVoteProgress()
     },
 
+    /** Host: permanently remove a departed guest from the current voting state. */
+    removeParticipantFromVote(participantId) {
+      if (typeof participantId !== 'string' || !participantId) return
+      const hadVoter = this.voterIds.includes(participantId)
+      const hadVote = participantId in this.votesByParticipant
+      if (!hadVoter && !hadVote) return
+
+      this.voterIds = this.voterIds.filter((id) => id !== participantId)
+      if (hadVote) {
+        const rest = { ...this.votesByParticipant }
+        delete rest[participantId]
+        this.votesByParticipant = rest
+      }
+      this._updateVoteProgress()
+    },
+
     _updateVoteProgress() {
       const total = this.voterIds.length
       const submitted = this.voterIds.filter((id) => this.votesByParticipant[id]?.length).length

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -222,11 +222,15 @@ export const useMovieVoteStore = defineStore('movieVote', {
       this.uniqueSuggestedMovieCount = 0
     },
 
-    /** Solo: start over (clears ballot state; used when joining a room). */
+    /**
+     * Clears ballot-phase state before joining/resuming a room. Draft picks are
+     * the user's personal nominations and are intentionally preserved across
+     * joins and refreshes — the host's welcome/state broadcast will bring the
+     * rest of the ballot model back into sync.
+     */
     resetSessionSoft() {
       this.phase = 'suggest'
       this.readyToVote = false
-      this.myDraftPicks = []
       this.participants = []
       this.ballotMovies = []
       this.ballotOrderIds = []


### PR DESCRIPTION
## Summary

Peer connections and room sync could misbehave around disconnects, peer identity, and error handling. This change tightens lifecycle handling for both **Game Timer** and **Movie Vote** P2P layers and adds shared helpers used by both apps.

## What changed

- **`src/features/p2p/errors.js`** — Structured error helpers and classification for connection and protocol failures.
- **`src/features/p2p/identity.js`** — Consistent peer identity handling to reduce mismatches after reconnects or duplicate IDs.
- **`src/features/p2p/reconnect.js`** — Small reconnect policy glue used by sessions.
- **`src/features/game-timer/p2p/protocol.js`** / **`session.js`** — Clearer message boundaries and session lifecycle behavior around drops and recovery.
- **`src/features/movie-vote/p2p/protocol.js`** / **`session.js`** — Broader session hardening: validation, state transitions, and safer handling when peers leave or reconnect mid-session.
- **`src/stores/movieVote.js`** — Aligns public state application with the hardened P2P behavior where the store consumes session events.

## Testing notes

- Manual smoke: host/guest connect, disconnect one side, reconnect; confirm room state and voting still converge where expected.

Fixes #6