### PR TITLE
Allow users to add custom movies in movie vote

### DIFF
--- a/src/features/movie-vote/components/MovieDetailDialog.vue
+++ b/src/features/movie-vote/components/MovieDetailDialog.vue
@@ -164,7 +164,7 @@ const displayedCast = computed(() => {
 watch(
   () => [props.modelValue, props.movie?.tmdbId],
   async ([open, tmdbId], _, onCleanup) => {
-    if (!open || tmdbId == null) {
+    if (!open) {
       fetched.value = null
       posterSrc.value = null
       castExpanded.value = false
@@ -172,12 +172,11 @@ watch(
     }
     castExpanded.value = false
     const m = props.movie
-    if (m?.posterPath) {
-      posterSrc.value = posterUrl(m.posterPath, 'w342')
-    } else {
-      posterSrc.value = null
-    }
-    if (!isTmdbConfigured()) return
+    posterSrc.value = m?.posterPath ? posterUrl(m.posterPath, 'w342') : null
+    fetched.value = null
+
+    if (typeof tmdbId !== 'number' || !isTmdbConfigured()) return
+
     const ac = new AbortController()
     onCleanup(() => ac.abort())
     try {

--- a/src/features/movie-vote/components/MovieSearchField.vue
+++ b/src/features/movie-vote/components/MovieSearchField.vue
@@ -161,6 +161,7 @@ async function runSearch() {
 function resetQueryState() {
   query.value = ''
   suggestions.value = []
+  thumbUrls.value = {}
   lastSearchedQuery.value = ''
 }
 
@@ -207,10 +208,6 @@ function pickCustom(title) {
 }
 
 function onEnterPressed() {
-  if (suggestions.value.length > 0) {
-    void pickTmdb(suggestions.value[0])
-    return
-  }
   if (showCustomOption.value) pickCustom(trimmedQuery.value)
 }
 

--- a/src/features/movie-vote/components/MovieSearchField.vue
+++ b/src/features/movie-vote/components/MovieSearchField.vue
@@ -1,23 +1,28 @@
 <template>
   <div class="mv-search q-px-md q-pb-sm">
     <div v-if="!configured" class="text-caption text-warning q-mb-xs">
-      Add <code class="text-body2">VITE_TMDB_READ_ACCESS_TOKEN</code> or <code class="text-body2">VITE_TMDB_API_KEY</code> in
-      <code class="text-body2">.env</code> (see <code class="text-body2">.env.example</code>), then restart the dev server.
+      TMDB search is off. Add <code class="text-body2">VITE_TMDB_READ_ACCESS_TOKEN</code> or
+      <code class="text-body2">VITE_TMDB_API_KEY</code> in
+      <code class="text-body2">.env</code> (see <code class="text-body2">.env.example</code>) to enable it.
+      You can still add titles manually below.
     </div>
     <q-input
       v-model="query"
       outlined
       dense
       clearable
-      label="Search movies"
+      label="Search or enter a movie title"
       :loading="loading"
       autocomplete="off"
       autocorrect="off"
       spellcheck="false"
       inputmode="search"
       @update:model-value="onQueryInput"
+      @keydown.enter.prevent="onEnterPressed"
     >
-      <template #hint> Type at least 2 characters to search. </template>
+      <template #hint>
+        Type 2+ characters to search TMDB, or press Enter to add a custom title.
+      </template>
     </q-input>
 
     <!-- Inline list (no q-menu): avoids focus bugs and stray overlays on desktop/mobile -->
@@ -28,7 +33,7 @@
       class="rounded-borders q-mt-xs mv-search__suggestions"
       dense
     >
-      <q-item v-for="r in suggestions" :key="r.id" v-ripple clickable @click="pick(r)">
+      <q-item v-for="r in suggestions" :key="r.id" v-ripple clickable @click="pickTmdb(r)">
         <q-item-section avatar class="mv-search__avatar">
           <q-img
             v-if="thumbUrls[r.id]"
@@ -47,12 +52,26 @@
           <q-item-label v-if="r.release_date" caption>{{ String(r.release_date).slice(0, 4) }}</q-item-label>
         </q-item-section>
       </q-item>
+
       <q-item v-if="showNoResults">
-        <q-item-section class="text-grey-6 text-caption">No results</q-item-section>
+        <q-item-section class="text-grey-6 text-caption">No TMDB match.</q-item-section>
       </q-item>
-      <q-item v-if="showNeedKey">
-        <q-item-section class="text-caption text-warning">
-          Set TMDB read token or API key in <code>.env</code> to load results.
+
+      <q-item
+        v-if="showCustomOption"
+        v-ripple
+        clickable
+        class="mv-search__custom"
+        @click="pickCustom(trimmedQuery)"
+      >
+        <q-item-section avatar class="mv-search__avatar">
+          <q-icon name="add" size="md" color="primary" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Add &ldquo;{{ trimmedQuery }}&rdquo; as a custom entry</q-item-label>
+          <q-item-label caption class="text-grey-6">
+            No poster or description — just the title.
+          </q-item-label>
         </q-item-section>
       </q-item>
     </q-list>
@@ -61,6 +80,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { normalizeCustomTitle } from '../core.js'
 import { getMovieDetails, isTmdbConfigured, posterUrl, searchMovies } from '../tmdb.js'
 
 const emit = defineEmits(['select'])
@@ -81,27 +101,26 @@ function onQueryInput() {
   debounceId = window.setTimeout(runSearch, 320)
 }
 
+const trimmedQuery = computed(() => query.value.trim())
+
 const showNoResults = computed(
   () =>
     configured.value &&
-    query.value.trim().length >= 2 &&
+    trimmedQuery.value.length >= 2 &&
     !loading.value &&
-    lastSearchedQuery.value === query.value.trim() &&
+    lastSearchedQuery.value === trimmedQuery.value &&
     suggestions.value.length === 0,
 )
 
-const showNeedKey = computed(
-  () => !configured.value && query.value.trim().length >= 2 && !loading.value,
-)
+const showCustomOption = computed(() => trimmedQuery.value.length >= 2 && !loading.value)
 
 const showSuggestionPanel = computed(() => {
-  const q = query.value.trim()
-  if (q.length < 2) return false
-  return loading.value || suggestions.value.length > 0 || showNoResults.value || showNeedKey.value
+  if (trimmedQuery.value.length < 2) return false
+  return loading.value || suggestions.value.length > 0 || showNoResults.value || showCustomOption.value
 })
 
 async function runSearch() {
-  const q = query.value.trim()
+  const q = trimmedQuery.value
   if (abort) abort.abort()
   if (q.length < 2) {
     suggestions.value = []
@@ -139,10 +158,16 @@ async function runSearch() {
   }
 }
 
+function resetQueryState() {
+  query.value = ''
+  suggestions.value = []
+  lastSearchedQuery.value = ''
+}
+
 /**
  * @param {{ id: number, title: string, poster_path: string | null, overview: string, release_date?: string }} r
  */
-async function pick(r) {
+async function pickTmdb(r) {
   if (!isTmdbConfigured()) return
   /** @type {number | undefined} */
   let runtime
@@ -154,6 +179,7 @@ async function pick(r) {
   }
   emit('select', {
     localId: crypto.randomUUID(),
+    source: 'tmdb',
     tmdbId: r.id,
     title: r.title,
     posterPath: r.poster_path,
@@ -161,9 +187,31 @@ async function pick(r) {
     releaseDate: r.release_date,
     runtime,
   })
-  query.value = ''
-  suggestions.value = []
-  lastSearchedQuery.value = ''
+  resetQueryState()
+}
+
+/** @param {string} title */
+function pickCustom(title) {
+  const trimmed = title.trim()
+  if (trimmed.length < 2) return
+  emit('select', {
+    localId: crypto.randomUUID(),
+    source: 'custom',
+    tmdbId: null,
+    customKey: normalizeCustomTitle(trimmed),
+    title: trimmed,
+    posterPath: null,
+    overview: '',
+  })
+  resetQueryState()
+}
+
+function onEnterPressed() {
+  if (suggestions.value.length > 0) {
+    void pickTmdb(suggestions.value[0])
+    return
+  }
+  if (showCustomOption.value) pickCustom(trimmedQuery.value)
 }
 
 watch(query, (q) => {
@@ -183,5 +231,9 @@ watch(query, (q) => {
 
 .mv-search__avatar {
   min-width: 48px;
+}
+
+.mv-search__custom {
+  background: rgba(25, 118, 210, 0.08);
 }
 </style>

--- a/src/features/movie-vote/core.js
+++ b/src/features/movie-vote/core.js
@@ -43,8 +43,8 @@ export function shuffleInPlace(arr) {
 
 /**
  * Normalize a free-form title so two users typing roughly the same custom movie
- * produce the same dedupe key. Casefolds, collapses whitespace, strips simple
- * punctuation, and removes trailing articles added by some search engines.
+ * produce the same dedupe key. Casefolds, collapses whitespace, and strips
+ * punctuation/symbols.
  *
  * @param {string} title
  * @returns {string}

--- a/src/features/movie-vote/core.js
+++ b/src/features/movie-vote/core.js
@@ -42,39 +42,82 @@ export function shuffleInPlace(arr) {
 }
 
 /**
- * Count of distinct TMDB titles in picks (same dedupe rule as {@link compileBallotMovies}).
- * @param {MoviePick[]} picks
- * @returns {number}
+ * Normalize a free-form title so two users typing roughly the same custom movie
+ * produce the same dedupe key. Casefolds, collapses whitespace, strips simple
+ * punctuation, and removes trailing articles added by some search engines.
+ *
+ * @param {string} title
+ * @returns {string}
  */
-export function uniqueTmdbCountInPicks(picks) {
-  const ids = new Set()
-  for (const p of picks) {
-    if (p && typeof p.tmdbId === 'number') ids.add(p.tmdbId)
-  }
-  return ids.size
+export function normalizeCustomTitle(title) {
+  const raw = typeof title === 'string' ? title : ''
+  return raw
+    .normalize('NFKD')
+    .replace(/[\p{Diacritic}]/gu, '')
+    .toLowerCase()
+    .replace(/[\p{P}\p{S}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 /**
- * Dedupe by tmdbId, shuffle, assign public ids.
+ * Stable, cross-peer dedupe key for a pick or ballot movie.
+ * TMDB picks dedupe on `tmdbId`; custom picks dedupe on `customKey` (normalized title).
+ *
+ * @param {MoviePick | BallotMovie} pick
+ * @returns {string | null} null if the pick has neither a numeric tmdbId nor a customKey.
+ */
+export function pickDedupeKey(pick) {
+  if (!pick) return null
+  if (pick.source === 'tmdb' || (pick.source == null && typeof pick.tmdbId === 'number')) {
+    return typeof pick.tmdbId === 'number' ? `tmdb:${pick.tmdbId}` : null
+  }
+  if (pick.source === 'custom') {
+    const key = typeof pick.customKey === 'string' ? pick.customKey : normalizeCustomTitle(pick.title)
+    return key ? `custom:${key}` : null
+  }
+  return null
+}
+
+/**
+ * Count distinct movies in picks (TMDB ids and normalized custom titles together).
+ *
+ * @param {MoviePick[]} picks
+ * @returns {number}
+ */
+export function uniqueMoviesInPicks(picks) {
+  const seen = new Set()
+  for (const p of picks) {
+    const key = pickDedupeKey(p)
+    if (key) seen.add(key)
+  }
+  return seen.size
+}
+
+/**
+ * Dedupe by {@link pickDedupeKey}, shuffle, assign public ids.
  * @param {MoviePick[]} picks
  * @returns {BallotMovie[]}
  */
 export function compileBallotMovies(picks) {
-  const byTmdb = new Map()
+  const byKey = new Map()
   for (const p of picks) {
-    if (!byTmdb.has(p.tmdbId)) {
-      byTmdb.set(p.tmdbId, {
-        publicId: generatePublicId(),
-        tmdbId: p.tmdbId,
-        title: p.title,
-        posterPath: p.posterPath,
-        overview: p.overview,
-        releaseDate: p.releaseDate,
-        runtime: p.runtime,
-      })
-    }
+    const key = pickDedupeKey(p)
+    if (!key || byKey.has(key)) continue
+    const source = p.source ?? (typeof p.tmdbId === 'number' ? 'tmdb' : 'custom')
+    byKey.set(key, {
+      publicId: generatePublicId(),
+      source,
+      tmdbId: source === 'tmdb' ? p.tmdbId : null,
+      customKey: source === 'custom' ? (p.customKey ?? normalizeCustomTitle(p.title)) : undefined,
+      title: p.title,
+      posterPath: p.posterPath,
+      overview: p.overview,
+      releaseDate: p.releaseDate,
+      runtime: p.runtime,
+    })
   }
-  const out = [...byTmdb.values()]
+  const out = [...byKey.values()]
   shuffleInPlace(out)
   return out
 }

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -9,7 +9,12 @@ import { Notify } from 'quasar'
 import Peer from 'peerjs'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
-import { HOST_PARTICIPANT_ID, compileBallotMovies, uniqueTmdbCountInPicks } from '../core.js'
+import {
+  HOST_PARTICIPANT_ID,
+  compileBallotMovies,
+  normalizeCustomTitle,
+  uniqueMoviesInPicks,
+} from '../core.js'
 import { runIrv } from '../irv.js'
 import {
   encodeDraft,
@@ -295,7 +300,7 @@ function allDraftPicksFlat() {
 }
 
 function distinctSuggestedMovieCount() {
-  return uniqueTmdbCountInPicks(allDraftPicksFlat())
+  return uniqueMoviesInPicks(allDraftPicksFlat())
 }
 
 function buildPublicPayload() {
@@ -403,26 +408,36 @@ function tryFinishVoting() {
 }
 
 /**
+ * Validate a pick from the wire. Accepts both TMDB picks (numeric `tmdbId`)
+ * and custom picks (`source === 'custom'` with a non-empty title).
+ *
  * @param {import('../types.js').MoviePick[]} picks
  */
 function normalizePicks(picks) {
-  return picks
-    .filter(
-      (p) =>
-        p &&
-        typeof p.localId === 'string' &&
-        typeof p.tmdbId === 'number' &&
-        typeof p.title === 'string',
-    )
-    .map((p) => ({
+  const out = []
+  for (const p of picks) {
+    if (!p || typeof p.localId !== 'string' || typeof p.title !== 'string') continue
+    const title = p.title.trim()
+    if (!title) continue
+
+    const explicitSource = p.source === 'tmdb' || p.source === 'custom' ? p.source : null
+    const source = explicitSource ?? (typeof p.tmdbId === 'number' ? 'tmdb' : 'custom')
+
+    if (source === 'tmdb' && typeof p.tmdbId !== 'number') continue
+
+    out.push({
       localId: p.localId,
-      tmdbId: p.tmdbId,
-      title: p.title,
+      source,
+      tmdbId: source === 'tmdb' ? p.tmdbId : null,
+      customKey: source === 'custom' ? (p.customKey || normalizeCustomTitle(title)) : undefined,
+      title,
       posterPath: p.posterPath ?? null,
       overview: typeof p.overview === 'string' ? p.overview : '',
       releaseDate: p.releaseDate,
       runtime: typeof p.runtime === 'number' && p.runtime > 0 ? p.runtime : undefined,
-    }))
+    })
+  }
+  return out
 }
 
 /**

--- a/src/features/movie-vote/types.js
+++ b/src/features/movie-vote/types.js
@@ -15,9 +15,18 @@
  */
 
 /**
+ * Pick source. `tmdb` picks carry a numeric `tmdbId`; `custom` picks have
+ * `tmdbId: null` and are deduped across the room by `customKey` (normalized title).
+ *
+ * @typedef {'tmdb' | 'custom'} MoviePickSource
+ */
+
+/**
  * @typedef {object} MoviePick
  * @property {string} localId
- * @property {number} tmdbId
+ * @property {MoviePickSource} source
+ * @property {number | null} tmdbId     Null for `source === 'custom'`.
+ * @property {string} [customKey]       Dedupe key for `source === 'custom'` (normalized title).
  * @property {string} title
  * @property {string | null} posterPath
  * @property {string} overview
@@ -28,7 +37,9 @@
 /**
  * @typedef {object} BallotMovie
  * @property {string} publicId
- * @property {number} tmdbId
+ * @property {MoviePickSource} source
+ * @property {number | null} tmdbId
+ * @property {string} [customKey]
  * @property {string} title
  * @property {string | null} posterPath
  * @property {string} overview
@@ -53,7 +64,7 @@
  * @property {string[] | null} ballotOrderIds
  * @property {{ submitted: number, total: number } | null} voteProgress
  * @property {import('./irv.js').IrvResult | null} [irvResult]
- * @property {number} [uniqueSuggestedMovieCount] Distinct TMDB ids across all draft picks (suggest phase); 0 otherwise.
+ * @property {number} [uniqueSuggestedMovieCount] Distinct titles across all draft picks (suggest phase); 0 otherwise.
  */
 
 export {}

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -4,16 +4,27 @@
  */
 
 import { defineStore, acceptHMRUpdate } from 'pinia'
-import { HOST_PARTICIPANT_ID } from '../features/movie-vote/core.js'
+import {
+  HOST_PARTICIPANT_ID,
+  normalizeCustomTitle,
+  pickDedupeKey,
+} from '../features/movie-vote/core.js'
 
-/** @returns {MoviePick} */
+/**
+ * Normalize incoming picks (handles legacy picks that predate `source`).
+ * @param {MoviePick} p
+ * @returns {MoviePick}
+ */
 function clonePick(p) {
+  const source = p.source ?? (typeof p.tmdbId === 'number' ? 'tmdb' : 'custom')
   return {
     localId: p.localId,
-    tmdbId: p.tmdbId,
+    source,
+    tmdbId: source === 'tmdb' ? p.tmdbId : null,
+    customKey: source === 'custom' ? (p.customKey ?? normalizeCustomTitle(p.title)) : undefined,
     title: p.title,
-    posterPath: p.posterPath,
-    overview: p.overview,
+    posterPath: p.posterPath ?? null,
+    overview: typeof p.overview === 'string' ? p.overview : '',
     releaseDate: p.releaseDate,
     runtime: p.runtime,
   }
@@ -63,16 +74,24 @@ export const useMovieVoteStore = defineStore('movieVote', {
   }),
 
   getters: {
-    tmdbIdsInDraft(state) {
-      return new Set(state.myDraftPicks.map((p) => p.tmdbId))
+    draftDedupeKeys(state) {
+      const keys = new Set()
+      for (const p of state.myDraftPicks) {
+        const k = pickDedupeKey(p)
+        if (k) keys.add(k)
+      }
+      return keys
     },
   },
 
   actions: {
     /** @param {MoviePick} pick */
     addDraftPick(pick) {
-      if (this.myDraftPicks.some((p) => p.tmdbId === pick.tmdbId)) return
-      this.myDraftPicks.push(clonePick(pick))
+      const cloned = clonePick(pick)
+      const key = pickDedupeKey(cloned)
+      if (!key) return
+      if (this.myDraftPicks.some((p) => pickDedupeKey(p) === key)) return
+      this.myDraftPicks.push(cloned)
     },
 
     /** @param {string} localId */

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -73,17 +73,6 @@ export const useMovieVoteStore = defineStore('movieVote', {
     uniqueSuggestedMovieCount: 0,
   }),
 
-  getters: {
-    draftDedupeKeys(state) {
-      const keys = new Set()
-      for (const p of state.myDraftPicks) {
-        const k = pickDedupeKey(p)
-        if (k) keys.add(k)
-      }
-      return keys
-    },
-  },
-
   actions: {
     /** @param {MoviePick} pick */
     addDraftPick(pick) {


### PR DESCRIPTION
## Summary

Movie vote search was limited to catalog results. Hosts and players can now nominate **user-defined titles** that behave like normal movies in the flow (nomination, sync, and detail views).

## What changed

- **`src/features/movie-vote/types.js`** — Types/metadata extended so custom entries are first-class alongside catalog movies.
- **`src/features/movie-vote/core.js`** — Core nomination and merge logic understands custom movie payloads.
- **`src/features/movie-vote/components/MovieSearchField.vue`** — UI to enter and confirm a custom title when search does not match the catalog.
- **`src/features/movie-vote/components/MovieDetailDialog.vue`** — Displays custom movie details consistently with catalog entries.
- **`src/features/movie-vote/p2p/session.js`** — Syncs custom nominations across peers with the same guarantees as catalog picks.
- **`src/stores/movieVote.js`** — Store actions and state updates for adding and persisting custom movies in the shared session.

## Testing notes

- Add a custom title as host and as guest; confirm it appears in lists and survives refresh/reconnect where applicable.

Fixes #7