### PR TITLE
Add total/non-player session timing strip to Game Timer

### DIFF
--- a/src/features/game-timer/components/GameTimerRoundBar.vue
+++ b/src/features/game-timer/components/GameTimerRoundBar.vue
@@ -1,75 +1,85 @@
 <template>
-  <div class="gt-round-bar row items-center no-wrap full-width">
-    <GameTimerSyncControl class="gt-round-bar__sync" />
-    <div class="gt-round-bar__layer-center">
-      <div class="row items-center no-wrap gt-round-bar__controls">
-        <q-btn
-          flat
-          round
-          size="md"
-          icon="chevron_left"
-          color="grey-5"
-          class="gt-round-bar__chev gt-round-bar__hit"
-          :class="{ 'gt-round-bar__chev--inert': !canGoPreviousRound }"
-          :disable="!canGoPreviousRound"
-          :tabindex="canGoPreviousRound ? undefined : -1"
-          :aria-hidden="canGoPreviousRound ? undefined : true"
-          aria-label="Previous round"
-          @click="store.goToPreviousRound()"
-        />
-        <div class="gt-round-bar__value text-weight-medium q-px-md" aria-live="polite">
-          Round {{ round }}
+  <div class="gt-round-bar full-width">
+    <div class="gt-round-bar__main row items-center no-wrap full-width">
+      <GameTimerSyncControl class="gt-round-bar__sync" />
+      <div class="gt-round-bar__layer-center">
+        <div class="row items-center no-wrap gt-round-bar__controls">
+          <q-btn
+            flat
+            round
+            size="md"
+            icon="chevron_left"
+            color="grey-5"
+            class="gt-round-bar__chev gt-round-bar__hit"
+            :class="{ 'gt-round-bar__chev--inert': !canGoPreviousRound }"
+            :disable="!canGoPreviousRound"
+            :tabindex="canGoPreviousRound ? undefined : -1"
+            :aria-hidden="canGoPreviousRound ? undefined : true"
+            aria-label="Previous round"
+            @click="store.goToPreviousRound()"
+          />
+          <div class="gt-round-bar__value text-weight-medium q-px-md" aria-live="polite">
+            Round {{ round }}
+          </div>
+          <q-btn
+            flat
+            round
+            size="md"
+            icon="chevron_right"
+            color="grey-5"
+            class="gt-round-bar__chev gt-round-bar__hit"
+            :class="{ 'gt-round-bar__chev--inert': !hasPlayers }"
+            :disable="!hasPlayers"
+            :tabindex="hasPlayers ? undefined : -1"
+            :aria-hidden="hasPlayers ? undefined : true"
+            aria-label="Next round"
+            @click="store.goToNextRound()"
+          />
         </div>
+      </div>
+      <div class="gt-round-bar__right row no-wrap items-center">
         <q-btn
           flat
           round
           size="md"
-          icon="chevron_right"
+          icon="settings"
           color="grey-5"
-          class="gt-round-bar__chev gt-round-bar__hit"
-          :class="{ 'gt-round-bar__chev--inert': !hasPlayers }"
-          :disable="!hasPlayers"
-          :tabindex="hasPlayers ? undefined : -1"
-          :aria-hidden="hasPlayers ? undefined : true"
-          aria-label="Next round"
-          @click="store.goToNextRound()"
-        />
+          class="gt-round-bar__settings gt-round-bar__hit"
+          aria-label="Game timer settings"
+        >
+          <q-menu anchor="bottom right" self="top right" :offset="[0, 6]">
+            <div class="gt-settings-menu q-pa-md" style="min-width: 280px">
+              <template v-if="settingsModel.showRoundRules">
+                <div class="text-subtitle2 text-weight-medium q-mb-sm">Round rules</div>
+                <q-toggle v-model="hardPassEnabledModel" color="primary" label="Hard pass" />
+                <div class="text-caption text-grey-6 q-mb-md q-ml-sm">
+                  Hard pass removes a player from the current round.
+                </div>
+                <div class="q-pl-md q-mb-sm">
+                  <q-toggle
+                    v-model="hardPassOrderNextRoundModel"
+                    color="primary"
+                    :disable="!hardPassEnabled"
+                    label="Pass order determines round order"
+                  />
+                </div>
+              </template>
+              <div v-if="settingsModel.showFullscreen">
+                <q-toggle v-model="fullscreenModel" color="primary" label="Fullscreen" />
+              </div>
+            </div>
+          </q-menu>
+        </q-btn>
       </div>
     </div>
-    <div class="gt-round-bar__right row no-wrap items-center">
-      <q-btn
-        flat
-        round
-        size="md"
-        icon="settings"
-        color="grey-5"
-        class="gt-round-bar__settings gt-round-bar__hit"
-        aria-label="Game timer settings"
-      >
-        <q-menu anchor="bottom right" self="top right" :offset="[0, 6]">
-          <div class="gt-settings-menu q-pa-md" style="min-width: 280px">
-            <template v-if="settingsModel.showRoundRules">
-              <div class="text-subtitle2 text-weight-medium q-mb-sm">Round rules</div>
-              <q-toggle v-model="hardPassEnabledModel" color="primary" label="Hard pass" />
-              <div class="text-caption text-grey-6 q-mb-md q-ml-sm">
-                Hard pass removes a player from the current round.
-              </div>
-              <div class="q-pl-md q-mb-sm">
-                <q-toggle
-                  v-model="hardPassOrderNextRoundModel"
-                  color="primary"
-                  :disable="!hardPassEnabled"
-                  label="Pass order determines round order"
-                />
-              </div>
-            </template>
-            <div v-if="settingsModel.showFullscreen">
-              <q-toggle v-model="fullscreenModel" color="primary" label="Fullscreen" />
-            </div>
-          </div>
-        </q-menu>
-      </q-btn>
-    </div>
+    <button
+      type="button"
+      class="gt-round-bar__session-strip row items-center justify-between full-width"
+      @click="store.toggleTimingStripMode()"
+    >
+      <span class="gt-round-bar__session-label">{{ timingStripLabel }}</span>
+      <span class="gt-round-bar__session-value text-mono">{{ timingStripValue }}</span>
+    </button>
   </div>
 </template>
 
@@ -77,16 +87,42 @@
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import GameTimerSyncControl from './GameTimerSyncControl.vue'
+import { displayedMsForPlayer, formatDurationMs } from '../core.js'
+import { useGameTimerNow } from '../composables/useGameTimerNow.js'
 import { useGameTimerP2P } from '../composables/useGameTimerP2P.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { getGameTimerSettingsModel } from '../settingsModel.js'
 
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
-const { round, players, hardPassEnabled, hardPassOrderNextRound, fullscreenEnabled } = storeToRefs(store)
+const now = useGameTimerNow(1000)
+const { round, players, hardPassEnabled, hardPassOrderNextRound, fullscreenEnabled, timingStripMode } =
+  storeToRefs(store)
 const hasPlayers = computed(() => players.value.length > 0)
 const canGoPreviousRound = computed(() => hasPlayers.value && round.value > 1)
 const settingsModel = computed(() => getGameTimerSettingsModel({ isGuest: isGuest.value }))
+const totalGameElapsedMs = computed(() => {
+  if (store.totalGameStartedAt == null) return 0
+  return Math.max(0, now.value - store.totalGameStartedAt)
+})
+const playerTotalElapsedMs = computed(() => {
+  const session = {
+    activePlayerId: store.activePlayerId,
+    turnStartedAt: store.turnStartedAt,
+  }
+  let total = 0
+  for (const p of store.players) {
+    total += displayedMsForPlayer(p, session, now.value)
+  }
+  return total
+})
+const nonPlayerElapsedMs = computed(() => Math.max(0, totalGameElapsedMs.value - playerTotalElapsedMs.value))
+const timingStripLabel = computed(() =>
+  timingStripMode.value === 'non-player' ? 'Non-player' : 'Total game',
+)
+const timingStripValue = computed(() =>
+  formatDurationMs(timingStripMode.value === 'non-player' ? nonPlayerElapsedMs.value : totalGameElapsedMs.value),
+)
 
 const hardPassEnabledModel = computed({
   get: () => hardPassEnabled.value,
@@ -109,11 +145,16 @@ const fullscreenModel = computed({
   flex-shrink: 0;
   position: relative;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 10px;
-  padding-bottom: 10px;
-  min-height: 56px;
+  min-height: 92px;
   box-sizing: border-box;
 }
+.gt-round-bar__main {
+  position: relative;
+  padding-top: 10px;
+  padding-bottom: 8px;
+  min-height: 56px;
+}
+
 
 .body--light .gt-round-bar {
   border-bottom-color: rgba(0, 0, 0, 0.08);
@@ -178,6 +219,33 @@ const fullscreenModel = computed({
   position: relative;
   z-index: 1;
   margin-left: auto;
+}
+
+.gt-round-bar__session-strip {
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.86);
+  min-height: 34px;
+  padding: 0 12px;
+  text-align: left;
+}
+
+.gt-round-bar__session-label,
+.gt-round-bar__session-value {
+  font-size: 0.85rem;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
+.gt-round-bar__session-label {
+  letter-spacing: 0.01em;
+}
+
+.body--light .gt-round-bar__session-strip {
+  border-top-color: rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.05);
+  color: rgba(0, 0, 0, 0.72);
 }
 
 </style>

--- a/src/features/game-timer/p2p/gameTimerPiniaBridge.js
+++ b/src/features/game-timer/p2p/gameTimerPiniaBridge.js
@@ -42,6 +42,7 @@ function pickSnapshot(store) {
     activePlayerId: s.activePlayerId,
     turnStartedAt: s.turnStartedAt,
     turnStartedRound: s.turnStartedRound,
+    totalGameStartedAt: s.totalGameStartedAt,
     round: s.round,
     playerOrderByRound: JSON.parse(JSON.stringify(s.playerOrderByRound)),
     hardPassEnabled: s.hardPassEnabled,
@@ -73,6 +74,7 @@ function normalizeAfterRemotePatch(store) {
   }
   if (typeof store.hardPassEnabled !== 'boolean') store.hardPassEnabled = false
   if (typeof store.hardPassOrderNextRound !== 'boolean') store.hardPassOrderNextRound = false
+  if (typeof store.totalGameStartedAt !== 'number') store.totalGameStartedAt = null
   if (!store.hardPassOrderByRound || typeof store.hardPassOrderByRound !== 'object') {
     store.hardPassOrderByRound = {}
   }
@@ -106,6 +108,8 @@ export function gameTimerP2PPlugin(ctx) {
           state.activePlayerId = snap.activePlayerId
           state.turnStartedAt = snap.turnStartedAt
           state.turnStartedRound = snap.turnStartedRound
+          state.totalGameStartedAt =
+            typeof snap.totalGameStartedAt === 'number' ? snap.totalGameStartedAt : null
           state.round = snap.round
           state.playerOrderByRound = JSON.parse(JSON.stringify(snap.playerOrderByRound))
           state.hardPassEnabled = typeof snap.hardPassEnabled === 'boolean' ? snap.hardPassEnabled : false

--- a/src/features/game-timer/p2p/protocol.js
+++ b/src/features/game-timer/p2p/protocol.js
@@ -43,6 +43,13 @@ export function isValidSnapshot(snap) {
   if (!snap.playerOrderByRound || typeof snap.playerOrderByRound !== 'object' || Array.isArray(snap.playerOrderByRound)) {
     return false
   }
+  if (
+    'totalGameStartedAt' in snap &&
+    snap.totalGameStartedAt !== null &&
+    typeof snap.totalGameStartedAt !== 'number'
+  ) {
+    return false
+  }
   if ('hardPassEnabled' in snap && typeof snap.hardPassEnabled !== 'boolean') return false
   if ('hardPassOrderNextRound' in snap && typeof snap.hardPassOrderNextRound !== 'boolean') return false
   if ('hardPassOrderByRound' in snap) {

--- a/src/features/game-timer/p2p/protocol.test.js
+++ b/src/features/game-timer/p2p/protocol.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isValidSnapshot } from './protocol.js'
+
+function baseSnapshot() {
+  return {
+    players: [],
+    activePlayerId: null,
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+  }
+}
+
+test('snapshot accepts missing or numeric totalGameStartedAt', () => {
+  assert.equal(isValidSnapshot(baseSnapshot()), true)
+  assert.equal(isValidSnapshot({ ...baseSnapshot(), totalGameStartedAt: null }), true)
+  assert.equal(isValidSnapshot({ ...baseSnapshot(), totalGameStartedAt: 1234 }), true)
+})
+
+test('snapshot rejects invalid totalGameStartedAt type', () => {
+  assert.equal(isValidSnapshot({ ...baseSnapshot(), totalGameStartedAt: '1234' }), false)
+})

--- a/src/features/game-timer/sessionTiming.test.js
+++ b/src/features/game-timer/sessionTiming.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useGameTimerStore } from '../../stores/gameTimer.js'
+
+function withFakeNow(startMs, run) {
+  const originalNow = Date.now
+  let now = startMs
+  Date.now = () => now
+  const advance = (ms) => {
+    now += ms
+  }
+  try {
+    run(advance)
+  } finally {
+    Date.now = originalNow
+  }
+}
+
+test('game timer session timing starts on first selectPlayer only', () => {
+  withFakeNow(1_000, (advance) => {
+    setActivePinia(createPinia())
+    const store = useGameTimerStore()
+    const p1 = store.addPlayer({ name: 'A' })
+
+    assert.equal(store.totalGameStartedAt, null)
+    assert.equal(store.totalGameElapsedMs, 0)
+    assert.equal(store.nonPlayerElapsedMs, 0)
+
+    advance(3_000)
+    store.selectPlayer(p1)
+    assert.equal(store.totalGameStartedAt, 4_000)
+    assert.equal(store.totalGameElapsedMs, 0)
+  })
+})
+
+test('non-player time is total minus players and clamps at zero', () => {
+  withFakeNow(10_000, (advance) => {
+    setActivePinia(createPinia())
+    const store = useGameTimerStore()
+    const p1 = store.addPlayer({ name: 'A' })
+
+    store.selectPlayer(p1)
+    advance(5_000)
+    store.selectPlayer(p1)
+
+    assert.equal(store.totalGameElapsedMs, 5_000)
+    assert.equal(store.nonPlayerElapsedMs, 0)
+
+    store.players[0].bankedMs = 12_000
+    assert.equal(store.nonPlayerElapsedMs, 0)
+  })
+})
+
+test('clear all players resets session timing baseline', () => {
+  withFakeNow(20_000, (advance) => {
+    setActivePinia(createPinia())
+    const store = useGameTimerStore()
+    const p1 = store.addPlayer({ name: 'A' })
+    store.selectPlayer(p1)
+    advance(2_000)
+
+    store.clearAllPlayers()
+    assert.equal(store.totalGameStartedAt, null)
+    assert.equal(store.totalGameElapsedMs, 0)
+    assert.equal(store.nonPlayerElapsedMs, 0)
+  })
+})

--- a/src/features/game-timer/types.js
+++ b/src/features/game-timer/types.js
@@ -42,6 +42,7 @@
  * @property {number | null} turnStartedRound
  * @property {number} round
  * @property {Record<string, string[]>} playerOrderByRound
+ * @property {number | null} [totalGameStartedAt] Epoch ms for first `selectPlayer`; nullable / omitted on older snapshots.
  * @property {boolean} [hardPassEnabled] Omitted on older snapshots; normalized on apply.
  * @property {boolean} [hardPassOrderNextRound]
  * @property {Record<string, string[]>} [hardPassOrderByRound]

--- a/src/stores/gameTimer.js
+++ b/src/stores/gameTimer.js
@@ -3,7 +3,7 @@
  */
 
 import { defineStore, acceptHMRUpdate } from 'pinia'
-import { createPlayerId, nextDefaultColor } from '../features/game-timer/core.js'
+import { createPlayerId, displayedMsForPlayer, nextDefaultColor } from '../features/game-timer/core.js'
 
 /**
  * Rebuild `players` to match `idOrder`, appending any players missing from that list.
@@ -54,6 +54,8 @@ export const useGameTimerStore = defineStore('gameTimer', {
     hardPassOrderNextRound: false,
     hardPassOrderByRound: {},
     fullscreenEnabled: false,
+    totalGameStartedAt: null,
+    timingStripMode: 'total',
   }),
 
   getters: {
@@ -78,6 +80,32 @@ export const useGameTimerStore = defineStore('gameTimer', {
       }
       return false
     },
+    /**
+     * Total game elapsed wall-clock ms since first `selectPlayer`; 0 before start.
+     * @returns {number}
+     */
+    totalGameElapsedMs(state) {
+      if (typeof state.totalGameStartedAt !== 'number') return 0
+      return Math.max(0, Date.now() - state.totalGameStartedAt)
+    },
+    /**
+     * Session non-player ms: total game minus sum of all player displayed totals.
+     * @returns {number}
+     */
+    nonPlayerElapsedMs(state) {
+      const total = this.totalGameElapsedMs
+      if (total <= 0 || !Array.isArray(state.players) || state.players.length === 0) return total
+      const now = Date.now()
+      const session = {
+        activePlayerId: state.activePlayerId,
+        turnStartedAt: state.turnStartedAt,
+      }
+      let playerSum = 0
+      for (const p of state.players) {
+        playerSum += displayedMsForPlayer(p, session, now)
+      }
+      return Math.max(0, total - playerSum)
+    },
   },
 
   /**
@@ -95,6 +123,8 @@ export const useGameTimerStore = defineStore('gameTimer', {
       'hardPassEnabled',
       'hardPassOrderNextRound',
       'hardPassOrderByRound',
+      'totalGameStartedAt',
+      'timingStripMode',
     ],
     afterHydrate: (ctx) => {
       const store = ctx.store
@@ -114,6 +144,10 @@ export const useGameTimerStore = defineStore('gameTimer', {
       if (typeof store.hardPassOrderNextRound !== 'boolean') store.hardPassOrderNextRound = false
       if (!store.hardPassOrderByRound || typeof store.hardPassOrderByRound !== 'object') {
         store.hardPassOrderByRound = {}
+      }
+      if (typeof store.totalGameStartedAt !== 'number') store.totalGameStartedAt = null
+      if (store.timingStripMode !== 'total' && store.timingStripMode !== 'non-player') {
+        store.timingStripMode = 'total'
       }
       store._applyOrderForActiveRound()
     },
@@ -255,6 +289,17 @@ export const useGameTimerStore = defineStore('gameTimer', {
     },
 
     /**
+     * @param {'total' | 'non-player'} mode
+     */
+    setTimingStripMode(mode) {
+      this.timingStripMode = mode === 'non-player' ? 'non-player' : 'total'
+    },
+
+    toggleTimingStripMode() {
+      this.timingStripMode = this.timingStripMode === 'total' ? 'non-player' : 'total'
+    },
+
+    /**
      * @param {string} playerId
      */
     registerHardPass(playerId) {
@@ -376,6 +421,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
     selectPlayer(playerId) {
       const now = Date.now()
       if (!this.players.some((p) => p.id === playerId)) return
+      if (this.totalGameStartedAt == null) this.totalGameStartedAt = now
 
       if (this.activePlayerId === playerId) {
         if (this.turnStartedAt != null) {
@@ -457,6 +503,8 @@ export const useGameTimerStore = defineStore('gameTimer', {
       this.hardPassOrderNextRound = false
       this.hardPassOrderByRound = {}
       this.fullscreenEnabled = false
+      this.totalGameStartedAt = null
+      this.timingStripMode = 'total'
     },
 
     /** Bank active segment and advance to the next player in list order (wraps); skips hard-passed when enabled. */


### PR DESCRIPTION
## Summary
- add a neutral bottom timing strip in the Game Timer round bar that toggles between `Total game` and `Non-player`
- start and sync a host-authoritative `totalGameStartedAt` baseline on first `selectPlayer`, while keeping display mode local and persisted per device
- add behavior tests for session timing semantics and protocol validation for the new snapshot field

## Test plan
- [x] Run `npm test`
- [x] Verify new tests pass:
  - `sessionTiming.test.js`
  - `p2p/protocol.test.js`
- [x] Manual UI check in Game Timer:
  - strip is visible pre-start with `0:00`
  - tap toggles exactly `Total game` ↔ `Non-player`
  - clear-all resets baseline and returns pre-start behavior

Closes #47.