### PR TITLE
Wrap long movie titles to two lines in nomination and ballot rows

### DIFF
--- a/src/features/movie-vote/components/MovieBallotList.vue
+++ b/src/features/movie-vote/components/MovieBallotList.vue
@@ -38,7 +38,7 @@
             />
             <q-icon v-else name="movie" size="lg" class="q-mr-sm" color="grey-5" />
             <div class="col min-width-0">
-              <div class="text-body1 text-weight-medium ellipsis">{{ element.title }}</div>
+              <div class="text-body1 text-weight-medium mv-movie-row-title">{{ element.title }}</div>
               <div v-if="ballotMetaLine(element)" class="text-caption text-grey-6 ellipsis">
                 {{ ballotMetaLine(element) }}
               </div>
@@ -145,6 +145,14 @@ function openDetail(m) {
 
 .body--light .mv-ballot-row {
   background: rgba(0, 0, 0, 0.04);
+}
+
+.mv-movie-row-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  word-break: break-word;
 }
 
 .mv-sortable-ghost {

--- a/src/features/movie-vote/components/MovieNominationList.vue
+++ b/src/features/movie-vote/components/MovieNominationList.vue
@@ -45,7 +45,7 @@
               />
               <q-icon v-else name="movie" size="lg" class="q-mr-sm" color="grey-5" />
               <div class="col min-width-0">
-                <div class="text-body1 text-weight-medium ellipsis">{{ pick.title }}</div>
+                <div class="text-body1 text-weight-medium mv-movie-row-title">{{ pick.title }}</div>
                 <div v-if="pickMetaLine(pick)" class="text-caption text-grey-6 ellipsis">
                   {{ pickMetaLine(pick) }}
                 </div>
@@ -166,6 +166,14 @@ function confirmDelete() {
 
 .body--light .mv-nom-row {
   background: rgba(0, 0, 0, 0.04);
+}
+
+.mv-movie-row-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  word-break: break-word;
 }
 
 .mv-sortable-ghost {


### PR DESCRIPTION
## Summary

Very long movie titles in list rows were clipped at the edge of the row (single-line ellipsis). There is enough horizontal space to show **two lines** of title without changing poster alignment or row layout.

## What changed

- **`src/features/movie-vote/components/MovieNominationList.vue`** — Title area uses a two-line line clamp so long names wrap instead of truncating at one line.
- **`src/features/movie-vote/components/MovieBallotList.vue`** — Same treatment for ballot rows so voting UI matches nominations.

Poster and row flex layout are unchanged; only the title typography/clamp behavior differs.

Fixes #8