### PR TITLE
P2P: shared star-room timing, awaitPeerOpen, and shell (PRD #15)

### DIFF
--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -9,12 +9,24 @@
 
 import { ref } from 'vue'
 import { Notify } from 'quasar'
-import Peer from 'peerjs'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
-import { classifyPeerError, isUnavailableIdError } from '../../p2p/errors.js'
+import { awaitPeerOpen } from '../../p2p/awaitPeerOpen.js'
+import {
+  runGuestStarReconnectLoop,
+  runHostStarReconnectLoop,
+  wireStarRoomPeerErrors,
+} from '../../p2p/starRoomShell.js'
+import { isUnavailableIdError } from '../../p2p/errors.js'
 import { deriveStableHostSuffix, getStableClientId } from '../../p2p/identity.js'
-import { reconnectDelayMs as sharedReconnectDelayMs } from '../../p2p/reconnect.js'
+import {
+  HEARTBEAT_GUEST_CHECK_MS,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_STALE_MS,
+  OPEN_PEER_TIMEOUT_MS,
+  PEER_OPTS,
+  RECONNECT_PEER_TIMEOUT_MS,
+} from '../../p2p/starRoomTiming.js'
 import {
   encodeGuestHello,
   encodeGuestUpdate,
@@ -87,11 +99,6 @@ let lastSeenSeq = 0
 
 let reconnectGeneration = 0
 
-const RECONNECT_MAX_ATTEMPTS = 10
-const RECONNECT_BASE_DELAY_MS = 800
-const RECONNECT_MAX_DELAY_MS = 5000
-const RECONNECT_INITIAL_PAUSE_MS = 1000
-
 /** Reactive session UI state for multiplayer (Vue ref; safe to use outside components). */
 export const sessionPhase = ref(/** @type {GameTimerSessionPhase} */ ('idle'))
 
@@ -103,26 +110,6 @@ export const sessionSuffix = ref(/** @type {string | null} */ (null))
  * Stays `true` when idle / hosting / unknown.
  */
 export const remoteHostTabVisible = ref(true)
-
-const PEER_OPTS = /** @type {const} */ ({
-  serialization: 'json',
-  reliable: true,
-})
-
-/** First connect / resume: allow slow signaling. */
-const OPEN_PEER_TIMEOUT_MS = 20000
-
-/** Reconnect loops: fail each try faster so backoff (below) dominates. */
-const RECONNECT_PEER_TIMEOUT_MS = 8000
-
-/** Hub → guests while hosting. */
-const HEARTBEAT_INTERVAL_MS = 3000
-
-/** Guest: no snapshot or ping from host for this long ⇒ reconnect. */
-const HEARTBEAT_STALE_MS = 12_000
-
-/** Guest: how often we check staleness. */
-const HEARTBEAT_GUEST_CHECK_MS = 2000
 
 /** @type {ReturnType<typeof setInterval> | null} */
 let hostHeartbeatIntervalId = null
@@ -297,46 +284,6 @@ function destroyWireOnly() {
   isHost = false
   nextSeq = 0
   lastSeenSeq = 0
-}
-
-/**
- * @param {number} attemptAfterFirst Zero-based: delay before attempt 2 uses index 0.
- * @returns {number}
- */
-function reconnectDelayMs(attemptAfterFirst) {
-  return sharedReconnectDelayMs(attemptAfterFirst, {
-    baseMs: RECONNECT_BASE_DELAY_MS,
-    maxMs: RECONNECT_MAX_DELAY_MS,
-  })
-}
-
-/**
- * @param {string} [brokerId] When non-empty, open as this broker id (hub). Otherwise random id (guest).
- * @param {number} [timeoutMs=OPEN_PEER_TIMEOUT_MS]
- * @returns {Promise<import('peerjs').Peer>}
- */
-function awaitPeerOpen(brokerId, timeoutMs = OPEN_PEER_TIMEOUT_MS) {
-  return new Promise((resolve, reject) => {
-    const pr =
-      typeof brokerId === 'string' && brokerId.length > 0 ? new Peer(brokerId) : new Peer()
-    const t = window.setTimeout(() => {
-      try {
-        pr.destroy()
-      } catch { void 0 }
-      reject(new Error('Peer open timeout'))
-    }, timeoutMs)
-    pr.on('error', (e) => {
-      window.clearTimeout(t)
-      try {
-        pr.destroy()
-      } catch { void 0 }
-      reject(e)
-    })
-    pr.on('open', () => {
-      window.clearTimeout(t)
-      resolve(pr)
-    })
-  })
 }
 
 /**
@@ -543,32 +490,21 @@ function handleGuestInbound(raw) {
 }
 
 /**
- * Forwards PeerJS `error` events to host or guest disconnect handling. Fatal
- * errors (per {@link classifyPeerError}) skip the reconnect loop and go
- * straight to a clean teardown so the UI surfaces the real problem instead of
- * spinning a doomed retry loop.
+ * Registers {@link wireStarRoomPeerErrors} with game-timer–specific handlers.
  * @param {import('peerjs').Peer} p
  * @returns {void}
  */
 function wirePeerErrors(p) {
-  p.on('error', (err) => {
-    const severity = classifyPeerError(err)
-    if (severity === 'fatal') {
+  wireStarRoomPeerErrors(p, {
+    bumpReconnectGeneration: () => {
       reconnectGeneration += 1
-      clearRoomPersistence()
-      const msg =
-        err && typeof err === 'object' && 'type' in err
-          ? `P2P error: ${/** @type {{type:string}} */ (err).type}`
-          : 'P2P error'
-      notifyP2P(msg, 'negative')
-      teardownSession()
-      return
-    }
-    if (isHost) {
-      onHostDisconnected()
-    } else {
-      onGuestDisconnected()
-    }
+    },
+    clearRoomPersistence,
+    notifyP2p: notifyP2P,
+    teardownSession,
+    getIsHost: () => isHost,
+    onHostDisconnected,
+    onGuestDisconnected,
   })
 }
 
@@ -627,38 +563,22 @@ function onHostDisconnected() {
  * @param {number} gen Captured reconnect generation; superseded when the user leaves or a new disconnect runs.
  * @returns {Promise<void>}
  */
-async function guestReconnectLoop(suffix, gen) {
-  await new Promise((r) => setTimeout(r, RECONNECT_INITIAL_PAUSE_MS))
-  if (gen !== reconnectGeneration) return
-
-  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
-    if (gen !== reconnectGeneration) return
-
-    if (attempt > 1) {
-      notifyP2P(`Reconnecting… attempt ${attempt} of ${RECONNECT_MAX_ATTEMPTS}`, 'warning')
-      await new Promise((r) => setTimeout(r, reconnectDelayMs(attempt - 2)))
-    }
-
-    if (gen !== reconnectGeneration) return
-
-    try {
-      destroyWireOnly()
-      await establishGuestSession(suffix, { peerTimeoutMs: RECONNECT_PEER_TIMEOUT_MS })
-      if (gen !== reconnectGeneration) {
-        leaveSession()
-        return
-      }
-      return
-    } catch {
-      continue
-    }
-  }
-
-  if (gen !== reconnectGeneration) return
-
-  clearRoomPersistence()
-  notifyP2P('Could not reconnect. Use Host room / Join room to try again.', 'negative')
-  teardownSession()
+function guestReconnectLoop(suffix, gen) {
+  return runGuestStarReconnectLoop({
+    gen,
+    getReconnectGeneration: () => reconnectGeneration,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    notifyReconnectingGuest: (attempt, max) =>
+      notifyP2P(`Reconnecting… attempt ${attempt} of ${max}`, 'warning'),
+    destroyWireOnly,
+    establishGuest: () =>
+      establishGuestSession(suffix, { peerTimeoutMs: RECONNECT_PEER_TIMEOUT_MS }),
+    leaveSession,
+    clearRoomPersistence,
+    notifyGuestReconnectFailed: () =>
+      notifyP2P('Could not reconnect. Use Host room / Join room to try again.', 'negative'),
+    teardownSession,
+  })
 }
 
 /**
@@ -666,40 +586,25 @@ async function guestReconnectLoop(suffix, gen) {
  * @param {number} gen Captured reconnect generation; superseded when the user leaves or a new disconnect runs.
  * @returns {Promise<void>}
  */
-async function hostReconnectLoop(suffix, gen) {
+function hostReconnectLoop(suffix, gen) {
   const fullId = fullPeerIdFromSuffix(suffix)
-  await new Promise((r) => setTimeout(r, RECONNECT_INITIAL_PAUSE_MS))
-  if (gen !== reconnectGeneration) return
-
-  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
-    if (gen !== reconnectGeneration) return
-
-    if (attempt > 1) {
-      notifyP2P(`Reconnecting as host… attempt ${attempt} of ${RECONNECT_MAX_ATTEMPTS}`, 'warning')
-      await new Promise((r) => setTimeout(r, reconnectDelayMs(attempt - 2)))
-    }
-
-    if (gen !== reconnectGeneration) return
-
-    try {
-      destroyWireOnly()
+  return runHostStarReconnectLoop({
+    gen,
+    getReconnectGeneration: () => reconnectGeneration,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    notifyReconnectingHost: (attempt, max) =>
+      notifyP2P(`Reconnecting as host… attempt ${attempt} of ${max}`, 'warning'),
+    destroyWireOnly,
+    establishHost: async () => {
       const p = await awaitPeerOpen(fullId, RECONNECT_PEER_TIMEOUT_MS)
       finishHostSession(/** @type {import('peerjs').Peer} */ (p), suffix)
-      if (gen !== reconnectGeneration) {
-        leaveSession()
-        return
-      }
-      return
-    } catch {
-      continue
-    }
-  }
-
-  if (gen !== reconnectGeneration) return
-
-  clearRoomPersistence()
-  notifyP2P('Could not restore hosting. Start a new room or try again later.', 'negative')
-  teardownSession()
+    },
+    leaveSession,
+    clearRoomPersistence,
+    notifyHostReconnectFailed: () =>
+      notifyP2P('Could not restore hosting. Start a new room or try again later.', 'negative'),
+    teardownSession,
+  })
 }
 
 /**

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -6,9 +6,9 @@
 
 import { ref } from 'vue'
 import { Notify } from 'quasar'
-import Peer from 'peerjs'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import { awaitPeerOpen } from '../../p2p/awaitPeerOpen.js'
 import {
   HOST_PARTICIPANT_ID,
   compileBallotMovies,
@@ -16,9 +16,21 @@ import {
   uniqueMoviesInPicks,
 } from '../core.js'
 import { runIrv } from '../irv.js'
-import { classifyPeerError, isUnavailableIdError } from '../../p2p/errors.js'
+import {
+  runGuestStarReconnectLoop,
+  runHostStarReconnectLoop,
+  wireStarRoomPeerErrors,
+} from '../../p2p/starRoomShell.js'
+import { isUnavailableIdError } from '../../p2p/errors.js'
 import { deriveStableHostSuffix, getStableClientId } from '../../p2p/identity.js'
-import { reconnectDelayMs as sharedReconnectDelayMs } from '../../p2p/reconnect.js'
+import {
+  HEARTBEAT_GUEST_CHECK_MS,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_STALE_MS,
+  OPEN_PEER_TIMEOUT_MS,
+  PEER_OPTS,
+  RECONNECT_PEER_TIMEOUT_MS,
+} from '../../p2p/starRoomTiming.js'
 import {
   encodeDraft,
   encodeHello,
@@ -110,22 +122,6 @@ export const sessionSuffix = ref(/** @type {string | null} */ (null))
  * Stays `true` when idle / hosting / unknown.
  */
 export const remoteHostTabVisible = ref(true)
-
-const RECONNECT_MAX_ATTEMPTS = 10
-const RECONNECT_BASE_DELAY_MS = 800
-const RECONNECT_MAX_DELAY_MS = 5000
-const RECONNECT_INITIAL_PAUSE_MS = 1000
-
-const PEER_OPTS = /** @type {const} */ ({
-  serialization: 'json',
-  reliable: true,
-})
-
-const OPEN_PEER_TIMEOUT_MS = 20000
-const RECONNECT_PEER_TIMEOUT_MS = 8000
-const HEARTBEAT_INTERVAL_MS = 3000
-const HEARTBEAT_STALE_MS = 12_000
-const HEARTBEAT_GUEST_CHECK_MS = 2000
 
 /**
  * When a guest's `DataConnection` closes, keep their participant slot (drafts,
@@ -293,45 +289,6 @@ function destroyWireOnly() {
   isHost = false
   nextSeq = 0
   lastSeenSeq = 0
-}
-
-function reconnectDelayMs(attemptAfterFirst) {
-  return sharedReconnectDelayMs(attemptAfterFirst, {
-    baseMs: RECONNECT_BASE_DELAY_MS,
-    maxMs: RECONNECT_MAX_DELAY_MS,
-  })
-}
-
-/**
- * @param {string} [brokerId]
- * @param {number} [timeoutMs]
- */
-function awaitPeerOpen(brokerId, timeoutMs = OPEN_PEER_TIMEOUT_MS) {
-  return new Promise((resolve, reject) => {
-    const pr =
-      typeof brokerId === 'string' && brokerId.length > 0 ? new Peer(brokerId) : new Peer()
-    const t = window.setTimeout(() => {
-      try {
-        pr.destroy()
-      } catch {
-        void 0
-      }
-      reject(new Error('Peer open timeout'))
-    }, timeoutMs)
-    pr.on('error', (e) => {
-      window.clearTimeout(t)
-      try {
-        pr.destroy()
-      } catch {
-        void 0
-      }
-      reject(e)
-    })
-    pr.on('open', () => {
-      window.clearTimeout(t)
-      resolve(pr)
-    })
-  })
 }
 
 /**
@@ -572,24 +529,16 @@ function handleGuestInbound(raw) {
 }
 
 function wirePeerErrors(p) {
-  p.on('error', (err) => {
-    const severity = classifyPeerError(err)
-    if (severity === 'fatal') {
+  wireStarRoomPeerErrors(p, {
+    bumpReconnectGeneration: () => {
       reconnectGeneration += 1
-      clearRoomPersistence()
-      const msg =
-        err && typeof err === 'object' && 'type' in err
-          ? `P2P error: ${/** @type {{type:string}} */ (err).type}`
-          : 'P2P error'
-      notifyP2P(msg, 'negative')
-      teardownSession()
-      return
-    }
-    if (isHost) {
-      onHostDisconnected()
-    } else {
-      onGuestDisconnected()
-    }
+    },
+    clearRoomPersistence,
+    notifyP2p: notifyP2P,
+    teardownSession,
+    getIsHost: () => isHost,
+    onHostDisconnected,
+    onGuestDisconnected,
   })
 }
 
@@ -639,78 +588,47 @@ function onHostDisconnected() {
  * @param {string} suffix
  * @param {number} gen
  */
-async function guestReconnectLoop(suffix, gen) {
-  await new Promise((r) => setTimeout(r, RECONNECT_INITIAL_PAUSE_MS))
-  if (gen !== reconnectGeneration) return
-
-  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
-    if (gen !== reconnectGeneration) return
-
-    if (attempt > 1) {
-      notifyP2P(`Reconnecting… attempt ${attempt} of ${RECONNECT_MAX_ATTEMPTS}`, 'warning')
-      await new Promise((r) => setTimeout(r, reconnectDelayMs(attempt - 2)))
-    }
-
-    if (gen !== reconnectGeneration) return
-
-    try {
-      destroyWireOnly()
-      await establishGuestSession(suffix, { peerTimeoutMs: RECONNECT_PEER_TIMEOUT_MS })
-      if (gen !== reconnectGeneration) {
-        leaveSession()
-        return
-      }
-      return
-    } catch {
-      continue
-    }
-  }
-
-  if (gen !== reconnectGeneration) return
-
-  clearRoomPersistence()
-  notifyP2P('Could not reconnect. Use Host room / Join room to try again.', 'negative')
-  teardownSession()
+function guestReconnectLoop(suffix, gen) {
+  return runGuestStarReconnectLoop({
+    gen,
+    getReconnectGeneration: () => reconnectGeneration,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    notifyReconnectingGuest: (attempt, max) =>
+      notifyP2P(`Reconnecting… attempt ${attempt} of ${max}`, 'warning'),
+    destroyWireOnly,
+    establishGuest: () =>
+      establishGuestSession(suffix, { peerTimeoutMs: RECONNECT_PEER_TIMEOUT_MS }),
+    leaveSession,
+    clearRoomPersistence,
+    notifyGuestReconnectFailed: () =>
+      notifyP2P('Could not reconnect. Use Host room / Join room to try again.', 'negative'),
+    teardownSession,
+  })
 }
 
 /**
  * @param {string} suffix
  * @param {number} gen
  */
-async function hostReconnectLoop(suffix, gen) {
+function hostReconnectLoop(suffix, gen) {
   const fullId = fullPeerIdFromSuffix(suffix)
-  await new Promise((r) => setTimeout(r, RECONNECT_INITIAL_PAUSE_MS))
-  if (gen !== reconnectGeneration) return
-
-  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
-    if (gen !== reconnectGeneration) return
-
-    if (attempt > 1) {
-      notifyP2P(`Reconnecting as host… attempt ${attempt} of ${RECONNECT_MAX_ATTEMPTS}`, 'warning')
-      await new Promise((r) => setTimeout(r, reconnectDelayMs(attempt - 2)))
-    }
-
-    if (gen !== reconnectGeneration) return
-
-    try {
-      destroyWireOnly()
+  return runHostStarReconnectLoop({
+    gen,
+    getReconnectGeneration: () => reconnectGeneration,
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    notifyReconnectingHost: (attempt, max) =>
+      notifyP2P(`Reconnecting as host… attempt ${attempt} of ${max}`, 'warning'),
+    destroyWireOnly,
+    establishHost: async () => {
       const p = await awaitPeerOpen(fullId, RECONNECT_PEER_TIMEOUT_MS)
       finishHostSession(/** @type {import('peerjs').Peer} */ (p), suffix)
-      if (gen !== reconnectGeneration) {
-        leaveSession()
-        return
-      }
-      return
-    } catch {
-      continue
-    }
-  }
-
-  if (gen !== reconnectGeneration) return
-
-  clearRoomPersistence()
-  notifyP2P('Could not restore hosting. Start a new room or try again later.', 'negative')
-  teardownSession()
+    },
+    leaveSession,
+    clearRoomPersistence,
+    notifyHostReconnectFailed: () =>
+      notifyP2P('Could not restore hosting. Start a new room or try again later.', 'negative'),
+    teardownSession,
+  })
 }
 
 /**

--- a/src/features/p2p/awaitPeerOpen.js
+++ b/src/features/p2p/awaitPeerOpen.js
@@ -1,0 +1,39 @@
+/**
+ * Open a PeerJS Peer with a timeout; destroys the peer on error or timeout.
+ */
+
+import Peer from 'peerjs'
+import { OPEN_PEER_TIMEOUT_MS } from './starRoomTiming.js'
+
+/**
+ * @param {string} [brokerId] When non-empty, open as this broker id (hub). Otherwise random id (guest).
+ * @param {number} [timeoutMs]
+ * @returns {Promise<import('peerjs').Peer>}
+ */
+export function awaitPeerOpen(brokerId, timeoutMs = OPEN_PEER_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const pr =
+      typeof brokerId === 'string' && brokerId.length > 0 ? new Peer(brokerId) : new Peer()
+    const t = window.setTimeout(() => {
+      try {
+        pr.destroy()
+      } catch {
+        void 0
+      }
+      reject(new Error('Peer open timeout'))
+    }, timeoutMs)
+    pr.on('error', (e) => {
+      window.clearTimeout(t)
+      try {
+        pr.destroy()
+      } catch {
+        void 0
+      }
+      reject(e)
+    })
+    pr.on('open', () => {
+      window.clearTimeout(t)
+      resolve(pr)
+    })
+  })
+}

--- a/src/features/p2p/starRoomReconnectDelay.js
+++ b/src/features/p2p/starRoomReconnectDelay.js
@@ -1,0 +1,17 @@
+/**
+ * Star-room reconnect backoff using shared {@link ./reconnect.js} tuning.
+ */
+
+import { reconnectDelayMs as reconnectDelayMsCore } from './reconnect.js'
+import { RECONNECT_BASE_DELAY_MS, RECONNECT_MAX_DELAY_MS } from './starRoomTiming.js'
+
+/**
+ * @param {number} attemptAfterFirst Zero-based: delay before attempt 2 uses index 0.
+ * @returns {number}
+ */
+export function starRoomReconnectDelayMs(attemptAfterFirst) {
+  return reconnectDelayMsCore(attemptAfterFirst, {
+    baseMs: RECONNECT_BASE_DELAY_MS,
+    maxMs: RECONNECT_MAX_DELAY_MS,
+  })
+}

--- a/src/features/p2p/starRoomShell.js
+++ b/src/features/p2p/starRoomShell.js
@@ -1,0 +1,166 @@
+/**
+ * Star-room P2P shell: shared Peer error wiring and reconnect loops used by
+ * feature sessions (Game Timer, Movie Vote). Feature code supplies closures
+ * (establish guest/host, notify, teardown). The shell does not import Pinia
+ * or Quasar.
+ *
+ * ## Adapter contract (call order)
+ *
+ * **wireStarRoomPeerErrors** — Register once per open `Peer`. On each error:
+ * 1. `classifyPeerError` (internal) → if `fatal`: `bumpReconnectGeneration`,
+ *    `clearRoomPersistence`, `notifyP2p` (fatal message), `teardownSession`, return.
+ * 2. Else: if `getIsHost()` then `onHostDisconnected()` else `onGuestDisconnected()`.
+ *
+ * **runGuestStarReconnectLoop** — After guest sets phase to `reconnecting`:
+ * 1. `sleep(RECONNECT_INITIAL_PAUSE_MS)`; abort if `gen !== getReconnectGeneration()`.
+ * 2. For attempts 1..`RECONNECT_MAX_ATTEMPTS`: optional notify + backoff sleep;
+ *    `destroyWireOnly()` then `await establishGuest()`; if generation changed,
+ *    `leaveSession()` and return; on success return.
+ * 3. On exhaustion: `clearRoomPersistence`, `notifyGuestReconnectFailed`, `teardownSession`.
+ *
+ * **runHostStarReconnectLoop** — Same structure; `establishHost` replaces
+ * `establishGuest`; final failure uses `notifyHostReconnectFailed`.
+ */
+
+import { classifyPeerError } from './errors.js'
+import { starRoomReconnectDelayMs } from './starRoomReconnectDelay.js'
+import { RECONNECT_INITIAL_PAUSE_MS, RECONNECT_MAX_ATTEMPTS } from './starRoomTiming.js'
+
+/**
+ * @typedef {object} StarRoomPeerErrorHandlers
+ * @property {() => void} bumpReconnectGeneration
+ * @property {() => void} clearRoomPersistence
+ * @property {(message: string, type: 'positive' | 'negative' | 'warning' | 'info') => void} notifyP2p
+ * @property {() => void} teardownSession
+ * @property {() => boolean} getIsHost
+ * @property {() => void} onHostDisconnected
+ * @property {() => void} onGuestDisconnected
+ */
+
+/**
+ * @param {import('peerjs').Peer} peer
+ * @param {StarRoomPeerErrorHandlers} h
+ * @returns {void}
+ */
+export function wireStarRoomPeerErrors(peer, h) {
+  peer.on('error', (err) => {
+    const severity = classifyPeerError(err)
+    if (severity === 'fatal') {
+      h.bumpReconnectGeneration()
+      h.clearRoomPersistence()
+      const msg =
+        err && typeof err === 'object' && 'type' in err
+          ? `P2P error: ${/** @type {{ type: string }} */ (err).type}`
+          : 'P2P error'
+      h.notifyP2p(msg, 'negative')
+      h.teardownSession()
+      return
+    }
+    if (h.getIsHost()) h.onHostDisconnected()
+    else h.onGuestDisconnected()
+  })
+}
+
+/**
+ * @typedef {object} StarRoomGuestReconnectHandlers
+ * @property {number} gen
+ * @property {() => number} getReconnectGeneration
+ * @property {(ms: number) => Promise<void>} sleep
+ * @property {(attempt: number, maxAttempts: number) => void} notifyReconnectingGuest
+ * @property {() => void} destroyWireOnly
+ * @property {() => Promise<void>} establishGuest
+ * @property {() => void} leaveSession
+ * @property {() => void} clearRoomPersistence
+ * @property {() => void} notifyGuestReconnectFailed
+ * @property {() => void} teardownSession
+ */
+
+/**
+ * @param {StarRoomGuestReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+export async function runGuestStarReconnectLoop(h) {
+  await h.sleep(RECONNECT_INITIAL_PAUSE_MS)
+  if (h.gen !== h.getReconnectGeneration()) return
+
+  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
+    if (h.gen !== h.getReconnectGeneration()) return
+
+    if (attempt > 1) {
+      h.notifyReconnectingGuest(attempt, RECONNECT_MAX_ATTEMPTS)
+      await h.sleep(starRoomReconnectDelayMs(attempt - 2))
+    }
+
+    if (h.gen !== h.getReconnectGeneration()) return
+
+    try {
+      h.destroyWireOnly()
+      await h.establishGuest()
+      if (h.gen !== h.getReconnectGeneration()) {
+        h.leaveSession()
+        return
+      }
+      return
+    } catch {
+      continue
+    }
+  }
+
+  if (h.gen !== h.getReconnectGeneration()) return
+
+  h.clearRoomPersistence()
+  h.notifyGuestReconnectFailed()
+  h.teardownSession()
+}
+
+/**
+ * @typedef {object} StarRoomHostReconnectHandlers
+ * @property {number} gen
+ * @property {() => number} getReconnectGeneration
+ * @property {(ms: number) => Promise<void>} sleep
+ * @property {(attempt: number, maxAttempts: number) => void} notifyReconnectingHost
+ * @property {() => void} destroyWireOnly
+ * @property {() => Promise<void>} establishHost
+ * @property {() => void} leaveSession
+ * @property {() => void} clearRoomPersistence
+ * @property {() => void} notifyHostReconnectFailed
+ * @property {() => void} teardownSession
+ */
+
+/**
+ * @param {StarRoomHostReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+export async function runHostStarReconnectLoop(h) {
+  await h.sleep(RECONNECT_INITIAL_PAUSE_MS)
+  if (h.gen !== h.getReconnectGeneration()) return
+
+  for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt++) {
+    if (h.gen !== h.getReconnectGeneration()) return
+
+    if (attempt > 1) {
+      h.notifyReconnectingHost(attempt, RECONNECT_MAX_ATTEMPTS)
+      await h.sleep(starRoomReconnectDelayMs(attempt - 2))
+    }
+
+    if (h.gen !== h.getReconnectGeneration()) return
+
+    try {
+      h.destroyWireOnly()
+      await h.establishHost()
+      if (h.gen !== h.getReconnectGeneration()) {
+        h.leaveSession()
+        return
+      }
+      return
+    } catch {
+      continue
+    }
+  }
+
+  if (h.gen !== h.getReconnectGeneration()) return
+
+  h.clearRoomPersistence()
+  h.notifyHostReconnectFailed()
+  h.teardownSession()
+}

--- a/src/features/p2p/starRoomTiming.js
+++ b/src/features/p2p/starRoomTiming.js
@@ -1,0 +1,29 @@
+/**
+ * Shared timing and PeerJS client options for star-hub P2P sessions (Game Timer, Movie Vote).
+ */
+
+export const RECONNECT_MAX_ATTEMPTS = 10
+export const RECONNECT_BASE_DELAY_MS = 800
+export const RECONNECT_MAX_DELAY_MS = 5000
+export const RECONNECT_INITIAL_PAUSE_MS = 1000
+
+/** @type {const} */
+export const PEER_OPTS = {
+  serialization: 'json',
+  reliable: true,
+}
+
+/** First connect / resume: allow slow signaling. */
+export const OPEN_PEER_TIMEOUT_MS = 20000
+
+/** Reconnect loops: fail each try faster so backoff dominates. */
+export const RECONNECT_PEER_TIMEOUT_MS = 8000
+
+/** Hub → guests while hosting. */
+export const HEARTBEAT_INTERVAL_MS = 3000
+
+/** Guest: no snapshot or ping from host for this long ⇒ reconnect. */
+export const HEARTBEAT_STALE_MS = 12_000
+
+/** Guest: how often we check staleness. */
+export const HEARTBEAT_GUEST_CHECK_MS = 2000


### PR DESCRIPTION
## Summary

Implements the [PRD: Shared PeerJS star-room lifecycle](https://github.com/enmaku/portfolio-site/issues/15) work: shared timing and `awaitPeerOpen`, reconnect backoff helper, and a `starRoomShell` module for peer fatal/transient handling plus guest/host reconnect loops. Game Timer and Movie Vote `session.js` both use the shared code; Pinia game-timer bridge unchanged.

## Verification

- `npm run lint` and `npm test` pass locally.
- Manual multiplayer smoke recommended for Game Timer and Movie Vote (host/guest, refresh, reconnect) per child issues.

---

Closes #19
Closes #20
Closes #17
Closes #18

Refs #15
