### PR TITLE
Game Timer: keep local roster when leaving or ending a room (#73)

### DIFF
--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -9,7 +9,6 @@
 
 import { ref } from 'vue'
 import { Notify } from 'quasar'
-import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
 import { awaitPeerOpen } from '../../p2p/awaitPeerOpen.js'
 import {
@@ -494,16 +493,16 @@ function handleHubInbound(conn, raw) {
 }
 
 /**
- * Dispatches inbound hub messages: room ended, ping, visibility, or sequenced snapshot.
+ * Dispatches inbound hub messages on the guest: room ended, ping, visibility, or sequenced snapshot.
  * @param {unknown} raw
  * @returns {void}
  */
-function handleGuestInbound(raw) {
+export function handleGuestInbound(raw) {
   if (isHostEndedNotice(raw)) {
     notifyP2P('The host ended the room.', 'info')
     reconnectGeneration += 1
     clearRoomPersistence()
-    resetLocalStateAfterRoomExit()
+    teardownSession()
     return
   }
   if (isHostPing(raw)) {
@@ -821,20 +820,8 @@ export function teardownSession() {
 }
 
 /**
- * After {@link teardownSession}: clears the game timer roster (no P2P broadcast; session already idle).
- * @returns {void}
- */
-function resetLocalStateAfterRoomExit() {
-  teardownSession()
-  try {
-    useGameTimerStore().clearAllPlayers()
-  } catch {
-    void 0
-  }
-}
-
-/**
- * User-initiated exit: notifies guests if hosting, then clears persistence, wire, and local timer state.
+ * User-initiated exit: notifies guests if hosting, clears persisted room role, then tears down P2P.
+ * Does not clear the game timer roster; explicit UI reset or a successful join snapshot still do.
  * @returns {void}
  */
 export function leaveSession() {
@@ -851,7 +838,7 @@ export function leaveSession() {
       }
     }
   }
-  resetLocalStateAfterRoomExit()
+  teardownSession()
 }
 
 /**

--- a/src/features/game-timer/p2p/sessionRoomLifecycle.test.js
+++ b/src/features/game-timer/p2p/sessionRoomLifecycle.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useGameTimerStore } from '../../../stores/gameTimer.js'
+import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { MSG_HOST_ENDED } from './protocol.js'
+import {
+  handleGuestInbound,
+  leaveSession,
+  teardownSession,
+} from './session.js'
+
+test('leaveSession clears room persistence but keeps game timer roster', () => {
+  setActivePinia(createPinia())
+  const store = useGameTimerStore()
+  const room = useGameTimerRoomSessionStore()
+  store.addPlayer({ name: 'Ada', color: '#111111' })
+  store.addPlayer({ name: 'Bob', color: '#222222' })
+  const ids = store.players.map((p) => p.id)
+  room.setHost('abc123')
+
+  leaveSession()
+
+  assert.equal(room.role, null)
+  assert.equal(room.suffix, null)
+  assert.equal(store.players.length, 2)
+  assert.deepEqual(
+    store.players.map((p) => p.id),
+    ids,
+  )
+})
+
+test('guest host-ended handling clears room persistence but keeps roster', () => {
+  setActivePinia(createPinia())
+  const store = useGameTimerStore()
+  const room = useGameTimerRoomSessionStore()
+  store.addPlayer({ name: 'Guest', color: '#333333' })
+  room.setGuest('xyz789')
+
+  handleGuestInbound({ type: MSG_HOST_ENDED })
+
+  assert.equal(room.role, null)
+  assert.equal(room.suffix, null)
+  assert.equal(store.players.length, 1)
+  assert.equal(store.players[0].name, 'Guest')
+})
+
+afterEach(() => {
+  teardownSession()
+})


### PR DESCRIPTION
## Summary

- Stopped tying multiplayer teardown to the timer store’s full reset: leaving a room or receiving “host ended” now clears persisted room role and tears down PeerJS only, without calling `clearAllPlayers()`.
- Documented `leaveSession()` so the split between wire/session lifecycle and intentional roster clears stays obvious at the call site.
- Exported `handleGuestInbound` (guest hub message entry) and added Node tests that assert room persistence clears while player count and ids stay intact—so a regression that re-attaches roster clearing to room exit fails in CI.

## Testing

- `npm test`
- `npm run lint`

Closes #73