### PR TITLE
Add start new game with same players (closes #50)

### DIFF
--- a/src/features/game-timer/components/GameTimerRoundBar.vue
+++ b/src/features/game-timer/components/GameTimerRoundBar.vue
@@ -37,7 +37,18 @@
           />
         </div>
       </div>
-      <div class="gt-round-bar__right row no-wrap items-center">
+      <div class="gt-round-bar__right row no-wrap items-center q-gutter-x-xs">
+        <q-btn
+          v-if="showStartNewGame"
+          flat
+          round
+          size="md"
+          icon="restart_alt"
+          color="grey-5"
+          class="gt-round-bar__new-game gt-round-bar__hit"
+          aria-label="Start new game with same players"
+          @click="newGameDialogOpen = true"
+        />
         <q-btn
           flat
           round
@@ -80,11 +91,25 @@
       <span class="gt-round-bar__session-label">{{ timingStripLabel }}</span>
       <span class="gt-round-bar__session-value text-mono">{{ timingStripValue }}</span>
     </button>
+
+    <q-dialog v-model="newGameDialogOpen" persistent>
+      <q-card class="gt-dialog-card gt-dialog-card--narrow">
+        <q-card-section class="text-h6">Start new game?</q-card-section>
+        <q-card-section class="q-pt-none text-body2">
+          All times and round progress reset to a clean start. Players, turn order as shown, and session options (round
+          rules, timing strip, fullscreen) stay as they are.
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" color="grey" @click="newGameDialogOpen = false" />
+          <q-btn unelevated label="Start new game" color="primary" @click="confirmStartNewGame" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import GameTimerSyncControl from './GameTimerSyncControl.vue'
 import { displayedMsForPlayer, formatDurationMs } from '../core.js'
@@ -99,6 +124,8 @@ const now = useGameTimerNow(1000)
 const { round, players, hardPassEnabled, hardPassOrderNextRound, fullscreenEnabled, timingStripMode } =
   storeToRefs(store)
 const hasPlayers = computed(() => players.value.length > 0)
+const showStartNewGame = computed(() => !isGuest.value && hasPlayers.value)
+const newGameDialogOpen = ref(false)
 const canGoPreviousRound = computed(() => hasPlayers.value && round.value > 1)
 const settingsModel = computed(() => getGameTimerSettingsModel({ isGuest: isGuest.value }))
 const totalGameElapsedMs = computed(() => {
@@ -138,6 +165,11 @@ const fullscreenModel = computed({
   get: () => fullscreenEnabled.value,
   set: (v) => store.setFullscreenEnabled(Boolean(v)),
 })
+
+function confirmStartNewGame() {
+  store.startNewGameSamePlayers()
+  newGameDialogOpen.value = false
+}
 </script>
 
 <style scoped lang="scss">
@@ -194,6 +226,7 @@ const fullscreenModel = computed({
 }
 
 .gt-round-bar__chev,
+.gt-round-bar__new-game,
 .gt-round-bar__settings,
 .gt-round-bar__sync {
   flex-shrink: 0;

--- a/src/features/game-timer/p2p/gameTimerPiniaBridge.js
+++ b/src/features/game-timer/p2p/gameTimerPiniaBridge.js
@@ -25,6 +25,7 @@ const SYNC_ACTION_NAMES = new Set([
   'setPlayerName',
   'setPlayerColor',
   'clearAllPlayers',
+  'startNewGameSamePlayers',
   'setHardPassEnabled',
   'setHardPassOrderNextRound',
   'registerHardPass',

--- a/src/features/game-timer/startNewGameSamePlayers.test.js
+++ b/src/features/game-timer/startNewGameSamePlayers.test.js
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useGameTimerStore } from '../../stores/gameTimer.js'
+
+function withFakeNow(startMs, run) {
+  const originalNow = Date.now
+  let now = startMs
+  Date.now = () => now
+  const advance = (ms) => {
+    now += ms
+  }
+  try {
+    run(advance)
+  } finally {
+    Date.now = originalNow
+  }
+}
+
+test('startNewGameSamePlayers keeps roster and clears clocks and rounds', () => {
+  withFakeNow(1000, (advance) => {
+    setActivePinia(createPinia())
+    const store = useGameTimerStore()
+    const a = store.addPlayer({ name: 'Ada', color: '#ff0000' })
+    const b = store.addPlayer({ name: 'Bob', color: '#00ff00' })
+    store.setHardPassEnabled(true)
+    store.setHardPassOrderNextRound(true)
+    store.setFullscreenEnabled(true)
+    store.setTimingStripMode('non-player')
+    store.selectPlayer(a)
+    advance(2000)
+    store.selectPlayer(a)
+    store.goToNextRound()
+    store.selectPlayer(b)
+    advance(1000)
+    store.registerHardPass(b)
+
+    const rosterSnapshot = store.players.map((p) => ({ id: p.id, name: p.name, color: p.color }))
+    const orderAtReset = store.players.map((p) => p.id)
+    assert.equal(store.round, 2)
+    assert.ok(store.players[0].bankedMs > 0 || store.players[1].bankedMs > 0)
+    assert.ok(Object.keys(store.hardPassOrderByRound).length > 0)
+
+    store.startNewGameSamePlayers()
+
+    assert.deepEqual(
+      store.players.map((p) => ({ id: p.id, name: p.name, color: p.color })),
+      rosterSnapshot,
+    )
+    assert.equal(store.round, 1)
+    assert.equal(store.activePlayerId, null)
+    assert.equal(store.turnStartedAt, null)
+    assert.equal(store.turnStartedRound, null)
+    assert.equal(store.totalGameStartedAt, null)
+    assert.equal(store.totalGameElapsedMs, 0)
+    for (const p of store.players) {
+      assert.equal(p.bankedMs, 0)
+      assert.deepEqual(p.bankedMsByRound, {})
+    }
+    assert.deepEqual(store.hardPassOrderByRound, {})
+    assert.equal(store.hardPassEnabled, true)
+    assert.equal(store.hardPassOrderNextRound, true)
+    assert.equal(store.fullscreenEnabled, true)
+    assert.equal(store.timingStripMode, 'non-player')
+    assert.deepEqual(store.playerOrderByRound['1'], orderAtReset)
+  })
+})
+
+test('startNewGameSamePlayers uses current list order as round 1 order', () => {
+  setActivePinia(createPinia())
+  const store = useGameTimerStore()
+  const a = store.addPlayer({ name: 'A' })
+  const b = store.addPlayer({ name: 'B' })
+  store.reorderPlayers([store.players[1], store.players[0]])
+  store.goToNextRound()
+  assert.equal(store.round, 2)
+
+  store.startNewGameSamePlayers()
+
+  assert.equal(store.round, 1)
+  assert.deepEqual(
+    store.players.map((p) => p.id),
+    [b, a],
+  )
+  assert.deepEqual(store.playerOrderByRound['1'], [b, a])
+  assert.equal(Object.keys(store.playerOrderByRound).length, 1)
+})
+
+test('startNewGameSamePlayers is a no-op with no players', () => {
+  setActivePinia(createPinia())
+  const store = useGameTimerStore()
+  store.startNewGameSamePlayers()
+  assert.equal(store.players.length, 0)
+  assert.equal(store.round, 1)
+})
+
+test('clearAllPlayers still resets session prefs unlike startNewGameSamePlayers', () => {
+  setActivePinia(createPinia())
+  const store = useGameTimerStore()
+  store.addPlayer({ name: 'A' })
+  store.setHardPassEnabled(true)
+  store.setTimingStripMode('non-player')
+  store.clearAllPlayers()
+  assert.equal(store.hardPassEnabled, false)
+  assert.equal(store.timingStripMode, 'total')
+})

--- a/src/stores/gameTimer.js
+++ b/src/stores/gameTimer.js
@@ -493,6 +493,29 @@ export const useGameTimerStore = defineStore('gameTimer', {
       p.color = color
     },
 
+    /**
+     * Bank live turn, clear clocks and round progression, keep roster and session rule toggles.
+     * Idempotent for empty roster (no-op).
+     */
+    startNewGameSamePlayers() {
+      if (this.players.length === 0) return
+      const now = Date.now()
+      this._pauseLiveTurn(now)
+      for (const p of this.players) {
+        p.bankedMs = 0
+        p.bankedMsByRound = {}
+      }
+      this.round = 1
+      const order = this.players.map((p) => p.id)
+      this.playerOrderByRound = { '1': [...order] }
+      this.hardPassOrderByRound = {}
+      this.totalGameStartedAt = null
+      if (this.hardPassEnabled && this.hardPassOrderNextRound) {
+        this._recomputeNextRoundOrderFromHardPasses(1)
+      }
+      this._applyOrderForActiveRound()
+    },
+
     /** Bank any live turn, then clear all players and order; round becomes 1. */
     clearAllPlayers() {
       this._pauseLiveTurn()


### PR DESCRIPTION
## Summary

Implements host-only **start new game** for the game timer: reset clocks, rounds, and hard-pass bookkeeping while keeping the roster and session options (hard pass toggles, timing strip mode, fullscreen).

## Changes

- **Store:** New `startNewGameSamePlayers` action banks any live turn, clears banked time and per-round maps, resets round to 1 and session timing baseline, clears `hardPassOrderByRound`, rebuilds round-1 order from the current player list, and preserves players plus session prefs (distinct from `clearAllPlayers`).
- **P2P:** Action is on the sync allowlist so guests receive host snapshots.
- **UI:** Icon-only control (restart) left of settings in the round bar for hosts with ≥1 player; persistent confirmation dialog with clear copy and a primary **Start new game** action (accessible name on the icon button).
- **Tests:** `startNewGameSamePlayers.test.js` covers roster/prefs preservation, round-1 order, empty-roster no-op, and `clearAllPlayers` regression.

Closes #50.