### PR TITLE
Movie Vote: Firebase RTDB collaboration (replace PeerJS transport)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,14 @@
 # GitHub Actions: add secrets `TMDB_READ_ACCESS_TOKEN` and/or `TMDB_API_KEY`.
 VITE_TMDB_READ_ACCESS_TOKEN=
 VITE_TMDB_API_KEY=
+
+# Firebase Realtime Database — Movie Vote multiplayer sync (RTDB; open rules in dev).
+# Console: Project settings → Your apps → Web app config + Realtime Database URL.
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_DATABASE_URL=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_APP_ID=
+# Optional (standard Firebase web template)
+# VITE_FIREBASE_STORAGE_BUCKET=
+# VITE_FIREBASE_MESSAGING_SENDER_ID=

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "enmaku-portfolio-site"
+  }
+}

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -13,6 +13,7 @@
 - **Portfolio site → Projects**: Routes and navigation expose **Game Timer** and **Movie Vote** as first-class **projects** alongside static portfolio content.
 - **Game Timer ↔ Star-room P2P**: Game Timer’s multiplayer session uses the star-room host/guest collaboration model for state sync.
 - **Movie Vote ↔ Star-room P2P**: Movie Vote uses the same collaboration model so a **host** aggregates **participant** drafts and votes.
+- **Movie Vote ↔ Game Timer**: Both use star-room roles today; **Game Timer**’s synchronized countdown state is not assumed to share the same persistence or transport shape as **Movie Vote** without its own design pass.
 - **Portfolio site ↔ sharing**: Publishable URLs and shared-link summaries for selected routes belong to the portfolio context; implementations read shared metadata keyed by route.
 - **Portfolio site ↔ Star-room P2P**: **Join links** live on canonical `/projects/…` paths with `room` query params; **public site origin** anchors absolute URLs when builds need a stable host.
 

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    ".read": true,
+    ".write": true
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,20 @@
+{
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "firestore": [
+    {
+      "database": "movie-vote",
+      "rules": "firestore.rules",
+      "indexes": "firestore.indexes.json"
+    }
+  ],
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@quasar/extras": "^1.16.4",
         "exifr": "^7.1.3",
+        "firebase": "^12.13.0",
         "nosleep.js": "0.12.0",
         "peerjs": "^1.5.5",
         "pinia": "^3.0.1",
@@ -806,6 +807,747 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+      "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+      "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+      "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+      "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+      "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.12",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+      "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+      "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+      "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+      "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+      "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+      "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+      "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+      "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+      "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+      "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+      "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@grpc/proto-loader/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2138,6 +2880,70 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@quasar/app-vite": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@quasar/app-vite/-/app-vite-2.5.1.tgz",
@@ -2688,7 +3494,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3036,7 +3841,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3738,7 +4542,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3751,7 +4554,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorjs.io": {
@@ -4273,7 +5075,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4752,6 +5553,18 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4844,6 +5657,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+      "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.12.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.12",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-compat": "0.4.3",
+        "@firebase/app-compat": "0.5.12",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-compat": "0.6.6",
+        "@firebase/data-connect": "0.7.0",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-compat": "0.4.9",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-compat": "0.4.4",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/messaging-compat": "0.2.26",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-compat": "0.2.24",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/flat": {
@@ -4972,7 +5821,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5209,6 +6057,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -5225,6 +6079,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5365,7 +6225,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6007,12 +6866,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -6779,6 +7650,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6947,6 +7842,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -7126,7 +8030,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8265,7 +9168,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -8322,7 +9224,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -8793,6 +9694,12 @@
         "vue": "^3.0.1"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -8825,6 +9732,29 @@
       "engines": {
         "node": ">=6.0.0",
         "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -8993,7 +9923,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@quasar/extras": "^1.16.4",
     "exifr": "^7.1.3",
+    "firebase": "^12.13.0",
     "nosleep.js": "0.12.0",
     "peerjs": "^1.5.5",
     "pinia": "^3.0.1",

--- a/src/features/movie-vote/CONTEXT.md
+++ b/src/features/movie-vote/CONTEXT.md
@@ -8,6 +8,8 @@ Collaborative picker: propose films, converge on a finalized **ballot**, collect
 
 Stage of the cooperative flow (`suggest` → `voting` → `results`).
 
+_Avoid_: Using “phase” for star-room connectivity posture—that is **connection status**.
+
 ### Suggest phase
 
 Everyone contributes **movie picks** and marks readiness without locking the group tally yet.
@@ -18,7 +20,7 @@ Participants submit **rankings** over the compiled **ballot**.
 
 ### Results phase
 
-Shows **instant-runoff** outcome (winner or declared tie metadata).
+Shows the **room**’s authoritative **instant-runoff** outcome—the **host** commits winner or **declared tie** metadata and the **IRV rounds log** into **room**-level authority when entering this **phase** (not a per-client recompute as the source of truth).
 
 ### Movie pick
 
@@ -62,7 +64,7 @@ _Avoid_: Treating the host as “not a **participant**” in copy about counts.
 
 ### Participant id
 
-Host-issued session identifier for a **participant**, carried in summaries and tallies—distinct from **stable client identity**, though reconnect may **resume** the same slot when the stable id matches.
+**Host**-managed seat label for a **participant** in summaries and tallies—includes the reserved **host participant seat**. Distinct from the shell’s canonical browser-level principal (**stable client identity**); reconnect maps that principal back to the same **participant id** when the **host** preserves the binding.
 
 ### Draft payload
 
@@ -82,7 +84,7 @@ Distinct nominated titles across the room during **suggest phase**—preview met
 
 ### Host / Guest
 
-Host aggregates participant payloads; guests send draft nominations and rankings. Mirrors [**Star-room P2P**](../p2p/CONTEXT.md).
+Host aggregates participant payloads into **room**-level authority (**phase**, **ballot order**, **ballot compilation**); guests supply **draft payloads**, **ready flags**, and **rankings**. Each **participant** may persist their own contribution while the **host** retains that **room** authority. The **host** role never transfers; with persisted collaboration, **guest** **participants** stay usable when the **host**’s browser is offline or backgrounded—**host**-only moves simply wait until that **host** returns. Mirrors [**Star-room P2P**](../p2p/CONTEXT.md) roles.
 
 ### Ranking
 
@@ -98,11 +100,13 @@ Deterministic tie rule when deciding which advancing candidate loses this IRV el
 
 ### IRV rounds log
 
-Recorded per-round tally snapshot for auditing or UX explanation.
+Per-round tally snapshots the **host** persists with the official **instant-runoff** outcome when entering **results phase**—for auditing or UX explanation.
 
-### Session phase
+### Connection status
 
-Realtime connection posture analogous to Game Timer (`idle`, `connecting`, `reconnecting`, `hosting`, `guest_connected`).
+Local star-room shell posture for transport and listeners (`idle`, `connecting`, `reconnecting`, `hosting`, `guest_connected`)—independent of collaborative **phase** (**suggest** → **voting** → **results**). [**Game Timer**](../game-timer/CONTEXT.md) documents the same shell values under **session phase**.
+
+_Avoid_: Saying “phase” when you mean connectivity or reconnect banners.
 
 ### Vote progress
 
@@ -114,12 +118,16 @@ Outcome where multiple titles remain inseparable after IRV concludes with tie me
 
 ## Relationships
 
+- **Phase** (collaborative flow) and **connection status** (shell connectivity) stay independent—do not merge them in UI or persisted **room** fields.
 - A **participant** submits many **movie picks** during **suggest phase**, shipped incrementally inside **draft payloads** guarded by **ready flags**.
-- The **host** is a **participant** via the **host participant seat**; **guests** receive ids from the host while retaining **stable client identity** at the browser layer for reconnect mapping.
+- The **host** is a **participant** via the **host participant seat**; **guests** receive **participant id** seat labels from the **host** while **stable client identity** is the canonical browser principal for reconnect and per-**participant** persistence.
+- **Room**-level authority (**phase**, **ballot order**, **ballot compilation**) is **host**-owned; **participant**-scoped state (**draft payload**, **ready flag**, **ranking**) is **participant**-owned at persistence while the **host** still aggregates for compilation and tally.
+- The **host** is never reassigned for a **room**; **guest** **participants** do not lose the **room** because the **host** tab sleeps or disconnects—only **host**-only progression waits on the **host**.
+- What collaborators must agree on in a **room** has a single authoritative shared copy; each browser mirrors that copy locally for UI rather than treating local state as a competing source of truth.
 - **Unique suggested movie count** summarizes nomination breadth before compilation locks **ballot order**.
 - Compilation reduces picks to mutually distinct **ballot movies** keyed by TMDB id or **normalized custom title**.
 - **Voting phase** consumes exactly the compiled ballot; each **participant** submits one **ranking**.
-- IRV emits either a single champion id or **declared tie** ids plus **IRV rounds log** detail.
+- The **host** persists the official **instant-runoff** outcome (**IRV rounds log**, winner or **declared tie**) into **room**-level authority when entering **results phase**; that record is the collective result the **room** shows.
 
 ## Example dialogue
 
@@ -135,5 +143,8 @@ Outcome where multiple titles remain inseparable after IRV concludes with tie me
 ## Flagged ambiguities
 
 - “Nomination” vs “pick”: Resolved — treat **movie pick** as the neutral term; reserve “nomination” for conversational tone only.
-- **Participant id** vs **stable client identity**: Resolved — stable identity is browser-persistent remapping glue; **participant id** is the host-visible seat label inside one **room**.
+- **Participant id** vs **stable client identity**: Resolved — **stable client identity** is the single canonical browser-level principal; **participant id** is the **host**-visible seat label inside one **room**; the shell aligns persistence and remapping with the principal while UX and tallies follow **participant id**.
 - **Host** vs **participant** in tallies: Resolved — the **host** counts as a **participant** through the **host participant seat**.
+- **Host** migration: Resolved — out of scope; a **room**’s **host** is fixed for that **room**’s lifetime.
+- **IRV** source of truth: Resolved — the **host** writes the official outcome package to **room**-level authority at **results** entry; clients mirror it, not independent recompute as truth.
+- “Phase” overload: Resolved — **phase** means **suggest** / **voting** / **results**; **connection status** means `idle` / `connecting` / … for the star-room shell (Game Timer still labels that **session phase**).

--- a/src/features/movie-vote/firebase/rtdb.js
+++ b/src/features/movie-vote/firebase/rtdb.js
@@ -1,0 +1,122 @@
+import { getApps, initializeApp } from 'firebase/app'
+import { getDatabase, ref, set } from 'firebase/database'
+
+const ROOMS_ROOT = 'movieVoteRooms'
+
+/** @param {Record<string, unknown>} env */
+function envString(env, key) {
+  const fromMeta = String(env[key] ?? '').trim()
+  if (fromMeta) return fromMeta
+  const fromProcess =
+    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
+  return String(fromProcess ?? '').trim()
+}
+
+/** @returns {import('firebase/app').FirebaseOptions | null} */
+function readFirebaseConfig() {
+  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
+  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
+  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
+  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
+  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
+
+  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
+    return null
+  }
+
+  /** @type {import('firebase/app').FirebaseOptions} */
+  const config = {
+    apiKey,
+    authDomain,
+    databaseURL,
+    projectId,
+    appId,
+  }
+
+  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
+  if (storageBucket) config.storageBucket = storageBucket
+
+  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
+  if (messagingSenderId) config.messagingSenderId = messagingSenderId
+
+  return config
+}
+
+/** @type {import('firebase/database').Database | null} */
+let databaseInstance = null
+
+// getMovieVoteDatabase() throws when required VITE_FIREBASE_* vars are unset.
+/**
+ * @returns {import('firebase/database').Database}
+ */
+export function getMovieVoteDatabase() {
+  if (databaseInstance) return databaseInstance
+
+  const config = readFirebaseConfig()
+  if (!config) {
+    const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+    const required = [
+      'VITE_FIREBASE_API_KEY',
+      'VITE_FIREBASE_AUTH_DOMAIN',
+      'VITE_FIREBASE_DATABASE_URL',
+      'VITE_FIREBASE_PROJECT_ID',
+      'VITE_FIREBASE_APP_ID',
+    ]
+    const missing = required.filter((key) => !envString(env, key))
+    const missingHint =
+      missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
+    throw new Error(
+      `Movie Vote Firebase RTDB is not configured. Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
+    )
+  }
+
+  const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
+  databaseInstance = getDatabase(app)
+  return databaseInstance
+}
+
+/**
+ * RTDB path for a room suffix (no leading slash).
+ * @param {string} suffix
+ * @returns {string}
+ */
+export function movieVoteRoomPath(suffix) {
+  return `${ROOMS_ROOT}/${suffix}`
+}
+
+/**
+ * @param {string} suffix
+ * @returns {import('firebase/database').DatabaseReference}
+ */
+export function movieVoteRoomRef(suffix) {
+  return ref(getMovieVoteDatabase(), movieVoteRoomPath(suffix))
+}
+
+/**
+ * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
+ * optional fields as undefined (e.g. ballotMovies[].customKey for TMDB picks).
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+export function sanitizeForRtdb(value) {
+  if (value === undefined) return null
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
+  /** @type {Record<string, unknown>} */
+  const out = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (child === undefined) continue
+    out[key] = sanitizeForRtdb(child)
+  }
+  return out
+}
+
+/**
+ * @param {import('firebase/database').DatabaseReference} dbRef
+ * @param {unknown} value
+ * @returns {Promise<void>}
+ */
+export function setRtdb(dbRef, value) {
+  return set(dbRef, sanitizeForRtdb(value))
+}

--- a/src/features/movie-vote/firebase/rtdb.test.js
+++ b/src/features/movie-vote/firebase/rtdb.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+const REQUIRED_FIREBASE_ENV = {
+  VITE_FIREBASE_API_KEY: 'test-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
+  VITE_FIREBASE_PROJECT_ID: 'test-project',
+  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
+}
+
+/** @param {Record<string, string | undefined>} overrides */
+async function withFirebaseEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+    saved[key] = process.env[key]
+    delete process.env[key]
+  }
+  for (const [key, value] of Object.entries({ ...REQUIRED_FIREBASE_ENV, ...overrides })) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  try {
+    return await fn()
+  } finally {
+    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
+test('getMovieVoteDatabase throws when Firebase env is missing', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { getMovieVoteDatabase } = await import(`./rtdb.js?missing=${Date.now()}`)
+      assert.throws(
+        () => getMovieVoteDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, /VITE_FIREBASE_\*/)
+          assert.match(err.message, /\.env\.example/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('movieVoteRoomPath maps suffix under movieVoteRooms', async () => {
+  const { movieVoteRoomPath } = await import('./rtdb.js')
+  assert.equal(movieVoteRoomPath('abc123'), 'movieVoteRooms/abc123')
+})
+
+test('getMovieVoteDatabase returns the same instance (lazy singleton)', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { getMovieVoteDatabase } = await import(`./rtdb.js?singleton=${Date.now()}`)
+    const first = getMovieVoteDatabase()
+    const second = getMovieVoteDatabase()
+    assert.equal(first, second)
+  })
+})
+
+test('movieVoteRoomRef points at movieVoteRooms/{suffix}', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { movieVoteRoomRef } = await import(`./rtdb.js?ref=${Date.now()}`)
+    const roomRef = movieVoteRoomRef('abc123')
+    assert.equal(roomRef.key, 'abc123')
+    assert.equal(roomRef.parent?.key, 'movieVoteRooms')
+  })
+})
+
+test('sanitizeForRtdb drops undefined keys (RTDB rejects undefined)', async () => {
+  const { sanitizeForRtdb } = await import('./rtdb.js')
+  const out = sanitizeForRtdb({
+    ballotMovies: [{ publicId: 'a', customKey: undefined, title: 'X' }],
+    voteProgress: null,
+    phase: 'voting',
+  })
+  assert.deepEqual(out, {
+    ballotMovies: [{ publicId: 'a', title: 'X' }],
+    voteProgress: null,
+    phase: 'voting',
+  })
+})

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -1,14 +1,23 @@
 /**
  * @import '../types.js'
- * PeerJS star hub for Movie Vote (`dperry-movievote-<suffix>`).
+ * Firebase RTDB star hub for Movie Vote (`movieVoteRooms/<suffix>`).
  * Typed messages; host aggregates guest drafts and runs IRV.
  */
 
-import { ref } from 'vue'
+import { ref as vueRef } from 'vue'
 import { Notify } from 'quasar'
+import {
+  child,
+  get,
+  onChildAdded,
+  onDisconnect,
+  onValue,
+  ref as dbRef,
+  remove,
+} from 'firebase/database'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
-import { awaitPeerOpen } from '../../p2p/awaitPeerOpen.js'
+import { getMovieVoteDatabase, movieVoteRoomRef, setRtdb } from '../firebase/rtdb.js'
 import {
   HOST_PARTICIPANT_ID,
   compileBallotMovies,
@@ -19,29 +28,15 @@ import { runIrv } from '../irv.js'
 import {
   runGuestStarReconnectLoop,
   runHostStarReconnectLoop,
-  wireStarRoomPeerErrors,
 } from '../../p2p/starRoomShell.js'
-import { isUnavailableIdError } from '../../p2p/errors.js'
 import { deriveStableHostSuffix, getStableClientId } from '../../p2p/identity.js'
-import {
-  HEARTBEAT_GUEST_CHECK_MS,
-  HEARTBEAT_INTERVAL_MS,
-  HEARTBEAT_STALE_MS,
-  OPEN_PEER_TIMEOUT_MS,
-  PEER_OPTS,
-  RECONNECT_PEER_TIMEOUT_MS,
-} from '../../p2p/starRoomTiming.js'
 import {
   encodeDraft,
   encodeHello,
-  encodeHostPing,
   encodeHostVisibility,
   encodeState,
   encodeVote,
   encodeWelcome,
-  isHostEndedNotice,
-  isHostPing,
-  MSG_MV_HOST_ENDED,
   parseDraft,
   parseHello,
   parseHostVisibility,
@@ -49,8 +44,9 @@ import {
   parseVote,
   parseWelcome,
 } from './protocol.js'
+import { canClaimHostRoom, isHostPingPresent } from './sessionHostPing.js'
+import { isRoomMarkedEnded, ROOM_CLAIM_RESET_PATHS } from './sessionRoomRtdb.js'
 import {
-  fullPeerIdFromSuffix,
   generateAnonymousVoterId,
   generateRoomSuffix,
   isValidRoomSuffix,
@@ -58,15 +54,6 @@ import {
 } from './roomId.js'
 
 const STABLE_HOST_SUFFIX_APP = 'movievote'
-
-/** @type {import('peerjs').Peer | null} */
-let peer = null
-
-/** @type {Set<import('peerjs').DataConnection>} */
-const hubConnections = new Set()
-
-/** @type {import('peerjs').DataConnection | null} */
-let guestHubConn = null
 
 let isHost = false
 
@@ -76,26 +63,20 @@ let lastSeenSeq = 0
 
 let reconnectGeneration = 0
 
-/** @type {Map<import('peerjs').DataConnection, string>} */
-const connToParticipant = new Map()
+/** @type {string | null} */
+let guestStableId = null
 
 /**
  * Stable client id → participant id.
- *
- * Populated when a guest sends a `hello` message after their `DataConnection`
- * opens, and kept across that guest's reconnects so their existing slot (and
- * any vote they've already cast) is preserved. Entries are cleared only when
- * the host session tears down.
  * @type {Map<string, string>}
  */
 const stableIdToParticipant = new Map()
 
 /**
- * Participant id → open DataConnection currently serving that participant.
- * Used to close an orphan connection when the same stable id reconnects.
- * @type {Map<string, import('peerjs').DataConnection>}
+ * Stable ids currently marked online under `guestOnline/`.
+ * @type {Set<string>}
  */
-const participantToConn = new Map()
+const activeGuestStableIds = new Set()
 
 /**
  * Guest drafts keyed by participant id (host tab uses store only).
@@ -104,47 +85,46 @@ const participantToConn = new Map()
 const guestDrafts = new Map()
 
 /**
- * Pending participant-removal timers keyed by participant id. Scheduled when a
- * guest's connection closes; cleared when they reconnect within the grace
- * window. See {@link GUEST_REMOVAL_GRACE_MS}.
  * @type {Map<string, ReturnType<typeof setTimeout>>}
  */
 const pendingRemovalTimers = new Map()
 
+/** @type {Array<() => void>} */
+let wireUnsubs = []
+
 /** Reactive session UI state for multiplayer (Vue ref; safe to use outside components). */
-export const sessionPhase = ref(/** @type {import('./types.js').MovieVoteSessionPhase} */ ('idle'))
+export const sessionPhase = vueRef(/** @type {import('./types.js').MovieVoteSessionPhase} */ ('idle'))
 
 /** Short user-facing room code while hosting or connected as guest; null when idle. */
-export const sessionSuffix = ref(/** @type {string | null} */ (null))
+export const sessionSuffix = vueRef(/** @type {string | null} */ (null))
 
 /**
  * Guest only: last host-reported tab visibility (`document.visibilityState === 'visible'` on host).
  * Stays `true` when idle / hosting / unknown.
  */
-export const remoteHostTabVisible = ref(true)
+export const remoteHostTabVisible = vueRef(true)
 
-/**
- * When a guest's `DataConnection` closes, keep their participant slot (drafts,
- * votes, ready flag) around for this long so that a quick reconnect can reuse
- * it. Long enough for brief wifi/bluetooth glitches, short enough that a
- * truly-departed voter doesn't block a room from advancing to the next phase.
- */
 const GUEST_REMOVAL_GRACE_MS = 45_000
 
-/** Minimum distinct TMDB titles across the room before anyone can mark ready (matches ballot dedupe). */
 const MIN_DISTINCT_SUGGESTIONS_FOR_READY = 2
-
-/** @type {ReturnType<typeof setInterval> | null} */
-let hostHeartbeatIntervalId = null
-
-/** @type {ReturnType<typeof setInterval> | null} */
-let guestHostWatchIntervalId = null
 
 /** @type {(() => void) | null} */
 let hostVisibilityTeardown = null
 
-/** @type {number} */
-let guestLastHostActivityAt = 0
+/**
+ * @param {string} suffix
+ * @param {string} path
+ */
+function roomChild(suffix, path) {
+  return child(movieVoteRoomRef(suffix), path)
+}
+
+/**
+ * @param {() => void} unsub
+ */
+function trackUnsub(unsub) {
+  wireUnsubs.push(unsub)
+}
 
 /**
  * @param {string} message
@@ -169,7 +149,6 @@ function notifyP2P(message, type = 'info', opts = {}) {
   }
 }
 
-/** Clears persisted host/guest intent from the room session Pinia store. */
 function clearRoomPersistence() {
   try {
     useMovieVoteRoomSessionStore().clear()
@@ -179,121 +158,88 @@ function clearRoomPersistence() {
 }
 
 function clearHeartbeatAndWatch() {
-  if (hostHeartbeatIntervalId !== null) {
-    clearInterval(hostHeartbeatIntervalId)
-    hostHeartbeatIntervalId = null
-  }
-  if (guestHostWatchIntervalId !== null) {
-    clearInterval(guestHostWatchIntervalId)
-    guestHostWatchIntervalId = null
-  }
   if (hostVisibilityTeardown) {
     hostVisibilityTeardown()
     hostVisibilityTeardown = null
   }
 }
 
-function sendHostHeartbeats() {
-  if (!isHost || !peer || peer.destroyed) return
-  const msg = encodeHostPing()
-  for (const c of hubConnections) {
-    if (!c.open) continue
+function clearWireUnsubs() {
+  for (const unsub of wireUnsubs) {
     try {
-      c.send(msg)
+      unsub()
     } catch {
       void 0
     }
   }
+  wireUnsubs = []
 }
 
 function broadcastHostVisibility(visible) {
-  if (!isHost || !peer || peer.destroyed) return
-  const msg = encodeHostVisibility(visible)
-  for (const c of hubConnections) {
-    if (!c.open) continue
-    try {
-      c.send(msg)
-    } catch {
-      void 0
-    }
-  }
+  if (!isHost || !sessionSuffix.value) return
+  setRtdb(roomChild(sessionSuffix.value, 'hostVisible'), encodeHostVisibility(visible)).catch(() => {})
 }
 
-function startHostHeartbeats() {
-  if (hostHeartbeatIntervalId !== null) {
-    clearInterval(hostHeartbeatIntervalId)
-    hostHeartbeatIntervalId = null
+function startHostVisibilityWatch() {
+  if (typeof document === 'undefined' || hostVisibilityTeardown) return
+  const onVis = () => {
+    broadcastHostVisibility(document.visibilityState === 'visible')
   }
-  hostHeartbeatIntervalId = window.setInterval(sendHostHeartbeats, HEARTBEAT_INTERVAL_MS)
-  sendHostHeartbeats()
-
-  if (typeof document !== 'undefined' && !hostVisibilityTeardown) {
-    const onVis = () => {
-      const visible = document.visibilityState === 'visible'
-      broadcastHostVisibility(visible)
-      if (visible) sendHostHeartbeats()
-    }
-    document.addEventListener('visibilitychange', onVis)
-    hostVisibilityTeardown = () => document.removeEventListener('visibilitychange', onVis)
-  }
+  document.addEventListener('visibilitychange', onVis)
+  hostVisibilityTeardown = () => document.removeEventListener('visibilitychange', onVis)
+  broadcastHostVisibility(document.visibilityState === 'visible')
 }
 
-function touchGuestHostActivity() {
-  guestLastHostActivityAt = Date.now()
+function wireDatabaseConnectivity() {
+  const connectedRef = dbRef(getMovieVoteDatabase(), '.info/connected')
+  trackUnsub(
+    onValue(connectedRef, (snap) => {
+      if (snap.val() !== false) return
+      if (isHost && sessionPhase.value === 'hosting') onHostDisconnected()
+      else if (!isHost && sessionPhase.value === 'guest_connected') onGuestDisconnected()
+    }),
+  )
 }
 
-function startGuestHostWatch() {
-  if (guestHostWatchIntervalId !== null) {
-    clearInterval(guestHostWatchIntervalId)
-    guestHostWatchIntervalId = null
-  }
-  touchGuestHostActivity()
-  guestHostWatchIntervalId = window.setInterval(() => {
-    if (sessionPhase.value !== 'guest_connected' || isHost) return
-    if (Date.now() - guestLastHostActivityAt > HEARTBEAT_STALE_MS) onGuestDisconnected()
-  }, HEARTBEAT_GUEST_CHECK_MS)
+/**
+ * @param {string} suffix
+ * @param {string} stableId
+ */
+async function markGuestOnline(suffix, stableId) {
+  const onlineRef = roomChild(suffix, `guestOnline/${stableId}`)
+  await setRtdb(onlineRef, true)
+  onDisconnect(onlineRef).set(false)
+}
+
+/**
+ * @param {string} suffix
+ * @param {string} stableId
+ */
+async function markGuestOffline(suffix, stableId) {
+  await setRtdb(roomChild(suffix, `guestOnline/${stableId}`), false).catch(() => {})
 }
 
 function destroyWireOnly() {
   clearHeartbeatAndWatch()
-  for (const c of hubConnections) {
-    try {
-      c.close()
-    } catch {
-      void 0
-    }
+  clearWireUnsubs()
+
+  const suffix = sessionSuffix.value
+  const sid = guestStableId
+  if (!isHost && suffix && sid) {
+    void markGuestOffline(suffix, sid)
   }
-  hubConnections.clear()
-  connToParticipant.clear()
-  participantToConn.clear()
+
   stableIdToParticipant.clear()
+  activeGuestStableIds.clear()
   guestDrafts.clear()
   for (const t of pendingRemovalTimers.values()) clearTimeout(t)
   pendingRemovalTimers.clear()
-  if (guestHubConn) {
-    try {
-      guestHubConn.close()
-    } catch {
-      void 0
-    }
-    guestHubConn = null
-  }
-  if (peer && !peer.destroyed) {
-    try {
-      peer.destroy()
-    } catch {
-      void 0
-    }
-  }
-  peer = null
+  guestStableId = null
   isHost = false
   nextSeq = 0
   lastSeenSeq = 0
 }
 
-/**
- * @returns {import('../types.js').MovieVotePublicPayload}
- */
 function allDraftPicksFlat() {
   const store = useMovieVoteStore()
   const out = [...store.myDraftPicks]
@@ -336,7 +282,7 @@ function buildPublicPayload() {
 }
 
 function hostBroadcastState() {
-  if (!isHost || !peer || peer.destroyed) return
+  if (!isHost || !sessionSuffix.value) return
   const payload = buildPublicPayload()
   try {
     const st = useMovieVoteStore()
@@ -348,14 +294,7 @@ function hostBroadcastState() {
     void 0
   }
   const msg = encodeState(payload, ++nextSeq)
-  for (const c of hubConnections) {
-    if (!c.open) continue
-    try {
-      c.send(msg)
-    } catch {
-      void 0
-    }
-  }
+  setRtdb(roomChild(sessionSuffix.value, 'state'), msg).catch(() => {})
 }
 
 function roomHasEnoughDistinctSuggestionsForReady() {
@@ -412,9 +351,6 @@ function tryFinishVoting() {
 }
 
 /**
- * Validate a pick from the wire. Accepts both TMDB picks (numeric `tmdbId`)
- * and custom picks (`source === 'custom'` with a non-empty title).
- *
  * @param {import('../types.js').MoviePick[]} picks
  */
 function normalizePicks(picks) {
@@ -445,20 +381,43 @@ function normalizePicks(picks) {
 }
 
 /**
- * @param {import('peerjs').DataConnection} conn
+ * Re-attach stable id → participant after host tab refresh (inbox may hold draft/vote, not hello).
+ * @param {string} stableId
+ * @param {unknown} raw
+ * @returns {string | null}
+ */
+function bindStableIdFromGuestPayload(stableId, raw) {
+  const existing = stableIdToParticipant.get(stableId)
+  if (existing) return existing
+
+  const draft = parseDraft(raw)
+  const pid = draft?.participantId ?? parseVote(raw)?.participantId
+  if (!pid) return null
+
+  stableIdToParticipant.set(stableId, pid)
+  if (!guestDrafts.has(pid)) {
+    guestDrafts.set(pid, { picks: [], ready: false })
+  }
+  cancelParticipantRemoval(pid)
+  return pid
+}
+
+/**
+ * @param {string} stableId
  * @param {unknown} raw
  */
-function handleHubInbound(conn, raw) {
+function handleHostInboxMessage(stableId, raw) {
   const hello = parseHello(raw)
   if (hello) {
-    onGuestHello(conn, hello.stableId)
+    if (hello.stableId !== stableId) return
+    onGuestHello(stableId)
     return
   }
 
-  const store = useMovieVoteStore()
-  const expectedPid = connToParticipant.get(conn)
+  const expectedPid = bindStableIdFromGuestPayload(stableId, raw)
   if (!expectedPid) return
 
+  const store = useMovieVoteStore()
   const draft = parseDraft(raw)
   if (draft) {
     if (draft.participantId !== expectedPid) return
@@ -489,57 +448,124 @@ function handleHubInbound(conn, raw) {
   }
 }
 
+function handleGuestHostEnded() {
+  notifyP2P('The host ended the room.', 'info')
+  reconnectGeneration += 1
+  clearRoomPersistence()
+  resetLocalStateAfterRoomExit()
+}
+
 /**
  * @param {unknown} raw
  */
-function handleGuestInbound(raw) {
-  if (isHostEndedNotice(raw)) {
-    notifyP2P('The host ended the room.', 'info')
-    reconnectGeneration += 1
-    clearRoomPersistence()
-    resetLocalStateAfterRoomExit()
-    return
-  }
-  if (isHostPing(raw)) {
-    touchGuestHostActivity()
-    return
-  }
-  const vis = parseHostVisibility(raw)
-  if (vis) {
-    touchGuestHostActivity()
-    remoteHostTabVisible.value = vis.visible
-    return
-  }
+function handleGuestWelcome(raw) {
   const welcome = parseWelcome(raw)
-  if (welcome) {
-    touchGuestHostActivity()
-    useMovieVoteStore().setMyParticipantId(welcome.participantId)
-    // Re-push our drafts so the host picks them up even if they refreshed and
-    // lost all participant state. Cheap; the host is idempotent on incoming
-    // draft messages.
-    movieVoteGuestPushDraft()
-    return
-  }
+  if (!welcome) return
+  useMovieVoteStore().setMyParticipantId(welcome.participantId)
+  movieVoteGuestPushDraft()
+}
+
+/**
+ * @param {unknown} raw
+ */
+function handleGuestState(raw) {
   const st = parseState(raw)
   if (!st) return
-  touchGuestHostActivity()
   if (st.seq <= lastSeenSeq) return
   lastSeenSeq = st.seq
   useMovieVoteStore().applyPublicPayload(st.payload)
 }
 
-function wirePeerErrors(p) {
-  wireStarRoomPeerErrors(p, {
-    bumpReconnectGeneration: () => {
-      reconnectGeneration += 1
-    },
-    clearRoomPersistence,
-    notifyP2p: notifyP2P,
-    teardownSession,
-    getIsHost: () => isHost,
-    onHostDisconnected,
-    onGuestDisconnected,
-  })
+/**
+ * @param {string} suffix
+ */
+function wireHostRoom(suffix) {
+  wireDatabaseConnectivity()
+
+  const inboxRef = roomChild(suffix, 'inbox')
+  trackUnsub(
+    onChildAdded(inboxRef, (snap) => {
+      const stableId = snap.key
+      if (!stableId) return
+      const itemRef = snap.ref
+      trackUnsub(
+        onValue(itemRef, (itemSnap) => {
+          const val = itemSnap.val()
+          if (val != null) handleHostInboxMessage(stableId, val)
+        }),
+      )
+    }),
+  )
+
+  const guestOnlineRef = roomChild(suffix, 'guestOnline')
+  trackUnsub(
+    onChildAdded(guestOnlineRef, (snap) => {
+      const stableId = snap.key
+      if (!stableId) return
+      const onlineRef = snap.ref
+      trackUnsub(
+        onValue(onlineRef, (onlineSnap) => {
+          const pid = stableIdToParticipant.get(stableId)
+          if (!pid) return
+          if (onlineSnap.val() === true) {
+            activeGuestStableIds.add(stableId)
+            cancelParticipantRemoval(pid)
+          } else {
+            activeGuestStableIds.delete(stableId)
+            if (!activeGuestStableIds.has(stableId)) scheduleParticipantRemoval(pid)
+          }
+        }),
+      )
+    }),
+  )
+}
+
+/**
+ * @param {string} suffix
+ * @param {string} stableId
+ */
+function wireGuestRoom(suffix, stableId) {
+  wireDatabaseConnectivity()
+
+  trackUnsub(
+    onValue(roomChild(suffix, 'state'), (snap) => {
+      const raw = snap.val()
+      if (raw != null) handleGuestState(raw)
+    }),
+  )
+
+  trackUnsub(
+    onValue(roomChild(suffix, `welcome/${stableId}`), (snap) => {
+      const raw = snap.val()
+      if (raw != null) handleGuestWelcome(raw)
+    }),
+  )
+
+  trackUnsub(
+    onValue(roomChild(suffix, 'ended'), (snap) => {
+      if (isRoomMarkedEnded(snap.val())) handleGuestHostEnded()
+    }),
+  )
+
+  let sawHostPing = false
+  trackUnsub(
+    onValue(roomChild(suffix, 'hostPing'), (snap) => {
+      const ping = snap.val()
+      if (typeof ping === 'number') {
+        sawHostPing = true
+        return
+      }
+      if (sawHostPing && ping == null) handleGuestHostEnded()
+    }),
+  )
+
+  trackUnsub(
+    onValue(roomChild(suffix, 'hostVisible'), (snap) => {
+      const vis = parseHostVisibility(snap.val())
+      if (!vis) return
+      remoteHostTabVisible.value = vis.visible
+    }),
+  )
 }
 
 function onGuestDisconnected() {
@@ -596,8 +622,7 @@ function guestReconnectLoop(suffix, gen) {
     notifyReconnectingGuest: (attempt, max) =>
       notifyP2P(`Reconnecting… attempt ${attempt} of ${max}`, 'warning'),
     destroyWireOnly,
-    establishGuest: () =>
-      establishGuestSession(suffix, { peerTimeoutMs: RECONNECT_PEER_TIMEOUT_MS }),
+    establishGuest: () => establishGuestSession(suffix),
     leaveSession,
     clearRoomPersistence,
     notifyGuestReconnectFailed: () =>
@@ -611,7 +636,6 @@ function guestReconnectLoop(suffix, gen) {
  * @param {number} gen
  */
 function hostReconnectLoop(suffix, gen) {
-  const fullId = fullPeerIdFromSuffix(suffix)
   return runHostStarReconnectLoop({
     gen,
     getReconnectGeneration: () => reconnectGeneration,
@@ -619,10 +643,7 @@ function hostReconnectLoop(suffix, gen) {
     notifyReconnectingHost: (attempt, max) =>
       notifyP2P(`Reconnecting as host… attempt ${attempt} of ${max}`, 'warning'),
     destroyWireOnly,
-    establishHost: async () => {
-      const p = await awaitPeerOpen(fullId, RECONNECT_PEER_TIMEOUT_MS)
-      finishHostSession(/** @type {import('peerjs').Peer} */ (p), suffix)
-    },
+    establishHost: () => finishHostSession(suffix),
     leaveSession,
     clearRoomPersistence,
     notifyHostReconnectFailed: () =>
@@ -631,48 +652,19 @@ function hostReconnectLoop(suffix, gen) {
   })
 }
 
-/**
- * @param {import('peerjs').Peer} p
- */
-function attachHubConnectionHandlers(p) {
-  p.on('connection', (conn) => {
-    conn.on('open', () => {
-      hubConnections.add(conn)
-    })
-    conn.on('data', (data) => handleHubInbound(conn, data))
-    conn.on('close', () => {
-      const pid = connToParticipant.get(conn)
-      hubConnections.delete(conn)
-      connToParticipant.delete(conn)
-      if (pid && participantToConn.get(pid) === conn) {
-        participantToConn.delete(pid)
-        scheduleParticipantRemoval(pid)
-      }
-      hostBroadcastState()
-    })
-  })
-}
-
-/**
- * Schedule removal of a participant slot after {@link GUEST_REMOVAL_GRACE_MS}
- * unless a matching guest reconnects first. No-op if the slot is already
- * actively connected or already scheduled.
- * @param {string} pid
- */
 function scheduleParticipantRemoval(pid) {
   if (!guestDrafts.has(pid)) return
-  if (participantToConn.has(pid)) return
+  const stableId = [...stableIdToParticipant.entries()].find(([, p]) => p === pid)?.[0]
+  if (stableId && activeGuestStableIds.has(stableId)) return
   const existing = pendingRemovalTimers.get(pid)
   if (existing) clearTimeout(existing)
   const t = setTimeout(() => {
     pendingRemovalTimers.delete(pid)
-    if (participantToConn.has(pid)) return
+    if (stableId && activeGuestStableIds.has(stableId)) return
     guestDrafts.delete(pid)
-    for (const [sid, mapped] of stableIdToParticipant) {
-      if (mapped === pid) {
-        stableIdToParticipant.delete(sid)
-        break
-      }
+    if (stableId) {
+      stableIdToParticipant.delete(stableId)
+      activeGuestStableIds.delete(stableId)
     }
     if (isHost && sessionPhase.value === 'hosting') {
       useMovieVoteStore().removeParticipantFromVote(pid)
@@ -684,11 +676,6 @@ function scheduleParticipantRemoval(pid) {
   pendingRemovalTimers.set(pid, t)
 }
 
-/**
- * Cancel any pending removal for `pid` (guest is back before the grace period
- * expired).
- * @param {string} pid
- */
 function cancelParticipantRemoval(pid) {
   const t = pendingRemovalTimers.get(pid)
   if (t) {
@@ -698,17 +685,9 @@ function cancelParticipantRemoval(pid) {
 }
 
 /**
- * Completes the hello handshake for a new guest connection by picking (or
- * reusing) the participant slot, wiring up the new conn, dropping any orphan
- * conn that used to serve the same guest, and sending the initial welcome /
- * state bootstrap.
- *
- * @param {import('peerjs').DataConnection} conn
  * @param {string} stableId
  */
-function onGuestHello(conn, stableId) {
-  if (connToParticipant.has(conn)) return
-
+function onGuestHello(stableId) {
   const existingPid = stableIdToParticipant.get(stableId)
   const pid = existingPid ?? generateAnonymousVoterId()
   const resumed = Boolean(existingPid)
@@ -720,56 +699,141 @@ function onGuestHello(conn, stableId) {
     cancelParticipantRemoval(pid)
   }
 
-  const orphan = participantToConn.get(pid)
-  if (orphan && orphan !== conn) {
-    try {
-      connToParticipant.delete(orphan)
-      orphan.close()
-    } catch {
-      void 0
-    }
-    hubConnections.delete(orphan)
+  activeGuestStableIds.add(stableId)
+
+  const suffix = sessionSuffix.value
+  if (!suffix) return
+
+  const welcomeRef = roomChild(suffix, `welcome/${stableId}`)
+  setRtdb(welcomeRef, encodeWelcome(pid, resumed)).catch(() => {})
+
+  const payload = buildPublicPayload()
+  if (nextSeq < 1) nextSeq = 1
+  setRtdb(roomChild(suffix, 'state'), encodeState(payload, nextSeq)).catch(() => {})
+
+  if (typeof document !== 'undefined') {
+    setRtdb(roomChild(suffix, 'hostVisible'), encodeHostVisibility(document.visibilityState === 'visible')).catch(
+      () => {},
+    )
   }
 
-  connToParticipant.set(conn, pid)
-  participantToConn.set(pid, conn)
+  if (resumed) hostBroadcastState()
+}
 
-  try {
-    conn.send(encodeWelcome(pid, resumed))
-    const payload = buildPublicPayload()
-    if (nextSeq < 1) nextSeq = 1
-    conn.send(encodeState(payload, nextSeq))
-    if (typeof document !== 'undefined') {
-      conn.send(encodeHostVisibility(document.visibilityState === 'visible'))
+/**
+ * Restore seq, participant slots, and online flags after host reconnect / refresh.
+ * @param {string} suffix
+ */
+async function hydrateHostFromRtdb(suffix) {
+  const stateSnap = await get(roomChild(suffix, 'state'))
+  const parsed = parseState(stateSnap.val())
+  if (parsed) nextSeq = parsed.seq
+
+  const welcomeSnap = await get(roomChild(suffix, 'welcome'))
+  const welcomes = welcomeSnap.val()
+  if (welcomes && typeof welcomes === 'object') {
+    for (const [stableId, raw] of Object.entries(welcomes)) {
+      if (typeof stableId !== 'string') continue
+      const welcome = parseWelcome(raw)
+      if (!welcome) continue
+      stableIdToParticipant.set(stableId, welcome.participantId)
+      if (!guestDrafts.has(welcome.participantId)) {
+        guestDrafts.set(welcome.participantId, { picks: [], ready: false })
+      }
     }
-  } catch {
-    try {
-      conn.close()
-    } catch {
-      void 0
-    }
-    return
   }
 
-  if (resumed) {
-    hostBroadcastState()
+  const onlineSnap = await get(roomChild(suffix, 'guestOnline'))
+  const online = onlineSnap.val()
+  if (online && typeof online === 'object') {
+    for (const [stableId, isOnline] of Object.entries(online)) {
+      if (isOnline === true) activeGuestStableIds.add(stableId)
+    }
   }
 }
 
 /**
- * @param {import('peerjs').Peer} p
  * @param {string} suffix
  */
-function finishHostSession(p, suffix) {
-  peer = p
+async function clearRoomEnded(suffix) {
+  await remove(roomChild(suffix, 'ended')).catch(() => {})
+}
+
+/**
+ * Drop stale guest/host payloads after claiming an idle room suffix.
+ * @param {string} suffix
+ */
+async function resetStaleRoomRtdbForClaim(suffix) {
+  await Promise.all(
+    ROOM_CLAIM_RESET_PATHS.map((path) => remove(roomChild(suffix, path)).catch(() => {})),
+  )
+}
+
+/**
+ * @param {string} suffix
+ * @returns {Promise<boolean>} true if suffix is free to claim
+ */
+async function tryClaimHostRoom(suffix) {
+  const pingRef = roomChild(suffix, 'hostPing')
+  const stableClientId = getStableClientId()
+  const [pingSnap, endedSnap, hostClientSnap] = await Promise.all([
+    get(pingRef),
+    get(roomChild(suffix, 'ended')),
+    get(roomChild(suffix, 'hostClientId')),
+  ])
+  const pingVal = pingSnap.val()
+  const endedVal = endedSnap.val()
+  if (
+    !canClaimHostRoom(pingVal, endedVal, {
+      hostClientId: hostClientSnap.val(),
+      stableClientId,
+    })
+  ) {
+    return false
+  }
+
+  const reclaimOwn =
+    typeof hostClientSnap.val() === 'string' &&
+    hostClientSnap.val() === stableClientId &&
+    isHostPingPresent(pingVal) &&
+    !isRoomMarkedEnded(endedVal)
+
+  await setRtdb(pingRef, Date.now())
+  await setRtdb(roomChild(suffix, 'hostClientId'), stableClientId)
+  if (!reclaimOwn) {
+    await resetStaleRoomRtdbForClaim(suffix)
+  }
+  return true
+}
+
+/**
+ * @param {string} suffix
+ */
+async function registerHostOnDisconnect(suffix) {
+  try {
+    onDisconnect(roomChild(suffix, 'hostPing')).remove()
+    onDisconnect(roomChild(suffix, 'ended')).set(Date.now())
+  } catch {
+    void 0
+  }
+}
+
+/**
+ * @param {string} suffix
+ */
+async function finishHostSession(suffix) {
+  await clearRoomEnded(suffix)
   isHost = true
   sessionSuffix.value = suffix
   nextSeq = 0
   lastSeenSeq = 0
-  attachHubConnectionHandlers(peer)
+  await hydrateHostFromRtdb(suffix)
+  wireHostRoom(suffix)
   sessionPhase.value = 'hosting'
-  wirePeerErrors(peer)
-  startHostHeartbeats()
+  startHostVisibilityWatch()
+  await setRtdb(roomChild(suffix, 'hostPing'), Date.now())
+  await setRtdb(roomChild(suffix, 'hostClientId'), getStableClientId())
+  await registerHostOnDisconnect(suffix)
   useMovieVoteStore().setMyParticipantId(HOST_PARTICIPANT_ID)
   try {
     useMovieVoteRoomSessionStore().setHost(suffix)
@@ -781,53 +845,28 @@ function finishHostSession(p, suffix) {
 
 /**
  * @param {string} suffix
- * @param {{ peerTimeoutMs?: number }} [opts]
  */
-async function establishGuestSession(suffix, opts = {}) {
-  const peerTimeoutMs = opts.peerTimeoutMs ?? OPEN_PEER_TIMEOUT_MS
-  const hubId = fullPeerIdFromSuffix(suffix)
+async function establishGuestSession(suffix) {
+  const pingSnap = await get(roomChild(suffix, 'hostPing'))
+  if (!isHostPingPresent(pingSnap.val())) {
+    throw new Error('No active room for that code')
+  }
+
+  const endedSnap = await get(roomChild(suffix, 'ended'))
+  if (isRoomMarkedEnded(endedSnap.val())) {
+    throw new Error('No active room for that code')
+  }
+
+  guestStableId = getStableClientId()
   lastSeenSeq = 0
-  const p = await awaitPeerOpen(undefined, peerTimeoutMs)
-  peer = /** @type {import('peerjs').Peer} */ (p)
   isHost = false
+  remoteHostTabVisible.value = true
 
-  const conn = peer.connect(hubId, { ...PEER_OPTS })
-
-  await new Promise((resolve, reject) => {
-    const t = window.setTimeout(() => {
-      try {
-        conn.close()
-      } catch {
-        void 0
-      }
-      reject(new Error('Connect timeout'))
-    }, peerTimeoutMs)
-    conn.on('error', (e) => {
-      window.clearTimeout(t)
-      reject(e)
-    })
-    conn.on('open', () => {
-      window.clearTimeout(t)
-      resolve(undefined)
-    })
-  })
-
-  guestHubConn = conn
-  conn.on('data', (data) => handleGuestInbound(data))
-  conn.on('close', () => {
-    guestHubConn = null
-    onGuestDisconnected()
-  })
+  wireGuestRoom(suffix, guestStableId)
+  await markGuestOnline(suffix, guestStableId)
+  await setRtdb(roomChild(suffix, `inbox/${guestStableId}`), encodeHello(guestStableId))
 
   sessionPhase.value = 'guest_connected'
-  wirePeerErrors(peer)
-  startGuestHostWatch()
-
-  try {
-    conn.send(encodeHello(getStableClientId()))
-  } catch {
-    void 0
-  }
 
   try {
     useMovieVoteRoomSessionStore().setGuest(suffix)
@@ -848,7 +887,6 @@ export async function resumeAsHost(rawSuffix, maxAttempts = 10) {
     throw new Error('Invalid saved room')
   }
 
-  const fullId = fullPeerIdFromSuffix(suffix)
   sessionPhase.value = 'connecting'
   sessionSuffix.value = suffix
 
@@ -859,8 +897,7 @@ export async function resumeAsHost(rawSuffix, maxAttempts = 10) {
       notifyP2P(`Still resuming room… attempt ${attempt + 1} of ${maxAttempts}`, 'warning')
     }
     try {
-      const p = await awaitPeerOpen(fullId)
-      finishHostSession(/** @type {import('peerjs').Peer} */ (p), suffix)
+      await finishHostSession(suffix)
       return { suffix }
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e))
@@ -890,28 +927,44 @@ export function resumeMovieVoteSessionIfNeeded() {
   }
 }
 
+/**
+ * @returns {string[]}
+ */
+function hostStartSuffixOrder() {
+  const preferred = deriveStableHostSuffix(STABLE_HOST_SUFFIX_APP, 6)
+  const order = [preferred]
+  try {
+    const saved = useMovieVoteRoomSessionStore().suffix
+    const norm = saved ? normalizeRoomSuffixInput(saved) : ''
+    if (norm && isValidRoomSuffix(norm) && norm !== preferred) order.push(norm)
+  } catch {
+    void 0
+  }
+  return order
+}
+
 export async function startAsHost(maxAttempts = 12) {
   reconnectGeneration += 1
   teardownSession()
   sessionPhase.value = 'connecting'
 
-  const preferredSuffix = deriveStableHostSuffix(STABLE_HOST_SUFFIX_APP, 6)
+  const fixedSuffixes = hostStartSuffixOrder()
 
   let lastErr = /** @type {Error | null} */ (null)
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const suffix = attempt === 0 ? preferredSuffix : generateRoomSuffix(6)
-    const fullId = fullPeerIdFromSuffix(suffix)
+    const suffix =
+      attempt < fixedSuffixes.length ? fixedSuffixes[attempt] : generateRoomSuffix(6)
 
     try {
-      const p = await awaitPeerOpen(fullId)
+      if (!(await tryClaimHostRoom(suffix))) {
+        lastErr = new Error('Room code in use')
+        continue
+      }
       sessionSuffix.value = suffix
-      finishHostSession(/** @type {import('peerjs').Peer} */ (p), suffix)
+      await finishHostSession(suffix)
       return { suffix }
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e))
-      if (attempt === 0 && !isUnavailableIdError(e)) {
-        continue
-      }
     }
   }
 
@@ -967,17 +1020,17 @@ function resetLocalStateAfterRoomExit() {
 
 export function leaveSession() {
   reconnectGeneration += 1
-  clearRoomPersistence()
-  if (isHost && sessionPhase.value === 'hosting') {
-    const endMsg = { type: MSG_MV_HOST_ENDED }
-    for (const c of hubConnections) {
-      if (!c.open) continue
-      try {
-        c.send(endMsg)
-      } catch {
-        void 0
-      }
+  if (isHost && sessionPhase.value === 'hosting' && sessionSuffix.value) {
+    const suffix = sessionSuffix.value
+    setRtdb(roomChild(suffix, 'ended'), Date.now()).catch(() => {})
+    remove(roomChild(suffix, 'hostPing')).catch(() => {})
+    try {
+      useMovieVoteRoomSessionStore().clearHostRole()
+    } catch {
+      clearRoomPersistence()
     }
+  } else {
+    clearRoomPersistence()
   }
   resetLocalStateAfterRoomExit()
 }
@@ -986,45 +1039,33 @@ export function isMovieVoteP2PSessionActive() {
   return sessionPhase.value === 'hosting' || sessionPhase.value === 'guest_connected'
 }
 
-/** Host: local draft/ready changed — rebroadcast and maybe compile. */
 export function movieVoteHostLocalChanged() {
   if (!isHost || sessionPhase.value !== 'hosting') return
   tryCompileBallot()
   hostBroadcastState()
 }
 
-/** Guest: push draft to host */
 export function movieVoteGuestPushDraft() {
-  if (isHost || !guestHubConn?.open) return
+  if (isHost || !guestStableId || !sessionSuffix.value) return
   const store = useMovieVoteStore()
   const pid = store.myParticipantId
   if (!pid) return
-  try {
-    guestHubConn.send(
-      encodeDraft(store.myDraftPicks, store.readyToVote, pid),
-    )
-  } catch {
-    void 0
-  }
+  setRtdb(
+    roomChild(sessionSuffix.value, `inbox/${guestStableId}`),
+    encodeDraft(store.myDraftPicks, store.readyToVote, pid),
+  ).catch(() => {})
 }
 
-/** Guest: submit ranking */
 export function movieVoteGuestSubmitVote(ranking) {
-  if (isHost || !guestHubConn?.open) return
+  if (isHost || !guestStableId || !sessionSuffix.value) return
   const store = useMovieVoteStore()
   const pid = store.myParticipantId
   if (!pid) return
-  try {
-    guestHubConn.send(encodeVote(pid, ranking))
-  } catch {
-    void 0
-  }
+  setRtdb(roomChild(sessionSuffix.value, `inbox/${guestStableId}`), encodeVote(pid, ranking)).catch(() => {})
 }
 
-/** Host: after local vote submit */
 export function movieVoteHostAfterVoteSubmit() {
   if (!isHost || sessionPhase.value !== 'hosting') return
   hostBroadcastState()
   tryFinishVoting()
 }
-

--- a/src/features/movie-vote/p2p/sessionHostPing.js
+++ b/src/features/movie-vote/p2p/sessionHostPing.js
@@ -1,0 +1,66 @@
+import { isRoomMarkedEnded } from './sessionRoomRtdb.js'
+
+/** Legacy rooms without `hostClientId` still use ping freshness for occupancy. */
+export const HOST_PING_FRESH_MS = 120_000
+
+/**
+ * @param {unknown} ts
+ * @param {number} [nowMs]
+ * @returns {boolean}
+ */
+export function isHostPingFresh(ts, nowMs = Date.now()) {
+  return typeof ts === 'number' && ts > 0 && nowMs - ts < HOST_PING_FRESH_MS
+}
+
+/**
+ * @param {unknown} pingVal
+ * @returns {boolean}
+ */
+export function isHostPingPresent(pingVal) {
+  return typeof pingVal === 'number' && pingVal > 0
+}
+
+/**
+ * @param {unknown} pingVal
+ * @param {unknown} hostClientId
+ * @param {string} stableClientId
+ * @param {number} [nowMs]
+ * @returns {boolean}
+ */
+export function isRoomOccupiedByOtherHost(pingVal, hostClientId, stableClientId, nowMs = Date.now()) {
+  if (!isHostPingPresent(pingVal)) return false
+  if (typeof hostClientId === 'string' && hostClientId) {
+    return hostClientId !== stableClientId
+  }
+  return isHostPingFresh(pingVal, nowMs)
+}
+
+/**
+ * @param {unknown} pingVal RTDB `hostPing` value.
+ * @param {unknown} endedVal RTDB `ended` value.
+ * @param {{
+ *   nowMs?: number,
+ *   hostClientId?: unknown,
+ *   stableClientId?: string,
+ * }} [opts]
+ * @returns {boolean}
+ */
+export function canClaimHostRoom(pingVal, endedVal, opts = {}) {
+  const nowMs = opts.nowMs ?? Date.now()
+  const stableClientId = opts.stableClientId
+  const hostClientId = opts.hostClientId
+
+  if (isRoomMarkedEnded(endedVal)) return true
+  if (
+    typeof stableClientId === 'string' &&
+    stableClientId &&
+    typeof hostClientId === 'string' &&
+    hostClientId === stableClientId
+  ) {
+    return true
+  }
+  if (typeof stableClientId === 'string' && stableClientId) {
+    return !isRoomOccupiedByOtherHost(pingVal, hostClientId, stableClientId, nowMs)
+  }
+  return !isHostPingFresh(pingVal, nowMs)
+}

--- a/src/features/movie-vote/p2p/sessionHostPing.test.js
+++ b/src/features/movie-vote/p2p/sessionHostPing.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  HOST_PING_FRESH_MS,
+  canClaimHostRoom,
+  isHostPingFresh,
+  isHostPingPresent,
+  isRoomOccupiedByOtherHost,
+} from './sessionHostPing.js'
+
+test('isHostPingFresh accepts recent numeric timestamps', () => {
+  const now = 1_000_000
+  assert.equal(isHostPingFresh(now - 1, now), true)
+  assert.equal(isHostPingFresh(now - HOST_PING_FRESH_MS + 1, now), true)
+})
+
+test('isHostPingFresh rejects stale, missing, or invalid values', () => {
+  const now = 2_000_000
+  assert.equal(isHostPingFresh(now - HOST_PING_FRESH_MS, now), false)
+  assert.equal(isHostPingFresh(now - HOST_PING_FRESH_MS - 1, now), false)
+  assert.equal(isHostPingFresh(null, now), false)
+  assert.equal(isHostPingFresh('123', now), false)
+  assert.equal(isHostPingFresh(0, now), false)
+})
+
+test('isHostPingPresent detects an active host marker', () => {
+  assert.equal(isHostPingPresent(1), true)
+  assert.equal(isHostPingPresent(null), false)
+})
+
+test('isRoomOccupiedByOtherHost uses hostClientId when present', () => {
+  const now = 3_000_000
+  const oldPing = now - HOST_PING_FRESH_MS - 1
+  assert.equal(isRoomOccupiedByOtherHost(oldPing, 'HOST-A', 'HOST-B', now), true)
+  assert.equal(isRoomOccupiedByOtherHost(oldPing, 'HOST-A', 'HOST-A', now), false)
+  assert.equal(isRoomOccupiedByOtherHost(null, 'HOST-A', 'HOST-B', now), false)
+})
+
+test('isRoomOccupiedByOtherHost falls back to ping freshness without hostClientId', () => {
+  const now = 4_000_000
+  assert.equal(isRoomOccupiedByOtherHost(now - 1, null, 'HOST-A', now), true)
+  assert.equal(isRoomOccupiedByOtherHost(now - HOST_PING_FRESH_MS, null, 'HOST-A', now), false)
+})
+
+test('canClaimHostRoom allows claim when ended despite fresh hostPing', () => {
+  const now = 5_000_000
+  const freshPing = now - 1
+  assert.equal(canClaimHostRoom(freshPing, null, { nowMs: now, stableClientId: 'GUEST' }), false)
+  assert.equal(
+    canClaimHostRoom(freshPing, 1_700_000_000_000, { nowMs: now, stableClientId: 'GUEST' }),
+    true,
+  )
+})
+
+test('canClaimHostRoom allows reclaim when hostClientId matches this browser', () => {
+  const now = 6_000_000
+  const freshPing = now - 1
+  assert.equal(
+    canClaimHostRoom(freshPing, null, {
+      nowMs: now,
+      hostClientId: 'CLIENT-ABC',
+      stableClientId: 'CLIENT-ABC',
+    }),
+    true,
+  )
+  assert.equal(
+    canClaimHostRoom(freshPing, null, {
+      nowMs: now,
+      hostClientId: 'OTHER',
+      stableClientId: 'CLIENT-ABC',
+    }),
+    false,
+  )
+})
+
+test('canClaimHostRoom allows claim when hostPing is absent', () => {
+  const now = 7_000_000
+  assert.equal(canClaimHostRoom(null, null, { nowMs: now, stableClientId: 'GUEST' }), true)
+})

--- a/src/features/movie-vote/p2p/sessionRoomRtdb.js
+++ b/src/features/movie-vote/p2p/sessionRoomRtdb.js
@@ -1,0 +1,17 @@
+/** RTDB room children removed when a new host claims an idle suffix (not on resume/reconnect). */
+export const ROOM_CLAIM_RESET_PATHS = Object.freeze([
+  'inbox',
+  'welcome',
+  'guestOnline',
+  'state',
+  'ended',
+  'hostVisible',
+])
+
+/**
+ * @param {unknown} endedSnapVal RTDB `ended` node value.
+ * @returns {boolean}
+ */
+export function isRoomMarkedEnded(endedSnapVal) {
+  return endedSnapVal != null
+}

--- a/src/features/movie-vote/p2p/sessionRoomRtdb.test.js
+++ b/src/features/movie-vote/p2p/sessionRoomRtdb.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ROOM_CLAIM_RESET_PATHS, isRoomMarkedEnded } from './sessionRoomRtdb.js'
+
+test('ROOM_CLAIM_RESET_PATHS clears stale session payload but not hostPing', () => {
+  assert.ok(ROOM_CLAIM_RESET_PATHS.includes('ended'))
+  assert.ok(ROOM_CLAIM_RESET_PATHS.includes('state'))
+  assert.ok(ROOM_CLAIM_RESET_PATHS.includes('inbox'))
+  assert.ok(!ROOM_CLAIM_RESET_PATHS.includes('hostPing'))
+})
+
+test('ended marker alone does not block reclaim after stale hostPing', () => {
+  assert.ok(ROOM_CLAIM_RESET_PATHS.includes('ended'))
+  assert.equal(isRoomMarkedEnded(1_700_000_000_000), true)
+})
+
+test('isRoomMarkedEnded is false only when ended node is absent', () => {
+  assert.equal(isRoomMarkedEnded(null), false)
+  assert.equal(isRoomMarkedEnded(undefined), false)
+  assert.equal(isRoomMarkedEnded(1_700_000_000_000), true)
+})

--- a/src/features/p2p/CONTEXT.md
+++ b/src/features/p2p/CONTEXT.md
@@ -12,15 +12,19 @@ _Avoid_: “Lobby” unless the feature explicitly distinguishes waiting areas f
 
 ### Host
 
-The browser/tab that owns authoritative session lifecycle and relays state to attached **guest** connections.
+The collaborator role that owns authoritative **room** lifecycle for that **room**’s lifetime; the **host** is never reassigned to another **participant**.
+
+In wire-based star rooms, the **host** browser/tab relays state to attached **guest** connections. With persisted collaboration, **guest** **participants** are not coupled to whether the **host**’s browser is online at a given moment—**host**-only actions wait until that **host** **principal** acts again.
 
 ### Guest
 
 A browser/tab that joins **host**, sends updates upward, and follows **host**-issued snapshots or messages.
 
+With a valid **join link** and an existing **room**, attachment is immediate: the shared **room code** is the admission signal—no separate **host** approval step unless a product explicitly adds one.
+
 ### Star-room shell
 
-Cross-feature wiring for Peer errors classification, teardown, and backoff-based reconnect loops; individual products supply how to establish **host**/ **guest**, notify users, and clear persistence.
+Cross-feature wiring for Peer errors classification, teardown, and backoff-based reconnect loops; individual products supply how to establish **host**/ **guest**, notify users, and clear persistence—including shared persisted **room** artifacts when a product ends a **room** on the same user-visible teardown moments as today. Products may also define retention or automated cleanup for **rooms** that never receive a clean teardown.
 
 ### Room code
 
@@ -33,6 +37,8 @@ Characters allowed in generated **room suffix** values: uppercase letters and di
 ### Room suffix
 
 The normalized alphanumeric tail users mean when they say **room code**; paired with an **app-scoped broker prefix** it becomes the full signaling id.
+
+The same value is usually the canonical **room** key when a product persists **rooms** under an app-scoped path, so **join links** stay aligned with stored sessions.
 
 ### App-scoped broker prefix
 
@@ -53,6 +59,8 @@ Deterministic **room suffix** derived from **stable client identity** plus an ap
 ### Stable client identity
 
 Opaque per-browser identifier that lets a **host** treat a returning **guest** as the same collaborator after refresh or reconnect (so counts and submissions stay coherent).
+
+The shell picks **one** persisted principal as canonical for that remapping; feature stores may mirror it for convenience, not hold a second competing browser-level id.
 
 ### Reconnect generation
 
@@ -76,7 +84,9 @@ Stopping live connections without discarding persisted **room** identity (narrow
 
 ## Relationships
 
+- The **host** role is fixed for a **room**’s lifetime—never migrated to another **participant**.
 - Every **guest** attaches to exactly one **host** in a running **star-room shell** pairing (star **hub**).
+- **Guests** enter using **join links**; the shared **room code** admits them without a **host** approval gate unless a product deliberately adds one.
 - A **room suffix** is drawn from the **unambiguous room alphabet**; combined with an **app-scoped broker prefix** it forms the wire **hub** id.
 - A **room code**/**room suffix** selects which **host** **guest** browsers join; **join links** encode that suffix for copying.
 - **App-scoped broker prefixes** keep namespaces disjoint across products sharing the same broker fleet.
@@ -101,3 +111,5 @@ Stopping live connections without discarding persisted **room** identity (narrow
 ## Flagged ambiguities
 
 - “Session” vs “Room”: Resolved — persist user-facing wording as **room**; reserve **session** for implementation layers that include phase machines inside a product-specific store.
+- **Host** reassignment: Resolved — never; a **room**’s **host** is fixed for that **room**’s lifetime.
+- **Room** cleanup: Resolved — user-visible teardown clears shared persisted **room** artifacts; abandoned **rooms** may be purged by a product-defined time-based backstop whose clock **participant** activity refreshes—not **host**-only signals.

--- a/src/stores/movieVoteRoomSession.js
+++ b/src/stores/movieVoteRoomSession.js
@@ -28,6 +28,11 @@ export const useMovieVoteRoomSessionStore = defineStore('movieVoteRoomSession', 
       this.role = null
       this.suffix = null
     },
+
+    /** Host left deliberately; keep suffix so the same room code is reused next time. */
+    clearHostRole() {
+      this.role = null
+    },
   },
 
   persist: {


### PR DESCRIPTION
Closes #80

## Summary

- Replace Movie Vote’s PeerJS/WebRTC star-room transport with **Firebase Realtime Database** under `movieVoteRooms/<suffix>` while keeping the existing star-hub session shape (typed inbox messages, host aggregation, IRV on the host).
- Add Firebase project wiring (`firebase.json`, `.firebaserc`, `database.rules.json`), `VITE_FIREBASE_*` env vars (`.env.example`), and a small RTDB bootstrap module with unit tests.
- Extend host-claim / room lifecycle helpers (`sessionHostPing`, `sessionRoomRtdb`) and refactor `p2p/session.js` to read/write collaborative state via RTDB listeners instead of peer data channels.

**Note:** Issue #80’s PRD names Firestore; this branch ships **RTDB** as the collaborative store. Sub-issues #81–#90 are closed as completed in this delivery.

## Test plan

- [ ] Copy `.env.example` → `.env` with a Firebase project that has Realtime Database enabled; confirm Movie Vote host/guest flows locally.
- [ ] Host: start room, share join link; guest: join by suffix; exercise suggest → voting → results.
- [ ] Host disconnect/background: guest can still contribute; host resume rehydrates from RTDB.
- [ ] Host reclaim after `ended` / stale room: claim resets session payload per `ROOM_CLAIM_RESET_PATHS`.
- [ ] `npm test -- --run src/features/movie-vote/firebase/rtdb.test.js src/features/movie-vote/p2p/sessionHostPing.test.js src/features/movie-vote/p2p/sessionRoomRtdb.test.js`
- [ ] **Follow-up:** tighten `database.rules.json` (currently open read/write for bootstrap) before production use.