### PR TITLE
Clear draft picks after a decisive IRV result (keep on declared ties)

### DIFF
--- a/src/features/movie-vote/irv.js
+++ b/src/features/movie-vote/irv.js
@@ -19,6 +19,14 @@
  */
 
 /**
+ * @param {IrvResult | null | undefined} result
+ * @returns {boolean}
+ */
+export function isDeclaredIrvTie(result) {
+  return Array.isArray(result?.tieWinnerIds) && result.tieWinnerIds.length > 0
+}
+
+/**
  * First preference among active candidates for one ballot ranking.
  * @param {string[]} ranking Most preferred first.
  * @param {Set<string>} active

--- a/src/features/movie-vote/irv.test.js
+++ b/src/features/movie-vote/irv.test.js
@@ -3,7 +3,15 @@
  */
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { currentVoteForBallot, pickSingleElimination, runIrv } from './irv.js'
+import { currentVoteForBallot, isDeclaredIrvTie, pickSingleElimination, runIrv } from './irv.js'
+
+test('isDeclaredIrvTie: true only for non-empty tieWinnerIds', () => {
+  assert.equal(isDeclaredIrvTie(null), false)
+  assert.equal(isDeclaredIrvTie(undefined), false)
+  assert.equal(isDeclaredIrvTie({ tieWinnerIds: null, winnerId: 'x', rounds: [] }), false)
+  assert.equal(isDeclaredIrvTie({ tieWinnerIds: [], winnerId: null, rounds: [] }), false)
+  assert.equal(isDeclaredIrvTie({ tieWinnerIds: ['a', 'b'], winnerId: null, rounds: [] }), true)
+})
 
 test('currentVoteForBallot skips eliminated', () => {
   const active = new Set(['a', 'c'])

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -5,6 +5,7 @@
 
 import { defineStore, acceptHMRUpdate } from 'pinia'
 import { HOST_PARTICIPANT_ID } from '../features/movie-vote/core.js'
+import { isDeclaredIrvTie } from '../features/movie-vote/irv.js'
 
 /** @returns {MoviePick} */
 function clonePick(p) {
@@ -152,6 +153,9 @@ export const useMovieVoteStore = defineStore('movieVote', {
       this.setUniqueSuggestedMovieCount(
         typeof p.uniqueSuggestedMovieCount === 'number' ? p.uniqueSuggestedMovieCount : 0,
       )
+      if (p.phase === 'results' && p.irvResult && !isDeclaredIrvTie(p.irvResult)) {
+        this.myDraftPicks = []
+      }
     },
 
     /** Host / solo: enter voting with compiled ballot */
@@ -204,6 +208,9 @@ export const useMovieVoteStore = defineStore('movieVote', {
     setResults(result) {
       this.phase = 'results'
       this.irvResult = result
+      if (!isDeclaredIrvTie(result)) {
+        this.myDraftPicks = []
+      }
     },
 
     resetForRoomExit() {


### PR DESCRIPTION
## Summary

After a vote completed, persisted **draft picks** (`myDraftPicks`) could linger in the suggestion list even though the round had ended. Drafts should clear when the outcome is final, but **declared IRV ties** should still allow hosts to tweak and re-run without losing draft work.

## What changed

- **`src/features/movie-vote/irv.js`** — Exposes whether the current result is a **declared IRV tie** (`isDeclaredIrvTie`) for store logic.
- **`src/features/movie-vote/irv.test.js`** — Unit coverage for the new tie detection behavior.
- **`src/stores/movieVote.js`** — Clears `myDraftPicks` when applying decisive results (`setResults` on host, `applyPublicPayload` for guests). Ties skip the clear so drafts remain available for another run.

Fixes #9