### PR TITLE
Add debounce to game timer app

### DIFF
--- a/src/features/game-timer/p2p/gameTimerPiniaBridge.js
+++ b/src/features/game-timer/p2p/gameTimerPiniaBridge.js
@@ -131,13 +131,21 @@ export function gameTimerP2PPlugin(ctx) {
   if (actionHookInstalled.has(store)) return
   actionHookInstalled.add(store)
 
-  store.$onAction(({ name, after }) => {
+  store.$onAction(({ name, args, after }) => {
     after(() => {
       if (applyingRemote) return
       if (!SYNC_ACTION_NAMES.has(name)) return
       if (!isP2PSessionActive()) return
+      const sentAt = Date.now()
+      /** @type {{ kind: 'selectPlayer' | 'registerHardPass', playerId: string, sentAt: number } | undefined} */
+      let intent
+      if (name === 'selectPlayer' && typeof args[0] === 'string') {
+        intent = { kind: 'selectPlayer', playerId: args[0], sentAt }
+      } else if (name === 'registerHardPass' && typeof args[0] === 'string') {
+        intent = { kind: 'registerHardPass', playerId: args[0], sentAt }
+      }
       try {
-        broadcastGameTimerSnapshot(pickSnapshot(useGameTimerStore()))
+        broadcastGameTimerSnapshot(pickSnapshot(useGameTimerStore()), intent)
       } catch (e) {
         console.error('[gameTimerP2P] broadcast failed', e)
       }

--- a/src/features/game-timer/p2p/guestIntentDedupe.js
+++ b/src/features/game-timer/p2p/guestIntentDedupe.js
@@ -1,0 +1,89 @@
+/**
+ * Host-side debounce for duplicate guest action intents (same kind + playerId).
+ * Uses host receive time only; guest `sentAt` is wire metadata for debugging / future use.
+ */
+
+/** @typedef {{ kind: 'selectPlayer' | 'registerHardPass', playerId: string }} GuestIntentKey */
+
+export const GUEST_INTENT_DEBOUNCE_MS = 250
+
+/** @type {Set<string>} */
+const DEBOUNCED_KINDS = new Set(['selectPlayer', 'registerHardPass'])
+
+/**
+ * @param {unknown} intent
+ * @returns {intent is { kind: string, playerId: string, sentAt: number }}
+ */
+export function isWellFormedGuestIntent(intent) {
+  if (intent == null || typeof intent !== 'object' || Array.isArray(intent)) return false
+  const k = /** @type {{ kind?: unknown, playerId?: unknown, sentAt?: unknown }} */ (intent)
+  if (k.kind !== 'selectPlayer' && k.kind !== 'registerHardPass') return false
+  if (typeof k.playerId !== 'string' || !k.playerId) return false
+  if (typeof k.sentAt !== 'number') return false
+  return true
+}
+
+/**
+ * @param {unknown} intent
+ * @returns {boolean}
+ */
+export function isDebouncedGuestIntentKind(intent) {
+  return isWellFormedGuestIntent(intent) && DEBOUNCED_KINDS.has(/** @type {{ kind: string }} */ (intent).kind)
+}
+
+/**
+ * @param {{ debounceMs?: number }} [opts]
+ */
+export function createGuestIntentDeduper(opts = {}) {
+  const windowMs = typeof opts.debounceMs === 'number' ? opts.debounceMs : GUEST_INTENT_DEBOUNCE_MS
+  /** @type {Map<string, number>} */
+  const lastAcceptedAt = new Map()
+
+  /**
+   * @param {GuestIntentKey} intent
+   * @param {number} nowMs
+   * @returns {boolean} true if this message should be suppressed (duplicate inside window)
+   */
+  function shouldSuppress(intent, nowMs) {
+    const key = `${intent.kind}:${intent.playerId}`
+    const prev = lastAcceptedAt.get(key)
+    if (prev != null && nowMs - prev < windowMs) {
+      return true
+    }
+    lastAcceptedAt.set(key, nowMs)
+    return false
+  }
+
+  return { shouldSuppress }
+}
+
+/**
+ * @param {{ intent?: unknown }} parsed
+ * @param {{ shouldSuppress: (intent: GuestIntentKey, nowMs: number) => boolean }} deduper
+ * @param {number} nowMs
+ * @returns {boolean} whether the host should apply `parsed.snapshot`
+ */
+export function hostShouldApplyGuestSnapshot(parsed, deduper, nowMs) {
+  const intent = parsed.intent
+  if (!isDebouncedGuestIntentKind(intent)) return true
+  return !deduper.shouldSuppress(
+    { kind: /** @type {'selectPlayer' | 'registerHardPass'} */ (intent.kind), playerId: intent.playerId },
+    nowMs,
+  )
+}
+
+/**
+ * @param {{ snapshot: import('../types.js').GameTimerSyncPayload, intent?: unknown }} parsed
+ * @param {{ shouldSuppress: (intent: GuestIntentKey, nowMs: number) => boolean }} deduper
+ * @param {number} nowMs
+ * @param {(snap: import('../types.js').GameTimerSyncPayload) => void} applySnapshot
+ * @param {() => import('../types.js').GameTimerSyncPayload} getSnapshot
+ * @returns {{ broadcastSnapshot: import('../types.js').GameTimerSyncPayload, appliedGuestSnapshot: boolean }}
+ */
+export function authoritativeSnapshotAfterGuestMessage(parsed, deduper, nowMs, applySnapshot, getSnapshot) {
+  const appliedGuestSnapshot = hostShouldApplyGuestSnapshot(parsed, deduper, nowMs)
+  if (appliedGuestSnapshot) {
+    applySnapshot(parsed.snapshot)
+  }
+  return { broadcastSnapshot: getSnapshot(), appliedGuestSnapshot }
+}

--- a/src/features/game-timer/p2p/guestIntentDedupe.test.js
+++ b/src/features/game-timer/p2p/guestIntentDedupe.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  GUEST_INTENT_DEBOUNCE_MS,
+  authoritativeSnapshotAfterGuestMessage,
+  createGuestIntentDeduper,
+  hostShouldApplyGuestSnapshot,
+  isDebouncedGuestIntentKind,
+  isWellFormedGuestIntent,
+} from './guestIntentDedupe.js'
+
+test('duplicate selectPlayer same player inside debounce window: second suppressed', () => {
+  const deduper = createGuestIntentDeduper()
+  const t0 = 1_000_000
+  const parsed = (intent) => ({ snapshot: {}, intent })
+  const i1 = { kind: 'selectPlayer', playerId: 'p1', sentAt: t0 }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0), true)
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0 + 10), false)
+})
+
+test('duplicate selectPlayer outside debounce window: both apply', () => {
+  const deduper = createGuestIntentDeduper()
+  const t0 = 2_000_000
+  const parsed = (intent) => ({ snapshot: {}, intent })
+  const i1 = { kind: 'selectPlayer', playerId: 'p1', sentAt: t0 }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0), true)
+  assert.equal(
+    hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0 + GUEST_INTENT_DEBOUNCE_MS + 1),
+    true,
+  )
+})
+
+test('duplicate registerHardPass same player inside window: second suppressed', () => {
+  const deduper = createGuestIntentDeduper()
+  const t0 = 3_000_000
+  const parsed = (intent) => ({ snapshot: {}, intent })
+  const i1 = { kind: 'registerHardPass', playerId: 'p1', sentAt: t0 }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0), true)
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0 + 5), false)
+})
+
+test('duplicate registerHardPass outside window: both apply', () => {
+  const deduper = createGuestIntentDeduper()
+  const t0 = 4_000_000
+  const parsed = (intent) => ({ snapshot: {}, intent })
+  const i1 = { kind: 'registerHardPass', playerId: 'p1', sentAt: t0 }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0), true)
+  assert.equal(
+    hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0 + GUEST_INTENT_DEBOUNCE_MS + 50),
+    true,
+  )
+})
+
+test('deduper uses shared window constant by default', () => {
+  const deduper = createGuestIntentDeduper()
+  const boundary = GUEST_INTENT_DEBOUNCE_MS - 1
+  const t0 = 0
+  const parsed = (intent) => ({ snapshot: {}, intent })
+  const i1 = { kind: 'selectPlayer', playerId: 'x', sentAt: t0 }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0), true)
+  assert.equal(hostShouldApplyGuestSnapshot(parsed(i1), deduper, t0 + boundary), false)
+})
+
+test('messages without debounced intent always apply', () => {
+  const deduper = createGuestIntentDeduper()
+  const parsed = { snapshot: {} }
+  assert.equal(hostShouldApplyGuestSnapshot(parsed, deduper, 0), true)
+  assert.equal(hostShouldApplyGuestSnapshot(parsed, deduper, 1), true)
+})
+
+test('well-formed intent helper', () => {
+  assert.equal(isWellFormedGuestIntent(null), false)
+  assert.equal(
+    isWellFormedGuestIntent({ kind: 'selectPlayer', playerId: 'a', sentAt: 1 }),
+    true,
+  )
+  assert.equal(
+    isWellFormedGuestIntent({ kind: 'registerHardPass', playerId: 'a', sentAt: 1 }),
+    true,
+  )
+  assert.equal(isWellFormedGuestIntent({ kind: 'selectPlayer', playerId: '', sentAt: 1 }), false)
+  assert.equal(isWellFormedGuestIntent({ kind: 'endTurnNext', playerId: 'a', sentAt: 1 }), false)
+})
+
+test('debounced kind guard', () => {
+  assert.equal(isDebouncedGuestIntentKind({ kind: 'selectPlayer', playerId: 'a', sentAt: 1 }), true)
+  assert.equal(
+    isDebouncedGuestIntentKind({ kind: 'registerHardPass', playerId: 'a', sentAt: 1 }),
+    true,
+  )
+})
+
+test('authoritative path: duplicate intent applies snapshot only once; still returns getSnapshot', () => {
+  const deduper = createGuestIntentDeduper()
+  let applied = 0
+  let state = { n: 0 }
+  const snap = (n) => ({ n })
+  const apply = (s) => {
+    applied++
+    state = s
+  }
+  const get = () => state
+  const intent = { kind: 'selectPlayer', playerId: 'p1', sentAt: 0 }
+  const out1 = authoritativeSnapshotAfterGuestMessage({ snapshot: snap(1), intent }, deduper, 0, apply, get)
+  const out2 = authoritativeSnapshotAfterGuestMessage({ snapshot: snap(2), intent }, deduper, 5, apply, get)
+  assert.equal(applied, 1)
+  assert.deepEqual(out1.broadcastSnapshot, { n: 1 })
+  assert.deepEqual(out2.broadcastSnapshot, { n: 1 })
+  assert.equal(out1.appliedGuestSnapshot, true)
+  assert.equal(out2.appliedGuestSnapshot, false)
+})

--- a/src/features/game-timer/p2p/protocol.js
+++ b/src/features/game-timer/p2p/protocol.js
@@ -3,6 +3,8 @@
  * Wire messages between game timer peers (JSON via PeerJS `serialization: 'json'`).
  */
 
+import { isWellFormedGuestIntent } from './guestIntentDedupe.js'
+
 /** Guest → hub: push snapshot after a local mutation. */
 export const MSG_GUEST_UPDATE = 'gt-u'
 
@@ -61,9 +63,13 @@ export function isValidSnapshot(snap) {
 
 /**
  * @param {GameTimerSyncPayload} snapshot
- * @returns {{ type: typeof MSG_GUEST_UPDATE, snapshot: GameTimerSyncPayload }}
+ * @param {{ kind: 'selectPlayer' | 'registerHardPass', playerId: string, sentAt: number } | undefined} [intent]
+ * @returns {{ type: typeof MSG_GUEST_UPDATE, snapshot: GameTimerSyncPayload, intent?: typeof intent }}
  */
-export function encodeGuestUpdate(snapshot) {
+export function encodeGuestUpdate(snapshot, intent) {
+  if (intent != null) {
+    return { type: MSG_GUEST_UPDATE, snapshot, intent }
+  }
   return { type: MSG_GUEST_UPDATE, snapshot }
 }
 
@@ -116,12 +122,26 @@ export function parseHostVisibility(data) {
 
 /**
  * @param {unknown} data
- * @returns {{ type: typeof MSG_GUEST_UPDATE, snapshot: GameTimerSyncPayload } | null}
+ * @returns {{ type: typeof MSG_GUEST_UPDATE, snapshot: GameTimerSyncPayload, intent?: { kind: 'selectPlayer' | 'registerHardPass', playerId: string, sentAt: number } } | null}
  */
 export function parseGuestMessage(data) {
   if (!isRecord(data) || data.type !== MSG_GUEST_UPDATE) return null
   if (!isValidSnapshot(data.snapshot)) return null
-  return { type: MSG_GUEST_UPDATE, snapshot: data.snapshot }
+  /** @type {{ type: typeof MSG_GUEST_UPDATE, snapshot: GameTimerSyncPayload, intent?: { kind: 'selectPlayer' | 'registerHardPass', playerId: string, sentAt: number } }} */
+  const out = { type: MSG_GUEST_UPDATE, snapshot: data.snapshot }
+  if (!('intent' in data)) return out
+  if (isWellFormedGuestIntent(data.intent)) {
+    out.intent = {
+      kind: data.intent.kind,
+      playerId: data.intent.playerId,
+      sentAt: data.intent.sentAt,
+    }
+    return out
+  }
+  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV) {
+    console.warn('[gameTimer P2P] malformed guest intent ignored')
+  }
+  return out
 }
 
 /**

--- a/src/features/game-timer/p2p/protocol.test.js
+++ b/src/features/game-timer/p2p/protocol.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { isValidSnapshot } from './protocol.js'
+import { encodeGuestUpdate, isValidSnapshot, parseGuestMessage } from './protocol.js'
 
 function baseSnapshot() {
   return {
@@ -21,4 +21,26 @@ test('snapshot accepts missing or numeric totalGameStartedAt', () => {
 
 test('snapshot rejects invalid totalGameStartedAt type', () => {
   assert.equal(isValidSnapshot({ ...baseSnapshot(), totalGameStartedAt: '1234' }), false)
+})
+
+test('guest update round-trips optional intent', () => {
+  const snap = baseSnapshot()
+  const intent = { kind: 'selectPlayer', playerId: 'p1', sentAt: 99 }
+  const wire = encodeGuestUpdate(snap, intent)
+  const parsed = parseGuestMessage(wire)
+  assert.ok(parsed)
+  assert.deepEqual(parsed.snapshot, snap)
+  assert.deepEqual(parsed.intent, intent)
+})
+
+test('parseGuestMessage drops malformed intent but keeps snapshot', () => {
+  const snap = baseSnapshot()
+  const parsed = parseGuestMessage({
+    type: 'gt-u',
+    snapshot: snap,
+    intent: { kind: 'selectPlayer', playerId: '', sentAt: 1 },
+  })
+  assert.ok(parsed)
+  assert.deepEqual(parsed.snapshot, snap)
+  assert.equal(parsed.intent, undefined)
 })

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -35,6 +35,8 @@ import {
   encodeHostVisibility,
   isHostEndedNotice,
   isHostPing,
+  isRecord,
+  MSG_GUEST_UPDATE,
   MSG_HOST_ENDED,
   parseGuestHello,
   parseGuestMessage,
@@ -47,8 +49,15 @@ import {
   isValidRoomSuffix,
   normalizeRoomSuffixInput,
 } from './roomId.js'
+import {
+  authoritativeSnapshotAfterGuestMessage,
+  createGuestIntentDeduper,
+} from './guestIntentDedupe.js'
 
 const STABLE_HOST_SUFFIX_APP = 'gametimer'
+
+/** @type {ReturnType<typeof createGuestIntentDeduper>} */
+let hostGuestIntentDeduper = createGuestIntentDeduper()
 
 /**
  * @typedef {object} GameTimerP2PHandlers
@@ -284,6 +293,7 @@ function destroyWireOnly() {
   isHost = false
   nextSeq = 0
   lastSeenSeq = 0
+  hostGuestIntentDeduper = createGuestIntentDeduper()
 }
 
 /**
@@ -350,6 +360,7 @@ function finishHostSession(p, suffix) {
   sessionSuffix.value = suffix
   nextSeq = 0
   lastSeenSeq = 0
+  hostGuestIntentDeduper = createGuestIntentDeduper()
   attachHubConnectionHandlers(peer)
   sessionPhase.value = 'hosting'
   wirePeerErrors(peer)
@@ -436,16 +447,44 @@ function handleHubInbound(conn, raw) {
     return
   }
   const msg = parseGuestMessage(raw)
-  if (!msg) return
+  if (!msg) {
+    if (
+      isRecord(raw) &&
+      raw.type === MSG_GUEST_UPDATE &&
+      typeof import.meta !== 'undefined' &&
+      import.meta.env &&
+      import.meta.env.DEV
+    ) {
+      console.warn('[gameTimer P2P] invalid guest update ignored')
+    }
+    return
+  }
+  const now = Date.now()
+  let snap
   try {
-    handlers.applySnapshot(msg.snapshot)
+    const result = authoritativeSnapshotAfterGuestMessage(
+      msg,
+      hostGuestIntentDeduper,
+      now,
+      (s) => handlers.applySnapshot(s),
+      () => handlers.getSnapshot(),
+    )
+    snap = result.broadcastSnapshot
+    if (
+      !result.appliedGuestSnapshot &&
+      msg.intent &&
+      typeof import.meta !== 'undefined' &&
+      import.meta.env &&
+      import.meta.env.DEV
+    ) {
+      console.debug('[gameTimer P2P] suppressed duplicate guest intent', msg.intent.kind)
+    }
   } catch {
     return
   }
-  const snap = handlers.getSnapshot()
   const out = encodeHostSnapshot(snap, ++nextSeq)
   for (const c of hubConnections) {
-    if (c === conn || !c.open) continue
+    if (!c.open) continue
     try {
       c.send(out)
     } catch {
@@ -741,9 +780,10 @@ export async function joinRoom(rawSuffix) {
 /**
  * Push current snapshot to peers (after a local store mutation).
  * @param {GameTimerSyncPayload} snapshot
+ * @param {{ kind: 'selectPlayer' | 'registerHardPass', playerId: string, sentAt: number } | undefined} [intent] guest → host only
  * @returns {void}
  */
-export function broadcastGameTimerSnapshot(snapshot) {
+export function broadcastGameTimerSnapshot(snapshot, intent) {
   if (!peer || peer.destroyed) return
 
   if (isHost) {
@@ -761,7 +801,7 @@ export function broadcastGameTimerSnapshot(snapshot) {
 
   if (guestHubConn?.open) {
     try {
-      guestHubConn.send(encodeGuestUpdate(snapshot))
+      guestHubConn.send(encodeGuestUpdate(snapshot, intent))
     } catch {
       void 0
     }


### PR DESCRIPTION
Implements host-side deduplication for rapid duplicate guest intents (`selectPlayer`, `registerHardPass`) using a shared debounce window and optional wire intent metadata.

Fixes #48.