### PR TITLE
Add fullscreen option to game timer settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "node --test src/features/movie-vote/irv.test.js",
+    "test": "node --test \"src/features/**/*.test.js\"",
     "dev": "quasar dev",
     "generate-thumbs": "node ./scripts/generate-photo-thumbs.mjs",
     "generate-share-pages": "node ./scripts/generate-share-pages.mjs",

--- a/src/features/game-timer/components/GameTimerRoundBar.vue
+++ b/src/features/game-timer/components/GameTimerRoundBar.vue
@@ -36,7 +36,7 @@
         />
       </div>
     </div>
-    <div v-if="!isGuest" class="gt-round-bar__right row no-wrap items-center">
+    <div class="gt-round-bar__right row no-wrap items-center">
       <q-btn
         flat
         round
@@ -48,18 +48,23 @@
       >
         <q-menu anchor="bottom right" self="top right" :offset="[0, 6]">
           <div class="gt-settings-menu q-pa-md" style="min-width: 280px">
-            <div class="text-subtitle2 text-weight-medium q-mb-sm">Round rules</div>
-            <q-toggle v-model="hardPassEnabledModel" color="primary" label="Hard pass" />
-            <div class="text-caption text-grey-6 q-mb-md q-ml-sm">
-              Hard pass removes a player from the current round.
-            </div>
-            <div class="q-pl-md">
-              <q-toggle
-                v-model="hardPassOrderNextRoundModel"
-                color="primary"
-                :disable="!hardPassEnabled"
-                label="Pass order determines round order"
-              />
+            <template v-if="settingsModel.showRoundRules">
+              <div class="text-subtitle2 text-weight-medium q-mb-sm">Round rules</div>
+              <q-toggle v-model="hardPassEnabledModel" color="primary" label="Hard pass" />
+              <div class="text-caption text-grey-6 q-mb-md q-ml-sm">
+                Hard pass removes a player from the current round.
+              </div>
+              <div class="q-pl-md q-mb-sm">
+                <q-toggle
+                  v-model="hardPassOrderNextRoundModel"
+                  color="primary"
+                  :disable="!hardPassEnabled"
+                  label="Pass order determines round order"
+                />
+              </div>
+            </template>
+            <div v-if="settingsModel.showFullscreen">
+              <q-toggle v-model="fullscreenModel" color="primary" label="Fullscreen" />
             </div>
           </div>
         </q-menu>
@@ -74,12 +79,14 @@ import { storeToRefs } from 'pinia'
 import GameTimerSyncControl from './GameTimerSyncControl.vue'
 import { useGameTimerP2P } from '../composables/useGameTimerP2P.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
+import { getGameTimerSettingsModel } from '../settingsModel.js'
 
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
-const { round, players, hardPassEnabled, hardPassOrderNextRound } = storeToRefs(store)
+const { round, players, hardPassEnabled, hardPassOrderNextRound, fullscreenEnabled } = storeToRefs(store)
 const hasPlayers = computed(() => players.value.length > 0)
 const canGoPreviousRound = computed(() => hasPlayers.value && round.value > 1)
+const settingsModel = computed(() => getGameTimerSettingsModel({ isGuest: isGuest.value }))
 
 const hardPassEnabledModel = computed({
   get: () => hardPassEnabled.value,
@@ -89,6 +96,11 @@ const hardPassEnabledModel = computed({
 const hardPassOrderNextRoundModel = computed({
   get: () => hardPassOrderNextRound.value,
   set: (v) => store.setHardPassOrderNextRound(Boolean(v)),
+})
+
+const fullscreenModel = computed({
+  get: () => fullscreenEnabled.value,
+  set: (v) => store.setFullscreenEnabled(Boolean(v)),
 })
 </script>
 

--- a/src/features/game-timer/composables/fullscreenController.js
+++ b/src/features/game-timer/composables/fullscreenController.js
@@ -1,0 +1,56 @@
+/**
+ * @param {{
+ *   getTargetElement: () => Element | null
+ *   readEnabled: () => boolean
+ *   writeEnabled: (next: boolean) => void
+ *   onRequestFailure?: () => void
+ *   fullscreenApi?: {
+ *     readonly fullscreenElement: Element | null
+ *     requestFullscreen: (el: Element) => Promise<void>
+ *     exitFullscreen: () => Promise<void>
+ *   }
+ * }} options
+ */
+export function createFullscreenController(options) {
+  const api = options.fullscreenApi ?? {
+    get fullscreenElement() {
+      return document.fullscreenElement
+    },
+    requestFullscreen: (el) => el.requestFullscreen(),
+    exitFullscreen: () => document.exitFullscreen(),
+  }
+
+  async function sync() {
+    const target = options.getTargetElement()
+    if (!target) return
+    if (options.readEnabled()) {
+      if (api.fullscreenElement === target) return
+      try {
+        await api.requestFullscreen(target)
+      } catch {
+        options.writeEnabled(false)
+        options.onRequestFailure?.()
+      }
+      return
+    }
+    if (api.fullscreenElement === target) {
+      await api.exitFullscreen()
+    }
+  }
+
+  return {
+    async setEnabled(next) {
+      options.writeEnabled(Boolean(next))
+      await sync()
+    },
+    sync,
+    async cleanup() {
+      const target = options.getTargetElement()
+      if (!target) return
+      if (api.fullscreenElement === target) {
+        await api.exitFullscreen()
+      }
+    },
+  }
+}
+

--- a/src/features/game-timer/composables/fullscreenController.test.js
+++ b/src/features/game-timer/composables/fullscreenController.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createFullscreenController } from './fullscreenController.js'
+
+function createApi(target) {
+  let fullscreenElement = null
+  return {
+    target,
+    get fullscreenElement() {
+      return fullscreenElement
+    },
+    async requestFullscreen(el) {
+      fullscreenElement = el
+    },
+    async exitFullscreen() {
+      fullscreenElement = null
+    },
+  }
+}
+
+test('setEnabled(true) requests fullscreen on target element', async () => {
+  const target = {}
+  const api = createApi(target)
+  let persisted = false
+  const controller = createFullscreenController({
+    getTargetElement: () => target,
+    readEnabled: () => persisted,
+    writeEnabled: (next) => {
+      persisted = next
+    },
+    fullscreenApi: api,
+  })
+
+  await controller.setEnabled(true)
+
+  assert.equal(api.fullscreenElement, target)
+  assert.equal(persisted, true)
+})
+
+test('request failure resets persisted preference and calls failure hook', async () => {
+  const target = {}
+  let persisted = false
+  let failureCalls = 0
+  const controller = createFullscreenController({
+    getTargetElement: () => target,
+    readEnabled: () => persisted,
+    writeEnabled: (next) => {
+      persisted = next
+    },
+    onRequestFailure: () => {
+      failureCalls += 1
+    },
+    fullscreenApi: {
+      get fullscreenElement() {
+        return null
+      },
+      async requestFullscreen() {
+        throw new Error('blocked')
+      },
+      async exitFullscreen() {},
+    },
+  })
+
+  await controller.setEnabled(true)
+
+  assert.equal(persisted, false)
+  assert.equal(failureCalls, 1)
+})
+
+test('cleanup exits fullscreen when target is active fullscreen element', async () => {
+  const target = {}
+  const api = createApi(target)
+  let persisted = false
+  const controller = createFullscreenController({
+    getTargetElement: () => target,
+    readEnabled: () => persisted,
+    writeEnabled: (next) => {
+      persisted = next
+    },
+    fullscreenApi: api,
+  })
+
+  await controller.setEnabled(true)
+  assert.equal(api.fullscreenElement, target)
+
+  await controller.cleanup()
+  assert.equal(api.fullscreenElement, null)
+})
+
+test('cleanup does not exit fullscreen for unrelated element', async () => {
+  const target = {}
+  const other = {}
+  let fullscreenElement = other
+  let exitCalls = 0
+  const controller = createFullscreenController({
+    getTargetElement: () => target,
+    readEnabled: () => false,
+    writeEnabled: () => {},
+    fullscreenApi: {
+      get fullscreenElement() {
+        return fullscreenElement
+      },
+      async requestFullscreen() {},
+      async exitFullscreen() {
+        exitCalls += 1
+        fullscreenElement = null
+      },
+    },
+  })
+
+  await controller.cleanup()
+
+  assert.equal(exitCalls, 0)
+  assert.equal(fullscreenElement, other)
+})
+
+test('setEnabled(false) exits fullscreen when target is active', async () => {
+  const target = {}
+  const api = createApi(target)
+  let persisted = false
+  const controller = createFullscreenController({
+    getTargetElement: () => target,
+    readEnabled: () => persisted,
+    writeEnabled: (next) => {
+      persisted = next
+    },
+    fullscreenApi: api,
+  })
+
+  await controller.setEnabled(true)
+  assert.equal(api.fullscreenElement, target)
+
+  await controller.setEnabled(false)
+  assert.equal(api.fullscreenElement, null)
+  assert.equal(persisted, false)
+})
+

--- a/src/features/game-timer/composables/useScopedFullscreen.js
+++ b/src/features/game-timer/composables/useScopedFullscreen.js
@@ -1,0 +1,33 @@
+import { onBeforeUnmount, toValue, watch } from 'vue'
+import { createFullscreenController } from './fullscreenController.js'
+
+/**
+ * @param {{
+ *   enabled: import('vue').MaybeRefOrGetter<boolean>
+ *   setEnabled: (next: boolean) => void
+ *   getTargetElement: () => Element | null
+ *   onRequestFailure?: () => void
+ * }} options
+ */
+export function useScopedFullscreen(options) {
+  const controller = createFullscreenController({
+    getTargetElement: options.getTargetElement,
+    readEnabled: () => Boolean(toValue(options.enabled)),
+    writeEnabled: (next) => options.setEnabled(Boolean(next)),
+    onRequestFailure: options.onRequestFailure,
+  })
+
+  const stop = watch(
+    () => Boolean(toValue(options.enabled)),
+    () => {
+      void controller.sync()
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(() => {
+    stop()
+    void controller.cleanup()
+  })
+}
+

--- a/src/features/game-timer/settingsModel.js
+++ b/src/features/game-timer/settingsModel.js
@@ -1,0 +1,10 @@
+/**
+ * @param {{ isGuest: boolean }} input
+ */
+export function getGameTimerSettingsModel(input) {
+  return {
+    showRoundRules: !input.isGuest,
+    showFullscreen: true,
+  }
+}
+

--- a/src/features/game-timer/settingsModel.test.js
+++ b/src/features/game-timer/settingsModel.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getGameTimerSettingsModel } from './settingsModel.js'
+
+test('guest settings only include fullscreen toggle', () => {
+  const model = getGameTimerSettingsModel({ isGuest: true })
+  assert.equal(model.showRoundRules, false)
+  assert.equal(model.showFullscreen, true)
+})
+
+test('host settings include round rules and fullscreen toggle', () => {
+  const model = getGameTimerSettingsModel({ isGuest: false })
+  assert.equal(model.showRoundRules, true)
+  assert.equal(model.showFullscreen, true)
+})
+

--- a/src/pages/projects/GameTimerPage.vue
+++ b/src/pages/projects/GameTimerPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="gt-page column fit no-wrap">
+  <q-page ref="pageRef" class="gt-page column fit no-wrap">
     <GameTimerRoundBar />
 
     <div
@@ -102,6 +102,7 @@ import GameTimerPlayerList from '../../features/game-timer/components/GameTimerP
 import GameTimerRoundBar from '../../features/game-timer/components/GameTimerRoundBar.vue'
 import GameTimerTurnControls from '../../features/game-timer/components/GameTimerTurnControls.vue'
 import { useGameTimerP2P } from '../../features/game-timer/composables/useGameTimerP2P.js'
+import { useScopedFullscreen } from '../../features/game-timer/composables/useScopedFullscreen.js'
 import { useScreenWakeLock } from '../../features/game-timer/composables/useScreenWakeLock.js'
 import { nextDefaultColor } from '../../features/game-timer/core.js'
 import {
@@ -117,13 +118,33 @@ const route = useRoute()
 const router = useRouter()
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
-const { players, activePlayerId, hasMultipleRounds } = storeToRefs(store)
+const { players, activePlayerId, hasMultipleRounds, fullscreenEnabled } = storeToRefs(store)
 
 /** True when a turn is held (clock running or paused); `activePlayerId` is set. */
 const hasHeldTurn = computed(() => activePlayerId.value != null)
 
 /** While a session has players, keep the display awake (wake lock with video fallback where needed). */
 useScreenWakeLock(computed(() => players.value.length > 0))
+
+const pageRef = ref(null)
+useScopedFullscreen({
+  enabled: fullscreenEnabled,
+  setEnabled: (next) => store.setFullscreenEnabled(next),
+  getTargetElement: () => {
+    const value = pageRef.value
+    if (!value) return null
+    return value.$el ?? value
+  },
+  onRequestFailure: () => {
+    $q.notify({
+      type: 'warning',
+      message: 'Fullscreen could not be enabled.',
+      timeout: 2500,
+      position: 'top',
+      classes: 'gt-notify',
+    })
+  },
+})
 
 onMounted(() => {
   const raw = route.query[GAME_TIMER_ROOM_QUERY_KEY]

--- a/src/stores/gameTimer.js
+++ b/src/stores/gameTimer.js
@@ -53,6 +53,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
     hardPassEnabled: false,
     hardPassOrderNextRound: false,
     hardPassOrderByRound: {},
+    fullscreenEnabled: false,
   }),
 
   getters: {
@@ -94,6 +95,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
       'hardPassEnabled',
       'hardPassOrderNextRound',
       'hardPassOrderByRound',
+      'fullscreenEnabled',
     ],
     afterHydrate: (ctx) => {
       const store = ctx.store
@@ -114,6 +116,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
       if (!store.hardPassOrderByRound || typeof store.hardPassOrderByRound !== 'object') {
         store.hardPassOrderByRound = {}
       }
+      if (typeof store.fullscreenEnabled !== 'boolean') store.fullscreenEnabled = false
       store._applyOrderForActiveRound()
     },
   },
@@ -244,6 +247,13 @@ export const useGameTimerStore = defineStore('gameTimer', {
           this._recomputeNextRoundOrderFromHardPasses(this.round)
         }
       }
+    },
+
+    /**
+     * @param {boolean} value
+     */
+    setFullscreenEnabled(value) {
+      this.fullscreenEnabled = Boolean(value)
     },
 
     /**
@@ -448,6 +458,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
       this.hardPassEnabled = false
       this.hardPassOrderNextRound = false
       this.hardPassOrderByRound = {}
+      this.fullscreenEnabled = false
     },
 
     /** Bank active segment and advance to the next player in list order (wraps); skips hard-passed when enabled. */


### PR DESCRIPTION
## Summary
- add a reusable scoped fullscreen controller/composable for game timer with failure recovery and cleanup on route leave
- expose a persisted `fullscreenEnabled` setting in the game timer store and wire it into the page container
- update game timer settings UI so hosts see round rules + fullscreen and guests see fullscreen-only controls
- add focused node:test coverage for settings visibility and fullscreen lifecycle behaviors

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [ ] Manual: host sees round rules + Fullscreen in settings
- [ ] Manual: guest sees only Fullscreen in settings
- [ ] Manual: fullscreen toggle enters/exits fullscreen and persists across reload
- [ ] Manual: when fullscreen request fails, warning toast appears and toggle resets to off
- [ ] Manual: leaving `/projects/game-timer` exits fullscreen