### PR TITLE
Desktop phone frame for mobile projects in project shell

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,9 +106,15 @@ _Avoid_: Conflating with immersive **project** layouts.
 
 ### Project shell
 
-Full-viewport layout for interactive **projects** (no portfolio masthead), giving controls and timers the full screen. **Game Timer**, **Movie Vote**, and **Dungeon Runner** use the same shell pattern (immersive chrome, trapped browser back).
+Full-viewport layout for interactive **projects** (no portfolio masthead), giving controls and timers the full screen. **Game Timer**, **Movie Vote**, and **Dungeon Runner** share one shell (immersive chrome, trapped browser back). On wide viewports the same shell applies a **desktop phone frame** around the app instead of stretching it edge-to-edge.
 
 _Avoid_: “Fullscreen layout” when meaning **project shell** (confuses with the browser Fullscreen API toggle on **Game Timer**).
+
+### Desktop phone frame
+
+On desktop-class viewports (Quasar **`md` and up**, ≥1024px), the **project shell** letterboxes each mobile **project** inside a centered portrait column sized like a phone display, with neutral gutter space on the sides (and above/below when the window is very tall). The column is **390px** wide; height is capped at roughly **19.5∶9** portrait (`min(90dvh, width × 19.5/9)`), shrinking on short windows while width stays 390px when space allows. Gutter uses the site dark background; the column gets subtle rounding and a light edge (shadow or border)—not a hardware mockup (no notch or bezel art). **Game Timer** and **Dungeon Runner** keep their existing Fullscreen toggle here: it still fullscreens the whole tab and exits the letterbox. Dialogs, **Notify** toasts, and other portaled overlays anchor **inside the column** on **`md+`** (not against the whole monitor). Viewports below **`md`** keep today’s full-bleed **project shell** behavior and viewport-scoped overlays.
+
+_Avoid_: “Desktop project” as a separate nav app; “expand the 390px column only” as fullscreen—the **Projects drawer sections** label “Desktop” remains a placeholder, and fullscreen still means the browser tab.
 
 ### Paste unfurl
 
@@ -120,8 +126,8 @@ _Avoid_: Assuming in-tab meta tag updates alone fix every preview provider.
 
 - The **portfolio site** includes the **photo gallery**, about content (**résumé data**), navigation, and routed **projects**.
 - **Photography (navigation)** names the same home experience as the **photo gallery**.
-- **Portfolio shell** wraps the gallery and about; **project shell** wraps each `/projects/…` route.
-- Drawer shortcuts use **detached project launch** so multiplayer **projects** typically run outside the shell tab.
+- **Portfolio shell** wraps the gallery and about; **project shell** wraps each `/projects/…` route and may add a **desktop phone frame** on wide viewports.
+- Drawer shortcuts use **detached project launch** so multiplayer **projects** typically run outside the shell tab; the **desktop phone frame** does not change that—wide viewports still open the same project routes in a separate tab.
 - **Projects drawer sections** organize how **projects** appear in navigation without changing their public routes.
 - Each **paste-unfurl eligible** path is a **shareable route** with exactly one **shared link summary**; **paste unfurl** surfaces those fields to link previews.
 - The **share metadata catalog** is the authority for **shared link summary** fields and **route document chrome** on **shareable routes**; router paths align with catalog paths rather than parallel ids.
@@ -140,6 +146,9 @@ _Avoid_: Assuming in-tab meta tag updates alone fix every preview provider.
 
 > **Dev:** “Why does `/projects/game-timer` look different from `/about`?”  
 > **Domain owner:** “**Portfolio shell** vs **project shell**—projects are immersive; about and home keep the standard site chrome.”
+
+> **Dev:** “On a laptop, why is Game Timer a narrow column?”  
+> **Domain owner:** “**Desktop phone frame** in the **project shell**—same mobile **project**, letterboxed at **`md+`** so we don’t stretch table UI across a 27″ monitor. Fullscreen still blows up the whole tab when you need it.”
 
 > **Dev:** “Why does Game Timer open in a new tab from the drawer?”  
 > **Domain owner:** “**Detached project launch** keeps the gallery/about shell stable while timers or votes run fullscreen in their own tab.”

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "node --experimental-test-module-mocks --test \"src/features/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\"",
+    "test": "node --experimental-test-module-mocks --test \"src/features/**/*.test.js\" \"src/layouts/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\"",
     "dev": "quasar dev",
     "dev:poll": "CHOKIDAR_USEPOLLING=1 CHOKIDAR_INTERVAL=300 quasar dev",
     "convert-dungeon-runner-h5": "node ./scripts/convert-dungeon-runner-h5.mjs",

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -16,6 +16,15 @@ body.project-shell--desktop-frame {
   .project-shell__frame-portal {
     transform: translateZ(0);
   }
+
+  // QPage defaults to min-height: $q.screen.height, which is taller than the framed
+  // column and gets clipped — internal scroll regions and bottom bars never activate.
+  .project-shell__frame-column > .q-page {
+    min-height: 0 !important;
+    height: 100%;
+    max-height: 100%;
+    box-sizing: border-box;
+  }
 }
 
 .body--dark {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -6,6 +6,17 @@
 @use 'sass:color';
 
 @import './gt-ui.scss';
+@import './project-shell-frame-grid.scss';
+
+body.project-shell--desktop-frame {
+  background-color: $dark-page;
+
+  // Contain Quasar `fixed` / `fullscreen` overlays inside the phone-frame column.
+  .project-shell__frame-column,
+  .project-shell__frame-portal {
+    transform: translateZ(0);
+  }
+}
 
 .body--dark {
   background-color: $dark-page;

--- a/src/css/project-shell-frame-grid.scss
+++ b/src/css/project-shell-frame-grid.scss
@@ -1,0 +1,39 @@
+@use 'sass:math';
+
+// Quasar flex grid breakpoints use the browser viewport. Inside the **desktop phone frame**
+// (~390px column) the viewport is still wide, so `col-sm-*` / `col-md-*` would otherwise
+// apply tablet/desktop widths. Clamp grid children to xs-style layout within the frame.
+
+body.project-shell--desktop-frame {
+  .project-shell__frame-column {
+    .row > .col-sm-auto,
+    .row > .col-md-auto,
+    .row > .col-lg-auto,
+    .row > .col-xl-auto {
+      width: 100% !important;
+      max-width: 100% !important;
+      flex: 0 0 100% !important;
+    }
+
+    @for $i from 1 through 12 {
+      .row > .col-sm-#{$i},
+      .row > .col-md-#{$i},
+      .row > .col-lg-#{$i},
+      .row > .col-xl-#{$i} {
+        width: 100% !important;
+        max-width: 100% !important;
+        flex: 0 0 100% !important;
+      }
+
+      .row > .col-#{$i}[class*='col-sm-'],
+      .row > .col-#{$i}[class*='col-md-'],
+      .row > .col-#{$i}[class*='col-lg-'],
+      .row > .col-#{$i}[class*='col-xl-'] {
+        $width: percentage(math.div($i, 12));
+        width: $width !important;
+        max-width: $width !important;
+        flex: 0 0 $width !important;
+      }
+    }
+  }
+}

--- a/src/features/dungeon-runner/nn/nnPipelineTrace.js
+++ b/src/features/dungeon-runner/nn/nnPipelineTrace.js
@@ -1,0 +1,20 @@
+/**
+ * @param {string} channel e.g. 'AITurn' | 'NN'
+ * @param {boolean} enabled
+ * @param {Record<string, unknown>} [baseContext]
+ */
+export function createPipelineStepLogger(channel, enabled, baseContext = {}) {
+  if (!enabled) return () => {}
+  const t0 = performance.now()
+  let tLast = t0
+  return (step, detail = {}) => {
+    const now = performance.now()
+    console.log(`[DungeonRunner][${channel}]`, step, {
+      ...baseContext,
+      ...detail,
+      msTotal: Math.round(now - t0),
+      msStep: Math.round(now - tLast),
+    })
+    tLast = now
+  }
+}

--- a/src/features/dungeon-runner/nn/nnPipelineTrace.test.js
+++ b/src/features/dungeon-runner/nn/nnPipelineTrace.test.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPipelineStepLogger } from './nnPipelineTrace.js'
+
+test('disabled pipeline logger is a no-op', () => {
+  const log = createPipelineStepLogger('NN', false)
+  assert.doesNotThrow(() => log('step', { x: 1 }))
+})

--- a/src/features/dungeon-runner/nn/runtime.js
+++ b/src/features/dungeon-runner/nn/runtime.js
@@ -1,17 +1,63 @@
 import { ACTION_TYPES, getLegalActions } from '../engine/kernel.js'
 import * as tf from '@tensorflow/tfjs'
 import { buildPolicyLegalMask, buildPolicyObservation, decodePolicyIndexToAction } from './policyAdapter.js'
+import { createPipelineStepLogger } from './nnPipelineTrace.js'
 
 const modelCache = new Map()
 let sharedWorker = null
 const workerRequests = new Map()
 let workerRequestId = 1
 let scheduledInferenceQueue = Promise.resolve()
+/**
+ * Main-thread WebGL inference (fast once cached). The TF worker only imports CPU tfjs
+ * and cold predict/load routinely exceeds NN_WORKER_TIMEOUT_MS.
+ */
+let workerPathDisabled = true
+
+export const DEFAULT_NN_WORKER_TIMEOUT_MS = 8_000
+export const DEFAULT_NN_MODEL_LOAD_TIMEOUT_MS = 12_000
+/** Cap time spent in the scheduled inference queue for one sample (0 = no cap). */
+/** Used only when callers explicitly cap inference time (not AI turns during play). */
+export const DEFAULT_NN_INFER_BUDGET_MS = 600
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} timeoutMs
+ * @param {() => Error} createError
+ * @returns {Promise<T>}
+ */
+function promiseWithTimeout(promise, timeoutMs, createError) {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => reject(createError()), timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timeoutId)
+        reject(error)
+      },
+    )
+  })
+}
 
 export async function chooseNnActionWithFallback(state, actor, options) {
+  const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), {
+    modelId: options?.modelId ?? 'latest',
+    seatId: actor.seatId,
+    phase: state.phase,
+    turnNumber: state.turn?.turnNumber,
+  })
+  trace('choose.start', { backend: tf.getBackend() || 'cpu' })
   const legal = getLegalActions(state, actor)
-  if (!legal.length) return null
+  if (!legal.length) {
+    trace('choose.no-legal-actions')
+    return null
+  }
   if (legal.length === 1) {
+    trace('choose.single-legal', { actionType: legal[0].type })
     options?.debugLogger?.({
       kind: 'single-legal',
       legalActions: legal,
@@ -22,11 +68,18 @@ export async function chooseNnActionWithFallback(state, actor, options) {
   }
   const modelId = options?.modelId ?? 'latest'
   const backend = tf.getBackend() || 'cpu'
-  const first = await attemptSample(modelId, state, legal, options)
-  if (first.ok && first.action) return first.action
-  const second = await attemptSample(modelId, state, legal, options)
-  if (second.ok && second.action) return second.action
-  if (!first.ok || !second.ok) {
+  trace('choose.sample.begin', { legalCount: legal.length })
+  const sample = await attemptSample(modelId, state, legal, options)
+  if (sample.ok && sample.action) {
+    if (sample.action.meta?.fallbackReason === 'INFER_BUDGET_EXCEEDED') {
+      trace('choose.fallback-budget', { actionType: sample.action.type })
+    } else {
+      trace('choose.sample.ok', { actionType: sample.action.type, backend: sample.action.meta?.backend })
+    }
+    return sample.action
+  }
+  if (!sample.ok) {
+    trace('choose.sample.failed', { errorMessage: sample.errorMessage })
     const fallback = createFallbackAction(legal, state, {
       backend,
       fallbackReason: 'MODEL_LOAD_FAILED',
@@ -35,8 +88,7 @@ export async function chooseNnActionWithFallback(state, actor, options) {
     options?.debugLogger?.({
       kind: 'fallback',
       fallbackReason: 'MODEL_LOAD_FAILED',
-      firstError: first.errorMessage,
-      secondError: second.errorMessage,
+      firstError: sample.errorMessage,
       legalActions: legal,
       selectedAction: fallback,
       seatId: actor.seatId,
@@ -55,12 +107,55 @@ export async function chooseNnActionWithFallback(state, actor, options) {
     selectedAction: fallback,
     seatId: actor.seatId,
   })
+  trace('choose.fallback', { fallbackReason: 'ILLEGAL_OUTPUT', actionType: fallback.type })
   return fallback
+}
+
+/** Preload TF.js models so the first AI turn does not pay fetch/parse cost. */
+export async function warmNnModelCache(modelIds, options = {}) {
+  const unique = [...new Set((modelIds ?? []).filter(Boolean))]
+  await Promise.all(unique.map((modelId) => loadModel(modelId, options).catch(() => {})))
+}
+
+/** Preload models on the main thread and in the inference worker. */
+export async function warmNnRuntime(modelIds, options = {}) {
+  const unique = [...new Set((modelIds ?? []).filter(Boolean))]
+  await warmNnModelCache(unique, options)
+  if (workerPathDisabled || typeof Worker !== 'function') return
+  await Promise.all(unique.map((modelId) => warmNnWorkerModel(modelId, options).catch(() => {})))
+}
+
+async function warmNnWorkerModel(modelId, options = {}) {
+  const worker = getOrCreateWorker()
+  if (!worker) return
+  const requestId = `warm-${workerRequestId++}`
+  const timeoutMs = options.loadTimeoutMs ?? DEFAULT_NN_MODEL_LOAD_TIMEOUT_MS
+  await promiseWithTimeout(
+    new Promise((resolve, reject) => {
+      workerRequests.set(requestId, { resolve, reject })
+      worker.postMessage({ kind: 'warm', requestId, modelId })
+    }),
+    timeoutMs,
+    () => new Error('NN_WORKER_WARM_TIMEOUT'),
+  )
+  workerRequests.delete(requestId)
 }
 
 async function attemptSample(modelId, state, legal, options) {
   try {
-    return { ok: true, action: await sampleAction(modelId, state, legal, options), errorMessage: null }
+    const sample = await sampleAction(modelId, state, legal, options)
+    if (sample.inferBudgetExceeded) {
+      return {
+        ok: true,
+        action: createFallbackAction(legal, state, {
+          backend: tf.getBackend() || 'cpu',
+          fallbackReason: 'INFER_BUDGET_EXCEEDED',
+          modelId,
+        }),
+        errorMessage: null,
+      }
+    }
+    return { ok: true, action: sample.action, errorMessage: null }
   } catch (error) {
     return {
       ok: false,
@@ -71,48 +166,124 @@ async function attemptSample(modelId, state, legal, options) {
 }
 
 async function sampleAction(modelId, state, legal, options) {
-  const sampled = await runScheduledInference(async () => {
+  const budgetMs = options?.inferBudgetMs ?? 0
+  const inferTask = () => runScheduledInference(async () => {
     return inferActionWithBestRuntime(modelId, state, legal, options)
-  })
-  if (!sampled || !legal.some((action) => action.type === sampled.type)) return null
+  }, options)
+  let sampled
+  if (budgetMs > 0) {
+    const raced = await Promise.race([
+      inferTask().then((value) => ({ kind: 'ok', value })),
+      new Promise((resolve) => {
+        setTimeout(() => resolve({ kind: 'timeout' }), budgetMs)
+      }),
+    ])
+    if (raced.kind === 'timeout') {
+      return { action: null, inferBudgetExceeded: true }
+    }
+    sampled = raced.value
+  } else {
+    sampled = await inferTask()
+  }
+  if (!sampled || !legal.some((action) => action.type === sampled.type)) {
+    return { action: null, inferBudgetExceeded: false }
+  }
   if (sampled.__debug && typeof options?.debugLogger === 'function') {
     options.debugLogger(sampled.__debug)
   }
   return {
-    ...sampled,
-    meta: {
-      backend: sampled.backend ?? tf.getBackend() ?? 'cpu',
-      modelId: sampled.modelId ?? modelId,
+    action: {
+      ...sampled,
+      meta: {
+        backend: sampled.backend ?? tf.getBackend() ?? 'cpu',
+        modelId: sampled.modelId ?? modelId,
+      },
     },
+    inferBudgetExceeded: false,
   }
 }
 
-async function runScheduledInference(task) {
-  const current = scheduledInferenceQueue.catch(() => {}).then(task)
+/** Drop queued inference waiters so a new sample is not blocked by an abandoned prefetch. */
+export function abandonScheduledInferenceQueue() {
+  scheduledInferenceQueue = Promise.resolve()
+}
+
+async function runScheduledInference(task, options) {
+  const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), {
+    modelId: options?.modelId ?? 'latest',
+  })
+  const queueWaitStart = performance.now()
+  let queueEntered = false
+  const current = scheduledInferenceQueue.catch(() => {}).then(async () => {
+    if (!queueEntered) {
+      queueEntered = true
+      trace('inference.queue.enter', { queueWaitMs: Math.round(performance.now() - queueWaitStart) })
+    }
+    return task()
+  })
   scheduledInferenceQueue = current
   return current
 }
 
-async function loadModel(modelId) {
+async function loadModel(modelId, options = {}) {
+  const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), { modelId })
   if (modelId.startsWith('missing')) throw new Error('missing model')
-  if (modelCache.has(modelId)) return modelCache.get(modelId)
+  if (modelCache.has(modelId)) {
+    trace('model.cache-hit')
+    return modelCache.get(modelId)
+  }
   const baseUrl = import.meta.env?.BASE_URL ?? '/'
   const prefix = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
   const modelUrl = `${prefix}models/dungeon-runner/${modelId}/model.json?ts=${Date.now()}`
-  const model = await tf.loadLayersModel(modelUrl, { requestInit: { cache: 'no-store' } })
+  const timeoutMs = options.loadTimeoutMs ?? DEFAULT_NN_MODEL_LOAD_TIMEOUT_MS
+  trace('model.load.begin', { modelUrl, timeoutMs })
+  const loadStart = performance.now()
+  const model = await promiseWithTimeout(
+    tf.loadLayersModel(modelUrl, { requestInit: { cache: 'no-store' } }),
+    timeoutMs,
+    () => new Error('MODEL_LOAD_TIMEOUT'),
+  )
+  trace('model.load.done', { loadMs: Math.round(performance.now() - loadStart) })
   modelCache.set(modelId, model)
   return model
 }
 
 async function inferActionWithBestRuntime(modelId, state, legal, options) {
+  const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), {
+    modelId,
+    seatId: state.turn?.activeSeatId,
+  })
   const backendHint = tf.getBackend() || 'cpu'
   const randomSeed = createSamplingSeed(state, modelId, backendHint)
-  if (typeof Worker === 'function') {
-    const workerAction = await inferActionViaWorker(modelId, state, legal, options, randomSeed)
-    if (workerAction) return workerAction
+  trace('infer.begin', { backend: backendHint, workerPathDisabled, legalCount: legal.length })
+  if (typeof Worker === 'function' && !workerPathDisabled) {
+    try {
+      trace('infer.worker.begin')
+      const workerStart = performance.now()
+      const workerAction = await inferActionViaWorker(modelId, state, legal, options, randomSeed)
+      trace('infer.worker.done', {
+        workerMs: Math.round(performance.now() - workerStart),
+        hasAction: Boolean(workerAction),
+      })
+      if (workerAction) return workerAction
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      trace('infer.worker.error', { message })
+      if (message === 'NN_WORKER_TIMEOUT') {
+        terminateSharedWorker()
+      }
+    }
   }
-  const model = await loadModel(modelId)
+  if (options?.allowMainThreadInfer === false) {
+    return null
+  }
+  const model = await loadModel(modelId, options)
+  const predictStart = performance.now()
   const action = await inferAction(model, state, legal, options, randomSeed)
+  trace('infer.main-thread.done', {
+    predictMs: Math.round(performance.now() - predictStart),
+    actionType: action?.type,
+  })
   return {
     ...action,
     backend: backendHint,
@@ -121,14 +292,18 @@ async function inferActionWithBestRuntime(modelId, state, legal, options) {
 }
 
 async function inferAction(model, state, legal, options, randomSeed) {
+  const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), { seatId: state.turn?.activeSeatId })
   const features = buildPolicyObservation(state, { seatId: state.turn.activeSeatId })
   const legalMask = buildPolicyLegalMask(state, { seatId: state.turn.activeSeatId }, legal)
   const obsInput = tf.tensor2d([features])
   const modelInputs = Array.isArray(model.inputs) ? model.inputs.length : 1
   const maskInput = modelInputs > 1 ? tf.tensor2d([legalMask]) : null
+  trace('predict.begin', { modelInputs, featureLen: features.length })
+  const predictStart = performance.now()
   const prediction = maskInput ? model.predict([obsInput, maskInput]) : model.predict(obsInput)
   const logitsTensor = selectPolicyLogitsTensor(prediction)
   const values = Array.from(await logitsTensor.data())
+  trace('predict.done', { predictMs: Math.round(performance.now() - predictStart), logitLen: values.length })
   obsInput.dispose()
   maskInput?.dispose()
   disposePrediction(prediction)
@@ -151,25 +326,42 @@ async function inferActionViaWorker(modelId, state, legal, options, randomSeed) 
   const requestId = `req-${workerRequestId++}`
   const seatId = state.turn.activeSeatId
   const seatLoadout = seatId ? [...(state.heroLoadout?.[seatId] ?? [])] : []
-  return new Promise((resolve, reject) => {
-    workerRequests.set(requestId, {
-      resolve,
-      reject,
-    })
-    worker.postMessage({
-      requestId,
-      modelId,
-      samplingMode: options?.samplingMode ?? 'stochastic',
-      randomSeed,
-      debugTrace: true,
-      legalMask: buildPolicyLegalMask(state, { seatId: state.turn.activeSeatId }, legal),
-      legalActions: legal,
-      features: buildPolicyObservation(state, { seatId }),
-      hero: state.hero,
-      activeSeatId: seatId,
-      seatLoadout,
-    })
-  })
+  const timeoutMs = options?.workerTimeoutMs ?? DEFAULT_NN_WORKER_TIMEOUT_MS
+  const payload = {
+    requestId,
+    modelId,
+    samplingMode: options?.samplingMode ?? 'stochastic',
+    randomSeed,
+    debugTrace: true,
+    legalMask: buildPolicyLegalMask(state, { seatId: state.turn.activeSeatId }, legal),
+    legalActions: legal,
+    features: buildPolicyObservation(state, { seatId }),
+    hero: state.hero,
+    activeSeatId: seatId,
+    seatLoadout,
+  }
+
+  const response = await promiseWithTimeout(
+    new Promise((resolve, reject) => {
+      workerRequests.set(requestId, { resolve, reject })
+      worker.postMessage(payload)
+    }),
+    timeoutMs,
+    () => new Error('NN_WORKER_TIMEOUT'),
+  )
+
+  workerRequests.delete(requestId)
+  return response
+}
+
+function terminateSharedWorker() {
+  if (!sharedWorker) return
+  for (const pending of workerRequests.values()) {
+    pending.reject(new Error('NN_WORKER_TERMINATED'))
+  }
+  workerRequests.clear()
+  sharedWorker.terminate()
+  sharedWorker = null
 }
 
 function getOrCreateWorker() {
@@ -184,6 +376,10 @@ function getOrCreateWorker() {
       workerRequests.delete(data.requestId)
       if (data.error) {
         pending.reject(new Error(data.error))
+        return
+      }
+      if (data.warmed) {
+        pending.resolve(null)
         return
       }
       pending.resolve(
@@ -332,12 +528,9 @@ function seededRandomFactory(seed) {
 }
 
 export function resetNnRuntimeForTests() {
-  if (sharedWorker) {
-    sharedWorker.terminate()
-    sharedWorker = null
-  }
-  workerRequests.clear()
+  terminateSharedWorker()
   workerRequestId = 1
   scheduledInferenceQueue = Promise.resolve()
   modelCache.clear()
+  workerPathDisabled = false
 }

--- a/src/features/dungeon-runner/nn/runtime.test.js
+++ b/src/features/dungeon-runner/nn/runtime.test.js
@@ -156,7 +156,7 @@ test('nn runtime uses worker path when available', async () => {
   }
 })
 
-test('nn runtime retries once before illegal-output fallback', async () => {
+test('nn runtime falls back on illegal worker output without retrying', async () => {
   const originalWorker = globalThis.Worker
   let calls = 0
   class FakeWorker {
@@ -190,7 +190,7 @@ test('nn runtime retries once before illegal-output fallback', async () => {
     )
     const seatId = state.turn.activeSeatId
     const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
-    assert.equal(calls, 2)
+    assert.equal(calls, 1)
     const legal = getLegalActions(state, { seatId })
     assert.equal(legal.some((candidate) => candidate.type === action.type), true)
     assert.equal(action.meta.fallbackReason, 'ILLEGAL_OUTPUT')
@@ -200,7 +200,7 @@ test('nn runtime retries once before illegal-output fallback', async () => {
   }
 })
 
-test('nn runtime retries once before model-load-failed fallback', async () => {
+test('nn runtime falls back on model-load failure without retrying', async () => {
   const originalWorker = globalThis.Worker
   let calls = 0
   class FakeWorker {
@@ -227,7 +227,7 @@ test('nn runtime retries once before model-load-failed fallback', async () => {
     )
     const seatId = state.turn.activeSeatId
     const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
-    assert.equal(calls, 2)
+    assert.equal(calls, 1)
     const legal = getLegalActions(state, { seatId })
     assert.equal(legal.some((candidate) => candidate.type === action.type), true)
     assert.equal(action.meta.fallbackReason, 'MODEL_LOAD_FAILED')
@@ -345,6 +345,44 @@ test('nn runtime emits debug trace on model-load fallback path', async () => {
   assert.equal(traces.at(-1).fallbackReason, 'MODEL_LOAD_FAILED')
 })
 
+test('hanging worker times out and falls back without blocking the inference queue', async () => {
+  const originalWorker = globalThis.Worker
+  class HangingWorker {
+    constructor() {
+      this.onmessage = null
+      this.onerror = null
+    }
+
+    postMessage() {
+      // Intentionally never responds.
+    }
+
+    terminate() {}
+  }
+  globalThis.Worker = HangingWorker
+  resetNnRuntimeForTests()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 153 },
+    )
+    const seatId = state.turn.activeSeatId
+    const started = Date.now()
+    const action = await chooseNnActionWithFallback(state, { seatId }, {
+      modelId: 'latest',
+      workerTimeoutMs: 40,
+      loadTimeoutMs: 40,
+    })
+    const elapsed = Date.now() - started
+    const legal = getLegalActions(state, { seatId })
+    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+    assert.ok(elapsed < 500, `expected bounded inference time, got ${elapsed}ms`)
+  } finally {
+    globalThis.Worker = originalWorker
+    resetNnRuntimeForTests()
+  }
+})
+
 test('worker-side model load errors do not masquerade as pass actions', async () => {
   const originalWorker = globalThis.Worker
   class FakeWorker {
@@ -378,6 +416,53 @@ test('worker-side model load errors do not masquerade as pass actions', async ()
     const legal = getLegalActions(state, { seatId })
     assert.equal(legal.some((candidate) => candidate.type === action.type), true)
     assert.equal(action.meta?.fallbackReason, 'MODEL_LOAD_FAILED')
+  } finally {
+    globalThis.Worker = originalWorker
+    resetNnRuntimeForTests()
+  }
+})
+
+test('inferBudgetMs falls back without waiting for slow inference', async () => {
+  const originalWorker = globalThis.Worker
+  class SlowWorker {
+    constructor() {
+      this.onmessage = null
+      this.onerror = null
+    }
+
+    postMessage(payload) {
+      setTimeout(() => {
+        this.onmessage?.({
+          data: {
+            requestId: payload.requestId,
+            action: { type: 'PASS' },
+            backend: 'webgl',
+            modelId: payload.modelId,
+          },
+        })
+      }, 500)
+    }
+
+    terminate() {}
+  }
+  globalThis.Worker = SlowWorker
+  resetNnRuntimeForTests()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 153 },
+    )
+    const seatId = state.turn.activeSeatId
+    const start = performance.now()
+    const action = await chooseNnActionWithFallback(state, { seatId }, {
+      modelId: 'latest',
+      inferBudgetMs: 40,
+    })
+    const elapsed = performance.now() - start
+    assert.ok(elapsed < 250, `expected budget cap, got ${elapsed}ms`)
+    const legal = getLegalActions(state, { seatId })
+    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+    assert.equal(action.meta.fallbackReason, 'INFER_BUDGET_EXCEEDED')
   } finally {
     globalThis.Worker = originalWorker
     resetNnRuntimeForTests()

--- a/src/features/dungeon-runner/nn/runtime.worker.js
+++ b/src/features/dungeon-runner/nn/runtime.worker.js
@@ -5,6 +5,18 @@ const modelCache = new Map()
 
 self.onmessage = async (event) => {
   const data = event?.data ?? {}
+  if (data.kind === 'warm') {
+    try {
+      await loadModel(data.modelId)
+      self.postMessage({ requestId: data.requestId, warmed: true })
+    } catch (error) {
+      self.postMessage({
+        requestId: data.requestId,
+        error: error instanceof Error ? error.message : 'MODEL_LOAD_FAILED',
+      })
+    }
+    return
+  }
   const { requestId, modelId, legalActions, legalMask, features, samplingMode, randomSeed, debugTrace, hero, activeSeatId, seatLoadout } = data
   try {
     const model = await loadModel(modelId)

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js
@@ -1,0 +1,82 @@
+/** @type {{ runToken: string, promise: Promise<{ runToken: string, action: object|null }> } | null} */
+let prefetchEntry = null
+/** @type {string | null} */
+let lastPrefetchSkipLogKey = null
+
+export function resetAiTurnPrefetch() {
+  prefetchEntry = null
+  lastPrefetchSkipLogKey = null
+}
+
+/**
+ * @param {{
+ *   runToken: string
+ *   compute: () => Promise<object|null>
+ *   trace?: (step: string, detail?: Record<string, unknown>) => void
+ * }} params
+ */
+export function startAiTurnPrefetch({ runToken, compute, trace }) {
+  if (!runToken) return
+  if (prefetchEntry?.runToken === runToken) {
+    const skipKey = `already-in-flight:${runToken}`
+    if (lastPrefetchSkipLogKey !== skipKey) {
+      lastPrefetchSkipLogKey = skipKey
+      trace?.('prefetch.skip', { reason: 'already-in-flight', runToken })
+    }
+    return
+  }
+  if (prefetchEntry && prefetchEntry.runToken !== runToken) {
+    trace?.('prefetch.supersede', { fromToken: prefetchEntry.runToken, runToken })
+    prefetchEntry = null
+  }
+  lastPrefetchSkipLogKey = null
+  trace?.('prefetch.start', { runToken })
+  const startMs = performance.now()
+  prefetchEntry = {
+    runToken,
+    promise: compute()
+      .then((action) => {
+        trace?.('prefetch.done', {
+          runToken,
+          actionType: action?.type ?? null,
+          ms: Math.round(performance.now() - startMs),
+        })
+        return { runToken, action: action ?? null }
+      })
+      .catch((error) => {
+        trace?.('prefetch.error', {
+          runToken,
+          message: error instanceof Error ? error.message : String(error),
+          ms: Math.round(performance.now() - startMs),
+        })
+        throw error
+      }),
+  }
+}
+
+/**
+ * @param {string} runToken
+ * @param {(step: string, detail?: Record<string, unknown>) => void} [trace]
+ * @returns {Promise<object|null>}
+ */
+export async function consumeAiTurnPrefetch(runToken, trace) {
+  if (!prefetchEntry || prefetchEntry.runToken !== runToken) {
+    trace?.('prefetch.consume.miss', {
+      runToken,
+      hasEntry: Boolean(prefetchEntry),
+      entryToken: prefetchEntry?.runToken ?? null,
+    })
+    return null
+  }
+  trace?.('prefetch.consume.await', { runToken })
+  const waitStart = performance.now()
+  const result = await prefetchEntry.promise
+  trace?.('prefetch.consume.resolved', { runToken, waitMs: Math.round(performance.now() - waitStart) })
+  prefetchEntry = null
+  if (result.runToken !== runToken) {
+    trace?.('prefetch.consume.stale', { runToken, resultToken: result.runToken })
+    return null
+  }
+  trace?.('prefetch.consume.hit', { runToken, actionType: result.action?.type ?? null })
+  return result.action
+}

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.test.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  consumeAiTurnPrefetch,
+  resetAiTurnPrefetch,
+  startAiTurnPrefetch,
+} from './dungeonRunnerAiTurnPrefetch.js'
+
+test('prefetch is consumed only for the matching run token', async () => {
+  resetAiTurnPrefetch()
+  startAiTurnPrefetch({
+    runToken: 'a',
+    compute: async () => ({ type: 'PASS' }),
+  })
+  assert.deepEqual(await consumeAiTurnPrefetch('a', () => {}), { type: 'PASS' })
+  assert.equal(await consumeAiTurnPrefetch('a', () => {}), null)
+})
+
+test('stale prefetch token is ignored', async () => {
+  resetAiTurnPrefetch()
+  startAiTurnPrefetch({
+    runToken: 'a',
+    compute: async () => ({ type: 'DRAW' }),
+  })
+  assert.equal(await consumeAiTurnPrefetch('b', () => {}), null)
+  assert.deepEqual(await consumeAiTurnPrefetch('a', () => {}), { type: 'DRAW' })
+})
+
+test('duplicate in-flight prefetch logs skip once per run token', async () => {
+  resetAiTurnPrefetch()
+  const skipSteps = []
+  const trace = (step) => {
+    skipSteps.push(step)
+  }
+  let resolveCompute
+  startAiTurnPrefetch({
+    runToken: 'a',
+    trace,
+    compute: () => new Promise((resolve) => {
+      resolveCompute = resolve
+    }),
+  })
+  startAiTurnPrefetch({ runToken: 'a', trace, compute: async () => ({ type: 'PASS' }) })
+  startAiTurnPrefetch({ runToken: 'a', trace, compute: async () => ({ type: 'PASS' }) })
+  assert.deepEqual(
+    skipSteps.filter((step) => step === 'prefetch.skip'),
+    ['prefetch.skip'],
+  )
+  resolveCompute({ type: 'DRAW' })
+  await consumeAiTurnPrefetch('a', () => {})
+})
+
+test('new run token supersedes in-flight prefetch', async () => {
+  resetAiTurnPrefetch()
+  const steps = []
+  const trace = (step) => {
+    steps.push(step)
+  }
+  let resolveA
+  startAiTurnPrefetch({
+    runToken: 'a',
+    trace,
+    compute: () => new Promise((resolve) => {
+      resolveA = resolve
+    }),
+  })
+  startAiTurnPrefetch({
+    runToken: 'b',
+    trace,
+    compute: async () => ({ type: 'PASS' }),
+  })
+  assert.ok(steps.includes('prefetch.supersede'))
+  assert.deepEqual(await consumeAiTurnPrefetch('b', trace), { type: 'PASS' })
+  resolveA({ type: 'DRAW' })
+  assert.equal(await consumeAiTurnPrefetch('a', trace), null)
+})
+
+test('consume awaits in-flight prefetch to completion', async () => {
+  resetAiTurnPrefetch()
+  const steps = []
+  const trace = (step) => {
+    steps.push(step)
+  }
+  startAiTurnPrefetch({
+    runToken: 'a',
+    trace,
+    compute: () => new Promise((resolve) => {
+      setTimeout(() => resolve({ type: 'DRAW' }), 40)
+    }),
+  })
+  const action = await consumeAiTurnPrefetch('a', trace)
+  assert.deepEqual(action, { type: 'DRAW' })
+  assert.ok(steps.includes('prefetch.consume.hit'))
+  assert.equal(steps.includes('prefetch.consume.timeout'), false)
+})

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnToken.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnToken.js
@@ -1,0 +1,26 @@
+import { MATCH_PHASES } from '../engine/kernel.js'
+
+/**
+ * Stable id for one AI decision point. Dedupes interval/watch reschedules without
+ * blocking multi-step bidding (draw then resolve) or dungeon runner subphases.
+ *
+ * @param {{ matchId: string, state: object }} params
+ */
+export function buildAiTurnRunToken({ matchId, state }) {
+  if (!matchId || !state) return ''
+  const seatId = state.turn?.activeSeatId ?? ''
+  const parts = [matchId, String(state.turn?.turnNumber ?? ''), state.phase ?? '', seatId]
+
+  if (state.phase === MATCH_PHASES.BIDDING) {
+    parts.push(state.bidding?.subphase ?? '')
+    parts.push(state.bidding?.revealedMonsterCard ?? '')
+  } else if (state.phase === MATCH_PHASES.DUNGEON) {
+    parts.push(state.dungeon?.subphase ?? '')
+    parts.push(state.dungeon?.currentMonster ?? '')
+    parts.push(String(Array.isArray(state.dungeon?.remainingMonsters) ? state.dungeon.remainingMonsters.length : ''))
+  }
+
+  parts.push(String(state.rng?.step ?? ''))
+
+  return parts.join(':')
+}

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnToken.test.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnToken.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIDDING_SUBPHASES, DUNGEON_SUBPHASES, MATCH_PHASES } from '../engine/kernel.js'
+import { buildAiTurnRunToken } from './dungeonRunnerAiTurnToken.js'
+
+test('bidding draw and follow-up resolve use different tokens at the same turn number', () => {
+  const matchId = 'match-1'
+  const beforeDraw = {
+    turn: { turnNumber: 1, activeSeatId: 'seat-3' },
+    phase: MATCH_PHASES.BIDDING,
+    bidding: { subphase: BIDDING_SUBPHASES.TURN, revealedMonsterCard: null },
+  }
+  const afterDraw = {
+    ...beforeDraw,
+    bidding: { subphase: BIDDING_SUBPHASES.PENDING, revealedMonsterCard: 'goblin-1' },
+  }
+
+  assert.notEqual(
+    buildAiTurnRunToken({ matchId, state: beforeDraw }),
+    buildAiTurnRunToken({ matchId, state: afterDraw }),
+  )
+})
+
+test('dungeon runner subphases are distinct tokens for the same turn number', () => {
+  const matchId = 'match-1'
+  const base = {
+    turn: { turnNumber: 4, activeSeatId: 'seat-2' },
+    phase: MATCH_PHASES.DUNGEON,
+    rng: { seed: 1, state: 2, step: 10 },
+  }
+  const vorpal = { ...base, dungeon: { subphase: DUNGEON_SUBPHASES.VORPAL, remainingMonsters: [] } }
+  const reveal = { ...base, dungeon: { subphase: DUNGEON_SUBPHASES.REVEAL, remainingMonsters: [] } }
+
+  assert.notEqual(
+    buildAiTurnRunToken({ matchId, state: vorpal }),
+    buildAiTurnRunToken({ matchId, state: reveal }),
+  )
+})
+
+test('dungeon reveal loop steps differ while subphase stays reveal', () => {
+  const matchId = 'match-1'
+  const afterReveal = {
+    turn: { turnNumber: 17, activeSeatId: 'seat-4' },
+    phase: MATCH_PHASES.DUNGEON,
+    rng: { seed: 9, state: 100, step: 42 },
+    dungeon: {
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: 'goblin',
+      remainingMonsters: ['orc', 'troll'],
+    },
+  }
+  const afterCombat = {
+    ...afterReveal,
+    rng: { seed: 9, state: 101, step: 43 },
+    dungeon: {
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['orc', 'troll'],
+    },
+  }
+
+  assert.notEqual(
+    buildAiTurnRunToken({ matchId, state: afterReveal }),
+    buildAiTurnRunToken({ matchId, state: afterCombat }),
+  )
+})
+
+test('identical decision points produce identical tokens', () => {
+  const matchId = 'match-1'
+  const state = {
+    turn: { turnNumber: 2, activeSeatId: 'seat-1' },
+    phase: MATCH_PHASES.BIDDING,
+    bidding: { subphase: BIDDING_SUBPHASES.TURN, revealedMonsterCard: null },
+  }
+
+  assert.equal(
+    buildAiTurnRunToken({ matchId, state }),
+    buildAiTurnRunToken({ matchId, state: { ...state, rng: { seed: 99 } } }),
+  )
+})

--- a/src/features/dungeon-runner/ui/presentationMotionRegistry.js
+++ b/src/features/dungeon-runner/ui/presentationMotionRegistry.js
@@ -43,6 +43,39 @@ function ghostFlightTargetRect(el) {
 }
 
 /**
+ * Viewport rects → clone `left`/`top` for ghost flight. Prefer layer-local `absolute`
+ * coords on `presentationFlightLayer` so motion stays aligned when an ancestor (project
+ * shell desktop frame) uses `transform` and re-parents `position: fixed`.
+ *
+ * @param {Element | null | undefined} flightRoot
+ * @param {DOMRect} srcRect
+ * @param {DOMRect} dstRect
+ */
+function ghostFlightCloneCoords(flightRoot, srcRect, dstRect) {
+  const endLeft = dstRect.left + dstRect.width / 2 - srcRect.width / 2
+  const endTop = dstRect.top + dstRect.height / 2 - srcRect.height / 2
+
+  if (isDomElement(flightRoot) && typeof flightRoot.getBoundingClientRect === 'function') {
+    const rootRect = flightRoot.getBoundingClientRect()
+    return {
+      position: 'absolute',
+      startLeft: srcRect.left - rootRect.left,
+      startTop: srcRect.top - rootRect.top,
+      endLeft: endLeft - rootRect.left,
+      endTop: endTop - rootRect.top,
+    }
+  }
+
+  return {
+    position: 'fixed',
+    startLeft: srcRect.left,
+    startTop: srcRect.top,
+    endLeft,
+    endTop,
+  }
+}
+
+/**
  * @param {Element} fromEl
  * @param {Element} toEl
  * @returns {{ dx: number, dy: number, ok: boolean }}
@@ -291,10 +324,16 @@ function addEquipmentActivationGhostFlights(gsapApi, tl, ctx, flightOpts = {}) {
       )
     }
 
+    const flightCoords = ghostFlightCloneCoords(
+      mount === flightRoot ? flightRoot : null,
+      srcRect,
+      dstRect,
+    )
+
     set(clone, {
-      position: 'fixed',
-      left: srcRect.left,
-      top: srcRect.top,
+      position: flightCoords.position,
+      left: flightCoords.startLeft,
+      top: flightCoords.startTop,
       width: srcRect.width,
       height: srcRect.height,
       maxWidth: srcRect.width,
@@ -306,14 +345,11 @@ function addEquipmentActivationGhostFlights(gsapApi, tl, ctx, flightOpts = {}) {
       overflow: 'hidden',
     })
 
-    const destLeft = dstRect.left + dstRect.width / 2 - srcRect.width / 2
-    const destTop = dstRect.top + dstRect.height / 2 - srcRect.height / 2
-
     tl.to(
       clone,
       {
-        left: destLeft,
-        top: destTop,
+        left: flightCoords.endLeft,
+        top: flightCoords.endTop,
         duration: flightDur,
         ease: 'power2.inOut',
       },
@@ -334,7 +370,7 @@ function addEquipmentActivationGhostFlights(gsapApi, tl, ctx, flightOpts = {}) {
  * - **`dungeonCardFlipAxis`** — inner flip pivot in `MonsterCardFace` (`transform-style: preserve-3d`). `DUNGEON_REVEAL` tweens `rotationY` 0→180 here; inline props cleared on teardown so settled rotation comes from the card’s CSS when `faceDown` is false.
  * - **`deckBadge`** — deck pile control; `BIDDING_ADD` / `BIDDING_DRAW` anchor deck motion here.
  * - **`heroChangeInterstitialOverlay`** — full-screen `.dr-hero-interstitial` control. `HERO_CHANGE_INTERSTITIAL` runs entrance / hold / exit here only (the board shell is not tweened for this beat).
- * - **`presentationFlightLayer`** — absolutely positioned, `pointer-events: none` host for fixed-position equipment ghost clones (`DUNGEON_NEUTRALIZE`, `BIDDING_SACRIFICE`).
+ * - **`presentationFlightLayer`** — absolutely positioned, `pointer-events: none` host for equipment ghost clones (`DUNGEON_NEUTRALIZE`, `BIDDING_SACRIFICE`); clones use layer-local `absolute` coords (not viewport `fixed`).
  * - **`equipment_<id>`** — in-play equipment token cell. Iterated from `payload.responsibleEquipmentIds` (`consumedEquipmentIds` retained as a back-compat alias). Source tile dims when `id` is in `payload.expendedEquipmentIds`; otherwise it gets a brief sunlight-colored activation pulse during the ghost flight.
  *
  * @typedef {{

--- a/src/features/dungeon-runner/ui/presentationMotionRegistry.test.js
+++ b/src/features/dungeon-runner/ui/presentationMotionRegistry.test.js
@@ -490,6 +490,7 @@ test('bot bidding sacrifice factory ghost-flies consumed equipment to card and p
   const flightLayer = {
     nodeType: 1,
     appended: [],
+    getBoundingClientRect: () => ({ left: 50, top: 50, width: 400, height: 600 }),
     appendChild(n) {
       this.appended.push(n)
     },
@@ -542,7 +543,20 @@ test('bot bidding sacrifice factory ghost-flies consumed equipment to card and p
   })
 
   assert.equal(flightLayer.appended.length, 1)
-  assert.ok(toCalls.some((c) => c.target === flightLayer.appended[0] && c.vars?.ease === 'power2.inOut'))
+  const ghost = flightLayer.appended[0]
+  const ghostSet = sets.find((s) => s.el === ghost)
+  assert.equal(ghostSet?.props?.position, 'absolute')
+  assert.equal(ghostSet?.props?.left, -50)
+  assert.equal(ghostSet?.props?.top, 450)
+  assert.ok(
+    toCalls.some(
+      (c) =>
+        c.target === ghost &&
+        c.vars?.ease === 'power2.inOut' &&
+        c.vars?.left === 114 &&
+        c.vars?.top === 84,
+    ),
+  )
   assert.ok(sets.some((s) => s.el === badge && s.props.opacity === 0.38))
   assert.ok(fromToCalls.some((c) => c.target === card && c.fromVars?.filter === 'brightness(1)'))
   assert.ok(toCalls.some((c) => c.target === card && Number(c.vars?.x ?? 0) > 50))
@@ -1183,6 +1197,7 @@ test('dungeon neutralize factory ghost-flies consumed equipment toward card with
   const flightLayer = {
     nodeType: 1,
     appended: [],
+    getBoundingClientRect: () => ({ left: 40, top: 20, width: 400, height: 600 }),
     appendChild(n) {
       this.appended.push(n)
     },
@@ -1229,7 +1244,9 @@ test('dungeon neutralize factory ghost-flies consumed equipment toward card with
   })
 
   assert.equal(flightLayer.appended.length, 1)
-  assert.ok(toCalls.some((c) => c.target === flightLayer.appended[0]))
+  const ghost = flightLayer.appended[0]
+  assert.equal(sets.find((s) => s.el === ghost)?.props?.position, 'absolute')
+  assert.ok(toCalls.some((c) => c.target === ghost))
   assert.ok(sets.some((s) => s.el === badge && s.props.opacity === 0.38))
   assert.ok(fromToCalls.some((c) => c.target === card && c.fromVars?.x === 0))
 })

--- a/src/layouts/projects/ProjectShellLayout.vue
+++ b/src/layouts/projects/ProjectShellLayout.vue
@@ -1,36 +1,187 @@
 <script setup>
+import { computed, nextTick, onUnmounted, watch } from 'vue'
+import { Notify, useQuasar } from 'quasar'
 import { useTrapBrowserBack } from '../../composables/useTrapBrowserBack.js'
+import { getDesktopPhoneFrameLayout } from './desktopPhoneFrame.js'
+import {
+  PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS,
+  PROJECT_SHELL_FRAME_GUTTER_BG_CLASS,
+  PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID,
+  PROJECT_SHELL_FRAME_PORTAL_LAYER_CLASS,
+  resolveProjectShellFrameColumnInlineStyle,
+  resolveProjectShellFrameGutterInlineStyle,
+  resolveProjectShellOverlayPortalMount,
+} from './projectShellFrame.js'
+import {
+  resetProjectShellOverlayPortalTarget,
+  syncProjectShellOverlayPortalTarget,
+} from './projectShellOverlayPortal.js'
+import {
+  syncProjectShellLayoutNotifyFrame,
+  teardownProjectShellLayoutNotifyFrame,
+} from './projectShellLayoutNotify.js'
 
 useTrapBrowserBack()
+
+const $q = useQuasar()
+
+const frameLayout = computed(() =>
+  getDesktopPhoneFrameLayout({
+    viewportWidthPx: $q.screen.width,
+    viewportHeightPx: $q.screen.height,
+  }),
+)
+
+const desktopFrameActive = computed(() => frameLayout.value.active)
+
+const frameGutterStyle = computed(() =>
+  resolveProjectShellFrameGutterInlineStyle(frameLayout.value),
+)
+
+const frameColumnStyle = computed(() =>
+  resolveProjectShellFrameColumnInlineStyle(frameLayout.value),
+)
+
+watch(
+  desktopFrameActive,
+  (active) => {
+    if (typeof document === 'undefined') return
+    document.body.classList.toggle(PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS, active)
+    const syncOverlayPortal = () => syncProjectShellOverlayPortalTarget(active)
+
+    nextTick(() => {
+      syncOverlayPortal()
+      if (active && resolveProjectShellOverlayPortalMount(true) == null) {
+        nextTick(syncOverlayPortal)
+      }
+      const syncNotifyFrame = () => {
+        const notifyReady = syncProjectShellLayoutNotifyFrame({
+          notifyApi: Notify,
+          frameActive: active,
+        })
+        if (active && !notifyReady) {
+          nextTick(syncNotifyFrame)
+        }
+      }
+      syncNotifyFrame()
+    })
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  if (typeof document === 'undefined') return
+  document.body.classList.remove(PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS)
+  resetProjectShellOverlayPortalTarget()
+  teardownProjectShellLayoutNotifyFrame({ notifyApi: Notify })
+})
 </script>
 
 <template>
   <!-- No app bar: mobile-style full-height shell (see Quasar `view` — `l` = no header band). -->
-  <q-layout view="lHh Lpr fFf" class="project-shell">
+  <q-layout
+    view="lHh Lpr fFf"
+    class="project-shell"
+    :class="{ [PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS]: desktopFrameActive }"
+  >
     <q-page-container class="project-shell__page-container">
-      <router-view />
+      <div
+        class="project-shell__frame-root"
+        :class="{
+          [`project-shell__frame-gutter ${PROJECT_SHELL_FRAME_GUTTER_BG_CLASS}`]:
+            desktopFrameActive,
+        }"
+        :style="frameGutterStyle"
+      >
+        <div
+          class="project-shell__frame-inner"
+          :class="{ 'project-shell__frame-column': desktopFrameActive }"
+          :style="frameColumnStyle"
+        >
+          <router-view />
+          <div
+            v-if="desktopFrameActive"
+            :id="PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID"
+            :class="PROJECT_SHELL_FRAME_PORTAL_LAYER_CLASS"
+          />
+        </div>
+      </div>
     </q-page-container>
   </q-layout>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .project-shell {
   min-height: 100vh;
 }
 
+.project-shell.project-shell--desktop-frame {
+  background-color: $dark-page;
+}
+
 .project-shell__page-container {
-  flex: 1 1 0;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+.project-shell__frame-root {
+  min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-shell__frame-gutter {
+  flex: 1 1 auto;
+  width: 100%;
+  background-color: $dark-page;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-shell__frame-inner {
+  flex: 1 1 auto;
+  width: 100%;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-shell__frame-root.project-shell__frame-gutter .project-shell__frame-inner {
+  flex: 0 0 auto;
+}
+
+.project-shell__frame-column {
+  flex: 0 0 auto;
+  position: relative;
+  border-radius: var(--project-shell-frame-column-radius);
+  border-width: var(--project-shell-frame-column-edge-border-width);
+  border-style: solid;
+  border-color: var(--project-shell-frame-column-edge-border-color);
+  box-shadow: var(--project-shell-frame-column-surface-box-shadow);
+  overflow: hidden;
+}
+
+.project-shell__frame-inner > :not(.project-shell__frame-portal) {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-.project-shell__page-container > * {
-  flex: 1 1 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
+.project-shell__frame-portal {
+  position: absolute;
+  inset: 0;
+  z-index: 6000;
+  pointer-events: none;
   overflow: hidden;
+
+  :deep(> *) {
+    pointer-events: auto;
+  }
 }
 </style>

--- a/src/layouts/projects/ProjectShellLayout.vue
+++ b/src/layouts/projects/ProjectShellLayout.vue
@@ -155,11 +155,24 @@ onUnmounted(() => {
 .project-shell__frame-column {
   flex: 0 0 auto;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   border-radius: var(--project-shell-frame-column-radius);
   border-width: var(--project-shell-frame-column-edge-border-width);
   border-style: solid;
   border-color: var(--project-shell-frame-column-edge-border-color);
   box-shadow: var(--project-shell-frame-column-surface-box-shadow);
+  overflow: hidden;
+}
+
+.project-shell.project-shell--desktop-frame .project-shell__frame-inner > :not(.project-shell__frame-portal) {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 

--- a/src/layouts/projects/desktopPhoneFrame.js
+++ b/src/layouts/projects/desktopPhoneFrame.js
@@ -1,0 +1,135 @@
+/** Quasar `md` minimum viewport width (px). */
+export const DESKTOP_PHONE_FRAME_MD_MIN_WIDTH_PX = 1024
+
+/** Target portrait column width before shrink (CSS px). */
+export const DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX = 390
+
+/** Minimum horizontal gutter on each side of the column (CSS px). */
+export const DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX = 24
+
+/** Portrait height-to-width ratio (19.5∶9). */
+export const DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH = 19.5 / 9
+
+/** Height cap as a fraction of viewport height (matches `90dvh`). */
+export const DESKTOP_PHONE_FRAME_MAX_HEIGHT_VIEWPORT_FRACTION = 0.9
+
+export const DESKTOP_PHONE_FRAME_CSS_VAR = {
+  columnWidth: '--project-shell-phone-frame-width',
+  columnHeight: '--project-shell-phone-frame-height',
+  columnMaxHeight: '--project-shell-phone-frame-max-height',
+}
+
+/**
+ * @param {number} viewportWidthPx
+ * @returns {boolean}
+ */
+export function isDesktopPhoneFrameBreakpointActive(viewportWidthPx) {
+  return viewportWidthPx >= DESKTOP_PHONE_FRAME_MD_MIN_WIDTH_PX
+}
+
+/**
+ * @param {number} viewportWidthPx
+ * @returns {number}
+ */
+export function resolveDesktopPhoneFrameColumnWidthPx(viewportWidthPx) {
+  const minViewportForFullColumn =
+    DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX + 2 * DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX
+  if (viewportWidthPx >= minViewportForFullColumn) {
+    return DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX
+  }
+  return Math.max(0, viewportWidthPx - 2 * DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX)
+}
+
+/**
+ * @param {number} columnWidthPx
+ * @param {number} viewportHeightPx
+ * @returns {number}
+ */
+export function resolveDesktopPhoneFrameColumnHeightPx(columnWidthPx, viewportHeightPx) {
+  const aspectCap = columnWidthPx * DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH
+  if (viewportHeightPx <= 0) {
+    return Math.round(aspectCap)
+  }
+  const viewportCap = viewportHeightPx * DESKTOP_PHONE_FRAME_MAX_HEIGHT_VIEWPORT_FRACTION
+  return Math.round(Math.min(viewportCap, aspectCap))
+}
+
+/**
+ * Normalize viewport dimensions for layout (Quasar Screen can report 0 before ready).
+ *
+ * @param {{ viewportWidthPx: number, viewportHeightPx: number }} dimensions
+ * @returns {{ viewportWidthPx: number, viewportHeightPx: number }}
+ */
+export function normalizeDesktopPhoneFrameViewport(dimensions) {
+  let { viewportWidthPx, viewportHeightPx } = dimensions
+  if (typeof window !== 'undefined') {
+    if (viewportWidthPx <= 0) viewportWidthPx = window.innerWidth
+    if (viewportHeightPx <= 0) viewportHeightPx = window.innerHeight
+  }
+  return { viewportWidthPx, viewportHeightPx }
+}
+
+/**
+ * @param {number} columnWidthPx
+ * @param {number} columnHeightPx
+ * @returns {Record<string, string>}
+ */
+export function buildDesktopPhoneFrameCssVars(columnWidthPx, columnHeightPx) {
+  const width = `${columnWidthPx}px`
+  const height = `${columnHeightPx}px`
+  const maxHeight = `min(90dvh, calc(${width} * ${DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH}))`
+  return {
+    [DESKTOP_PHONE_FRAME_CSS_VAR.columnWidth]: width,
+    [DESKTOP_PHONE_FRAME_CSS_VAR.columnHeight]: height,
+    [DESKTOP_PHONE_FRAME_CSS_VAR.columnMaxHeight]: maxHeight,
+  }
+}
+
+/**
+ * Inline styles for the framed column element (width, height, maxHeight).
+ *
+ * @param {number} columnWidthPx
+ * @param {number} columnHeightPx
+ * @returns {Record<string, string>}
+ */
+export function buildDesktopPhoneFrameColumnStyle(columnWidthPx, columnHeightPx) {
+  const cssVars = buildDesktopPhoneFrameCssVars(columnWidthPx, columnHeightPx)
+  return {
+    width: cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnWidth],
+    height: cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnHeight],
+    maxHeight: cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnMaxHeight],
+  }
+}
+
+/**
+ * @param {{ viewportWidthPx: number, viewportHeightPx: number }} dimensions
+ * @returns {{
+ *   active: boolean,
+ *   columnWidthPx?: number,
+ *   columnHeightPx?: number,
+ *   style?: Record<string, string>,
+ *   cssVars?: Record<string, string>,
+ * }}
+ */
+export function getDesktopPhoneFrameLayout(dimensions) {
+  const { viewportWidthPx, viewportHeightPx } = normalizeDesktopPhoneFrameViewport(dimensions)
+
+  if (!isDesktopPhoneFrameBreakpointActive(viewportWidthPx)) {
+    return { active: false }
+  }
+
+  const columnWidthPx = resolveDesktopPhoneFrameColumnWidthPx(viewportWidthPx)
+  const columnHeightPx = resolveDesktopPhoneFrameColumnHeightPx(
+    columnWidthPx,
+    viewportHeightPx,
+  )
+  const cssVars = buildDesktopPhoneFrameCssVars(columnWidthPx, columnHeightPx)
+
+  return {
+    active: true,
+    columnWidthPx,
+    columnHeightPx,
+    style: buildDesktopPhoneFrameColumnStyle(columnWidthPx, columnHeightPx),
+    cssVars,
+  }
+}

--- a/src/layouts/projects/desktopPhoneFrame.test.js
+++ b/src/layouts/projects/desktopPhoneFrame.test.js
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX,
+  DESKTOP_PHONE_FRAME_CSS_VAR,
+  DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX,
+  DESKTOP_PHONE_FRAME_MAX_HEIGHT_VIEWPORT_FRACTION,
+  DESKTOP_PHONE_FRAME_MD_MIN_WIDTH_PX,
+  DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH,
+  buildDesktopPhoneFrameColumnStyle,
+  buildDesktopPhoneFrameCssVars,
+  getDesktopPhoneFrameLayout,
+  isDesktopPhoneFrameBreakpointActive,
+  resolveDesktopPhoneFrameColumnHeightPx,
+  resolveDesktopPhoneFrameColumnWidthPx,
+} from './desktopPhoneFrame.js'
+
+const MIN_VIEWPORT_FOR_FULL_COLUMN_PX =
+  DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX + 2 * DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX
+
+test('desktop phone frame spec constants', () => {
+  assert.equal(DESKTOP_PHONE_FRAME_MD_MIN_WIDTH_PX, 1024)
+  assert.equal(DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX, 390)
+  assert.equal(DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX, 24)
+  assert.equal(DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH, 19.5 / 9)
+  assert.equal(DESKTOP_PHONE_FRAME_MAX_HEIGHT_VIEWPORT_FRACTION, 0.9)
+  assert.equal(MIN_VIEWPORT_FOR_FULL_COLUMN_PX, 438)
+})
+
+test('breakpoint is inactive below Quasar md', () => {
+  assert.equal(isDesktopPhoneFrameBreakpointActive(1023), false)
+})
+
+test('breakpoint is active at Quasar md and above', () => {
+  assert.equal(isDesktopPhoneFrameBreakpointActive(1024), true)
+  assert.equal(isDesktopPhoneFrameBreakpointActive(1920), true)
+})
+
+test('layout is inactive below md', () => {
+  const layout = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 800,
+    viewportHeightPx: 900,
+  })
+  assert.equal(layout.active, false)
+  assert.equal('columnWidthPx' in layout, false)
+  assert.equal('style' in layout, false)
+  assert.equal('cssVars' in layout, false)
+})
+
+test('column width is 390px when viewport fits column plus gutters', () => {
+  assert.equal(
+    resolveDesktopPhoneFrameColumnWidthPx(MIN_VIEWPORT_FOR_FULL_COLUMN_PX),
+    DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX,
+  )
+  assert.equal(resolveDesktopPhoneFrameColumnWidthPx(1280), DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX)
+})
+
+test('column width shrinks by horizontal gutters when viewport is narrower', () => {
+  const cramped = MIN_VIEWPORT_FOR_FULL_COLUMN_PX - 40
+  assert.equal(
+    resolveDesktopPhoneFrameColumnWidthPx(cramped),
+    cramped - 2 * DESKTOP_PHONE_FRAME_HORIZONTAL_GUTTER_PX,
+  )
+  assert.equal(resolveDesktopPhoneFrameColumnWidthPx(0), 0)
+})
+
+test('column height uses aspect cap when viewport height is not yet known', () => {
+  const width = 390
+  const aspectCap = width * DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH
+  assert.equal(resolveDesktopPhoneFrameColumnHeightPx(width, 0), Math.round(aspectCap))
+})
+
+test('active layout never yields zero column height at md', () => {
+  const layout = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 1920,
+    viewportHeightPx: 0,
+  })
+  assert.equal(layout.active, true)
+  assert.ok(layout.columnHeightPx > 0)
+  assert.notEqual(layout.style?.height, '0px')
+})
+
+test('column height is min(90% viewport height, width × 19.5/9)', () => {
+  const width = 360
+  const tallViewport = 2000
+  const aspectCap = width * DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH
+  assert.equal(
+    resolveDesktopPhoneFrameColumnHeightPx(width, tallViewport),
+    Math.round(aspectCap),
+  )
+
+  const shortViewport = 500
+  const viewportCap = shortViewport * DESKTOP_PHONE_FRAME_MAX_HEIGHT_VIEWPORT_FRACTION
+  assert.equal(
+    resolveDesktopPhoneFrameColumnHeightPx(width, shortViewport),
+    Math.round(Math.min(viewportCap, aspectCap)),
+  )
+})
+
+test('active layout at md uses 390px width and capped height', () => {
+  const layout = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 1280,
+    viewportHeightPx: 900,
+  })
+  assert.equal(layout.active, true)
+  assert.equal(layout.columnWidthPx, 390)
+  const aspectCap = 390 * DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH
+  assert.equal(layout.columnHeightPx, Math.round(Math.min(900 * 0.9, aspectCap)))
+})
+
+test('active layout at md boundary', () => {
+  const layout = getDesktopPhoneFrameLayout({
+    viewportWidthPx: DESKTOP_PHONE_FRAME_MD_MIN_WIDTH_PX,
+    viewportHeightPx: 800,
+  })
+  assert.equal(layout.active, true)
+  assert.equal(layout.columnWidthPx, DESKTOP_PHONE_FRAME_COLUMN_WIDTH_PX)
+})
+
+test('css vars expose shell custom properties with px dimensions', () => {
+  const cssVars = buildDesktopPhoneFrameCssVars(360, 720)
+  assert.equal(cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnWidth], '360px')
+  assert.equal(cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnHeight], '720px')
+  assert.equal(
+    cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnMaxHeight],
+    `min(90dvh, calc(360px * ${DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH}))`,
+  )
+})
+
+test('column style mirrors css var width, height, and maxHeight', () => {
+  const columnWidthPx = 320
+  const columnHeightPx = 640
+  const cssVars = buildDesktopPhoneFrameCssVars(columnWidthPx, columnHeightPx)
+  const style = buildDesktopPhoneFrameColumnStyle(columnWidthPx, columnHeightPx)
+  assert.equal(style.width, cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnWidth])
+  assert.equal(style.height, cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnHeight])
+  assert.equal(style.maxHeight, cssVars[DESKTOP_PHONE_FRAME_CSS_VAR.columnMaxHeight])
+})
+
+test('active layout exposes style and cssVars for shell binding', () => {
+  const layout = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 1280,
+    viewportHeightPx: 900,
+  })
+  assert.equal(layout.style?.width, '390px')
+  assert.equal(layout.style?.height, `${layout.columnHeightPx}px`)
+  assert.equal(
+    layout.style?.maxHeight,
+    `min(90dvh, calc(390px * ${DESKTOP_PHONE_FRAME_PORTRAIT_HEIGHT_PER_WIDTH}))`,
+  )
+  assert.deepEqual(layout.cssVars, buildDesktopPhoneFrameCssVars(390, layout.columnHeightPx))
+})

--- a/src/layouts/projects/projectShellFrame.js
+++ b/src/layouts/projects/projectShellFrame.js
@@ -1,0 +1,84 @@
+/** Body + `q-layout` modifier while **desktop phone frame** is active. */
+export const PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS = 'project-shell--desktop-frame'
+
+/** Dedicated Quasar global-nodes mount inside the framed column (`#…` in DOM). */
+export const PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID = 'project-shell-frame-portal'
+
+/** Layer that stacks portaled dialogs/menus above routed project content. */
+export const PROJECT_SHELL_FRAME_PORTAL_LAYER_CLASS = 'project-shell__frame-portal'
+
+/** Quasar background utility for frame gutter (`$dark-page`). */
+export const PROJECT_SHELL_FRAME_GUTTER_BG_CLASS = 'bg-dark-page'
+
+/** Framed column corner radius (px); keep within 12–16px product spec. */
+export const PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX = 14
+
+/** Subtle column edge (CONTEXT: light border, not hardware bezel). */
+export const PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_WIDTH_PX = 1
+export const PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_COLOR = 'rgba(255, 255, 255, 0.1)'
+export const PROJECT_SHELL_FRAME_COLUMN_SURFACE_BOX_SHADOW = '0 8px 32px rgba(0, 0, 0, 0.4)'
+
+/** Product shell uses flat rounding + edge only—no notch or bezel artwork. */
+export const PROJECT_SHELL_FRAME_COLUMN_USES_HARDWARE_BEZEL = false
+
+export const PROJECT_SHELL_FRAME_CSS_VAR = {
+  columnBorderRadius: '--project-shell-frame-column-radius',
+  columnEdgeBorderWidth: '--project-shell-frame-column-edge-border-width',
+  columnEdgeBorderColor: '--project-shell-frame-column-edge-border-color',
+  columnSurfaceBoxShadow: '--project-shell-frame-column-surface-box-shadow',
+}
+
+/**
+ * @returns {Record<string, string>}
+ */
+export function buildProjectShellFrameColumnPresentationVars() {
+  return {
+    [PROJECT_SHELL_FRAME_CSS_VAR.columnBorderRadius]: `${PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX}px`,
+    [PROJECT_SHELL_FRAME_CSS_VAR.columnEdgeBorderWidth]: `${PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_WIDTH_PX}px`,
+    [PROJECT_SHELL_FRAME_CSS_VAR.columnEdgeBorderColor]:
+      PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_COLOR,
+    [PROJECT_SHELL_FRAME_CSS_VAR.columnSurfaceBoxShadow]:
+      PROJECT_SHELL_FRAME_COLUMN_SURFACE_BOX_SHADOW,
+  }
+}
+
+/**
+ * @param {boolean} frameActive
+ * @returns {string | undefined}
+ */
+export function resolveProjectShellFramePortalElementId(frameActive) {
+  return frameActive ? PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID : undefined
+}
+
+/**
+ * @param {boolean} frameActive
+ * @param {Pick<Document, 'getElementById'> | null | undefined} [doc]
+ * @returns {HTMLElement | null}
+ */
+export function resolveProjectShellOverlayPortalMount(frameActive, doc) {
+  if (!frameActive) return null
+  const root = doc ?? (typeof document !== 'undefined' ? document : null)
+  if (root == null) return null
+  return root.getElementById(PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID)
+}
+
+/**
+ * @param {ReturnType<typeof import('./desktopPhoneFrame.js').getDesktopPhoneFrameLayout>} layout
+ * @returns {Record<string, string> | undefined}
+ */
+export function resolveProjectShellFrameGutterInlineStyle(layout) {
+  return layout.active ? layout.cssVars : undefined
+}
+
+/**
+ * @param {ReturnType<typeof import('./desktopPhoneFrame.js').getDesktopPhoneFrameLayout>} layout
+ * @returns {Record<string, string> | undefined}
+ */
+export function resolveProjectShellFrameColumnInlineStyle(layout) {
+  if (!layout.active || !layout.style || !layout.cssVars) return undefined
+  return {
+    ...buildProjectShellFrameColumnPresentationVars(),
+    ...layout.cssVars,
+    ...layout.style,
+  }
+}

--- a/src/layouts/projects/projectShellFrame.test.js
+++ b/src/layouts/projects/projectShellFrame.test.js
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getDesktopPhoneFrameLayout } from './desktopPhoneFrame.js'
+import {
+  PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS,
+  PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX,
+  PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_COLOR,
+  PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_WIDTH_PX,
+  PROJECT_SHELL_FRAME_COLUMN_SURFACE_BOX_SHADOW,
+  PROJECT_SHELL_FRAME_COLUMN_USES_HARDWARE_BEZEL,
+  PROJECT_SHELL_FRAME_CSS_VAR,
+  PROJECT_SHELL_FRAME_GUTTER_BG_CLASS,
+  PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID,
+  PROJECT_SHELL_FRAME_PORTAL_LAYER_CLASS,
+  buildProjectShellFrameColumnPresentationVars,
+  resolveProjectShellFrameColumnInlineStyle,
+  resolveProjectShellFrameGutterInlineStyle,
+  resolveProjectShellFramePortalElementId,
+  resolveProjectShellOverlayPortalMount,
+} from './projectShellFrame.js'
+
+test('shell frame portal element id is stable', () => {
+  assert.equal(PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID, 'project-shell-frame-portal')
+})
+
+test('shell frame portal layer class is stable', () => {
+  assert.equal(PROJECT_SHELL_FRAME_PORTAL_LAYER_CLASS, 'project-shell__frame-portal')
+})
+
+test('shell desktop frame body class matches layout modifier', () => {
+  assert.equal(PROJECT_SHELL_DESKTOP_FRAME_BODY_CLASS, 'project-shell--desktop-frame')
+})
+
+test('overlay portal mount resolves frame column id when framing is active', () => {
+  const portal = { id: PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID }
+  const doc = {
+    getElementById: (id) => (id === PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID ? portal : null),
+  }
+
+  assert.equal(resolveProjectShellOverlayPortalMount(false, doc), null)
+  assert.equal(resolveProjectShellOverlayPortalMount(true, doc), portal)
+})
+
+test('portal element id is set only when framing is active', () => {
+  assert.equal(resolveProjectShellFramePortalElementId(false), undefined)
+  assert.equal(
+    resolveProjectShellFramePortalElementId(true),
+    PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID,
+  )
+})
+
+test('gutter inline style exposes css vars only when layout is active', () => {
+  const inactive = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 800,
+    viewportHeightPx: 900,
+  })
+  assert.equal(resolveProjectShellFrameGutterInlineStyle(inactive), undefined)
+
+  const active = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 1280,
+    viewportHeightPx: 900,
+  })
+  assert.deepEqual(resolveProjectShellFrameGutterInlineStyle(active), active.cssVars)
+})
+
+test('column inline style merges css vars and dimensions when active', () => {
+  const inactive = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 800,
+    viewportHeightPx: 900,
+  })
+  assert.equal(resolveProjectShellFrameColumnInlineStyle(inactive), undefined)
+
+  const active = getDesktopPhoneFrameLayout({
+    viewportWidthPx: 1280,
+    viewportHeightPx: 900,
+  })
+  assert.deepEqual(resolveProjectShellFrameColumnInlineStyle(active), {
+    ...buildProjectShellFrameColumnPresentationVars(),
+    ...active.cssVars,
+    ...active.style,
+  })
+})
+
+test('frame column border radius stays within 12-16px spec', () => {
+  assert.ok(PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX >= 12)
+  assert.ok(PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX <= 16)
+  assert.equal(PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX, 14)
+})
+
+test('gutter uses site dark page background class', () => {
+  assert.equal(PROJECT_SHELL_FRAME_GUTTER_BG_CLASS, 'bg-dark-page')
+})
+
+test('column presentation vars expose border radius custom property', () => {
+  const vars = buildProjectShellFrameColumnPresentationVars()
+  assert.equal(
+    vars[PROJECT_SHELL_FRAME_CSS_VAR.columnBorderRadius],
+    `${PROJECT_SHELL_FRAME_COLUMN_BORDER_RADIUS_PX}px`,
+  )
+})
+
+test('frame column surface is flat edge without hardware bezel art', () => {
+  assert.equal(PROJECT_SHELL_FRAME_COLUMN_USES_HARDWARE_BEZEL, false)
+})
+
+test('column edge border stays a subtle 1px treatment', () => {
+  assert.equal(PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_WIDTH_PX, 1)
+  assert.match(PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_COLOR, /^rgba\(/)
+})
+
+test('column surface shadow is a soft elevation not a device bezel', () => {
+  assert.match(PROJECT_SHELL_FRAME_COLUMN_SURFACE_BOX_SHADOW, /^0 \d+px \d+px rgba\(/)
+})
+
+test('column presentation vars expose subtle edge custom properties', () => {
+  const vars = buildProjectShellFrameColumnPresentationVars()
+  assert.equal(
+    vars[PROJECT_SHELL_FRAME_CSS_VAR.columnEdgeBorderWidth],
+    `${PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_WIDTH_PX}px`,
+  )
+  assert.equal(
+    vars[PROJECT_SHELL_FRAME_CSS_VAR.columnEdgeBorderColor],
+    PROJECT_SHELL_FRAME_COLUMN_EDGE_BORDER_COLOR,
+  )
+  assert.equal(
+    vars[PROJECT_SHELL_FRAME_CSS_VAR.columnSurfaceBoxShadow],
+    PROJECT_SHELL_FRAME_COLUMN_SURFACE_BOX_SHADOW,
+  )
+})

--- a/src/layouts/projects/projectShellLayoutNotify.js
+++ b/src/layouts/projects/projectShellLayoutNotify.js
@@ -1,0 +1,73 @@
+import { PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID } from './projectShellFrame.js'
+import {
+  PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID,
+  applyProjectShellNotifyFrame,
+  restoreProjectShellNotifyFrame,
+} from './projectShellNotifyFrame.js'
+
+/**
+ * @param {boolean} frameActive
+ * @param {Pick<Document, 'getElementById'> | null | undefined} doc
+ * @returns {{ notifyRoot: Element | null, framePortal: Element | null }}
+ */
+export function resolveProjectShellNotifyFrameTargets(frameActive, doc) {
+  if (doc?.getElementById == null) {
+    return { notifyRoot: null, framePortal: null }
+  }
+
+  const notifyRoot = doc.getElementById(PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID)
+  const framePortal = frameActive
+    ? doc.getElementById(PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID)
+    : null
+
+  return { notifyRoot, framePortal }
+}
+
+/**
+ * Apply or clear **Notify** framing for the project shell (`md+` desktop phone frame).
+ *
+ * @param {{
+ *   notifyApi: { setDefaults: (opts: Record<string, unknown>) => void },
+ *   frameActive: boolean,
+ *   doc?: Pick<Document, 'body' | 'getElementById'> | null,
+ * }} params
+ * @returns {boolean} `true` when framed sync does not need a DOM retry
+ */
+export function syncProjectShellLayoutNotifyFrame({
+  notifyApi,
+  frameActive,
+  doc = typeof document !== 'undefined' ? document : null,
+}) {
+  if (doc == null) return true
+
+  const { notifyRoot, framePortal } = resolveProjectShellNotifyFrameTargets(frameActive, doc)
+
+  applyProjectShellNotifyFrame({
+    notifyApi,
+    frameActive,
+    notifyRoot,
+    framePortal,
+    documentBody: doc.body ?? null,
+  })
+
+  return !frameActive || framePortal != null
+}
+
+/**
+ * @param {{
+ *   notifyApi: { setDefaults: (opts: Record<string, unknown>) => void },
+ *   doc?: Pick<Document, 'body' | 'getElementById'> | null,
+ * }} params
+ */
+export function teardownProjectShellLayoutNotifyFrame({
+  notifyApi,
+  doc = typeof document !== 'undefined' ? document : null,
+}) {
+  if (doc == null) return
+
+  restoreProjectShellNotifyFrame({
+    notifyApi,
+    notifyRoot: doc.getElementById(PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID),
+    documentBody: doc.body ?? null,
+  })
+}

--- a/src/layouts/projects/projectShellLayoutNotify.test.js
+++ b/src/layouts/projects/projectShellLayoutNotify.test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID } from './projectShellFrame.js'
+import {
+  PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS,
+  PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID,
+  PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS,
+  resetProjectShellNotifyFrameStateForTests,
+} from './projectShellNotifyFrame.js'
+import {
+  resolveProjectShellNotifyFrameTargets,
+  syncProjectShellLayoutNotifyFrame,
+  teardownProjectShellLayoutNotifyFrame,
+} from './projectShellLayoutNotify.js'
+
+test.afterEach(() => {
+  resetProjectShellNotifyFrameStateForTests()
+})
+
+/**
+ * @param {Record<string, Element | null>} [elements]
+ */
+function createDocumentFixture(elements = {}) {
+  const body = { appendChild(el) { el.parentElement = body } }
+  return {
+    body,
+    getElementById: (id) => elements[id] ?? null,
+  }
+}
+
+test('resolveProjectShellNotifyFrameTargets resolves notify root and frame portal when active', () => {
+  const portal = { id: PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID }
+  const notifyRoot = { id: PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+
+  assert.deepEqual(resolveProjectShellNotifyFrameTargets(true, doc), {
+    notifyRoot,
+    framePortal: portal,
+  })
+})
+
+test('resolveProjectShellNotifyFrameTargets omits portal when framing is inactive', () => {
+  const portal = { id: PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID }
+  const notifyRoot = { id: PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+
+  assert.deepEqual(resolveProjectShellNotifyFrameTargets(false, doc), {
+    notifyRoot,
+    framePortal: null,
+  })
+})
+
+test('syncProjectShellLayoutNotifyFrame applies top defaults and mounts into frame portal', () => {
+  const portal = { appendChild(el) { el.parentElement = portal } }
+  const notifyRoot = { parentElement: /** @type {unknown} */ (null) }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+  doc.body.appendChild(notifyRoot)
+
+  const applied = []
+  const notifyApi = {
+    setDefaults: (opts) => {
+      applied.push(opts)
+    },
+  }
+
+  assert.equal(
+    syncProjectShellLayoutNotifyFrame({ notifyApi, frameActive: true, doc }),
+    true,
+  )
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, portal)
+})
+
+test('syncProjectShellLayoutNotifyFrame restores defaults and body mount when inactive', () => {
+  const portal = { appendChild(el) { el.parentElement = portal } }
+  const notifyRoot = { parentElement: /** @type {unknown} */ (null) }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+  doc.body.appendChild(notifyRoot)
+
+  const notifyApi = { setDefaults: () => {} }
+
+  syncProjectShellLayoutNotifyFrame({ notifyApi, frameActive: true, doc })
+  portal.appendChild(notifyRoot)
+
+  const applied = []
+  notifyApi.setDefaults = (opts) => {
+    applied.push(opts)
+  }
+
+  assert.equal(
+    syncProjectShellLayoutNotifyFrame({ notifyApi, frameActive: false, doc }),
+    true,
+  )
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, doc.body)
+})
+
+test('syncProjectShellLayoutNotifyFrame reports retry when portal is not mounted yet', () => {
+  const notifyRoot = { parentElement: /** @type {unknown} */ (null) }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+  doc.body.appendChild(notifyRoot)
+
+  const notifyApi = { setDefaults: () => {} }
+
+  assert.equal(
+    syncProjectShellLayoutNotifyFrame({ notifyApi, frameActive: true, doc }),
+    false,
+  )
+})
+
+test('teardownProjectShellLayoutNotifyFrame clears shell notify overrides', () => {
+  const portal = { appendChild(el) { el.parentElement = portal } }
+  const notifyRoot = { parentElement: /** @type {unknown} */ (null) }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+    [PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID]: notifyRoot,
+  })
+  doc.body.appendChild(notifyRoot)
+
+  const applied = []
+  const notifyApi = {
+    setDefaults: (opts) => {
+      applied.push(opts)
+    },
+  }
+
+  syncProjectShellLayoutNotifyFrame({ notifyApi, frameActive: true, doc })
+  portal.appendChild(notifyRoot)
+
+  teardownProjectShellLayoutNotifyFrame({ notifyApi, doc })
+
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, doc.body)
+})

--- a/src/layouts/projects/projectShellNotifyFrame.js
+++ b/src/layouts/projects/projectShellNotifyFrame.js
@@ -1,0 +1,112 @@
+/** Quasar Notify global mount (`createGlobalNode('q-notify')`). */
+export const PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID = 'q-notify'
+
+/** Notify defaults while **desktop phone frame** is active. */
+export const PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS = { position: 'top' }
+
+/** Baseline Notify position restored when leaving the frame (Quasar default). */
+export const PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS = { position: 'bottom' }
+
+/** @type {typeof PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS | null} */
+let notifyDefaultsRestoreSnapshot = null
+
+/**
+ * @param {boolean} frameActive
+ * @returns {typeof PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS | typeof PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS}
+ */
+export function resolveProjectShellNotifyDefaults(frameActive) {
+  return frameActive
+    ? { ...PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS }
+    : { ...PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS }
+}
+
+/**
+ * Reparent the Notify plugin root into the frame column or back to `document.body`.
+ *
+ * @param {{
+ *   notifyRoot: Element | null,
+ *   framePortal: Element | null,
+ *   frameActive: boolean,
+ *   documentBody?: Element | null,
+ * }} params
+ */
+export function syncProjectShellNotifyContainer({
+  notifyRoot,
+  framePortal,
+  frameActive,
+  documentBody = typeof document !== 'undefined' ? document.body : null,
+}) {
+  if (!notifyRoot || !documentBody) return
+
+  const target = frameActive && framePortal ? framePortal : documentBody
+  if (notifyRoot.parentElement !== target) {
+    target.appendChild(notifyRoot)
+  }
+}
+
+/**
+ * @param {{
+ *   notifyApi: { setDefaults: (opts: Record<string, unknown>) => void },
+ *   frameActive: boolean,
+ *   notifyRoot: Element | null,
+ *   framePortal: Element | null,
+ *   documentBody?: Element | null,
+ * }} params
+ */
+export function applyProjectShellNotifyFrame({
+  notifyApi,
+  frameActive,
+  notifyRoot,
+  framePortal,
+  documentBody,
+}) {
+  if (frameActive) {
+    if (notifyDefaultsRestoreSnapshot === null) {
+      notifyDefaultsRestoreSnapshot = { ...PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS }
+    }
+    notifyApi.setDefaults(resolveProjectShellNotifyDefaults(true))
+  } else if (notifyDefaultsRestoreSnapshot !== null) {
+    notifyApi.setDefaults(notifyDefaultsRestoreSnapshot)
+  } else {
+    notifyApi.setDefaults(resolveProjectShellNotifyDefaults(false))
+  }
+
+  syncProjectShellNotifyContainer({
+    notifyRoot,
+    framePortal,
+    frameActive,
+    documentBody,
+  })
+}
+
+/**
+ * @param {{
+ *   notifyApi: { setDefaults: (opts: Record<string, unknown>) => void },
+ *   notifyRoot: Element | null,
+ *   documentBody?: Element | null,
+ * }} params
+ */
+export function restoreProjectShellNotifyFrame({
+  notifyApi,
+  notifyRoot,
+  documentBody,
+}) {
+  if (notifyDefaultsRestoreSnapshot !== null) {
+    notifyApi.setDefaults(notifyDefaultsRestoreSnapshot)
+    notifyDefaultsRestoreSnapshot = null
+  } else {
+    notifyApi.setDefaults(resolveProjectShellNotifyDefaults(false))
+  }
+
+  syncProjectShellNotifyContainer({
+    notifyRoot,
+    framePortal: null,
+    frameActive: false,
+    documentBody,
+  })
+}
+
+/** @internal */
+export function resetProjectShellNotifyFrameStateForTests() {
+  notifyDefaultsRestoreSnapshot = null
+}

--- a/src/layouts/projects/projectShellNotifyFrame.test.js
+++ b/src/layouts/projects/projectShellNotifyFrame.test.js
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS,
+  PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID,
+  PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS,
+  applyProjectShellNotifyFrame,
+  resetProjectShellNotifyFrameStateForTests,
+  resolveProjectShellNotifyDefaults,
+  restoreProjectShellNotifyFrame,
+  syncProjectShellNotifyContainer,
+} from './projectShellNotifyFrame.js'
+
+test.afterEach(() => {
+  resetProjectShellNotifyFrameStateForTests()
+})
+
+/**
+ * @returns {{ body: { appendChild: (el: { parentElement: unknown }) => void }, portal: { appendChild: (el: { parentElement: unknown }) => void }, notifyRoot: { parentElement: unknown } }}
+ */
+function createNotifyMountFixture() {
+  const body = { appendChild(el) { el.parentElement = body } }
+  const portal = { appendChild(el) { el.parentElement = portal } }
+  const notifyRoot = { parentElement: /** @type {unknown} */ (null) }
+  body.appendChild(notifyRoot)
+  return { body, portal, notifyRoot }
+}
+
+test('notify root element id matches Quasar Notify mount', () => {
+  assert.equal(PROJECT_SHELL_NOTIFY_ROOT_ELEMENT_ID, 'q-notify')
+})
+
+test('framed notify defaults pin to top', () => {
+  assert.deepEqual(resolveProjectShellNotifyDefaults(true), PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS)
+  assert.equal(PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS.position, 'top')
+})
+
+test('restored notify defaults return to Quasar baseline position', () => {
+  assert.deepEqual(resolveProjectShellNotifyDefaults(false), PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS)
+  assert.equal(PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS.position, 'bottom')
+})
+
+test('syncProjectShellNotifyContainer appends notify root to frame portal when active', () => {
+  const { body, portal, notifyRoot } = createNotifyMountFixture()
+
+  syncProjectShellNotifyContainer({
+    notifyRoot,
+    framePortal: portal,
+    frameActive: true,
+    documentBody: body,
+  })
+
+  assert.equal(notifyRoot.parentElement, portal)
+})
+
+test('syncProjectShellNotifyContainer returns notify root to body when inactive', () => {
+  const { body, portal, notifyRoot } = createNotifyMountFixture()
+  portal.appendChild(notifyRoot)
+
+  syncProjectShellNotifyContainer({
+    notifyRoot,
+    framePortal: portal,
+    frameActive: false,
+    documentBody: body,
+  })
+
+  assert.equal(notifyRoot.parentElement, body)
+})
+
+test('applyProjectShellNotifyFrame sets framed defaults and mounts into portal', () => {
+  const { body, portal, notifyRoot } = createNotifyMountFixture()
+
+  const applied = []
+  const notifyApi = {
+    setDefaults: (opts) => {
+      applied.push(opts)
+    },
+  }
+
+  applyProjectShellNotifyFrame({
+    notifyApi,
+    frameActive: true,
+    notifyRoot,
+    framePortal: portal,
+    documentBody: body,
+  })
+
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_FRAME_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, portal)
+})
+
+test('applyProjectShellNotifyFrame restores defaults when framing drops', () => {
+  const { body, portal, notifyRoot } = createNotifyMountFixture()
+
+  const notifyApi = { setDefaults: () => {} }
+
+  applyProjectShellNotifyFrame({
+    notifyApi,
+    frameActive: true,
+    notifyRoot,
+    framePortal: portal,
+    documentBody: body,
+  })
+
+  const applied = []
+  notifyApi.setDefaults = (opts) => {
+    applied.push(opts)
+  }
+
+  applyProjectShellNotifyFrame({
+    notifyApi,
+    frameActive: false,
+    notifyRoot,
+    framePortal: portal,
+    documentBody: body,
+  })
+
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, body)
+})
+
+test('restoreProjectShellNotifyFrame clears shell notify overrides on teardown', () => {
+  const { body, portal, notifyRoot } = createNotifyMountFixture()
+  portal.appendChild(notifyRoot)
+
+  const applied = []
+  const notifyApi = {
+    setDefaults: (opts) => {
+      applied.push(opts)
+    },
+  }
+
+  applyProjectShellNotifyFrame({
+    notifyApi,
+    frameActive: true,
+    notifyRoot,
+    framePortal: portal,
+    documentBody: body,
+  })
+
+  restoreProjectShellNotifyFrame({
+    notifyApi,
+    notifyRoot,
+    documentBody: body,
+  })
+
+  assert.deepEqual(applied.at(-1), PROJECT_SHELL_RESTORE_NOTIFY_DEFAULTS)
+  assert.equal(notifyRoot.parentElement, body)
+})

--- a/src/layouts/projects/projectShellOverlayPortal.js
+++ b/src/layouts/projects/projectShellOverlayPortal.js
@@ -1,0 +1,49 @@
+import { changeGlobalNodesTarget } from 'quasar/src/utils/private.config/nodes.js'
+
+import { resolveProjectShellOverlayPortalMount } from './projectShellFrame.js'
+
+/**
+ * @param {Pick<Document, 'body'> | null | undefined} [doc]
+ * @returns {HTMLElement}
+ */
+function resolveDocumentBody(doc) {
+  const root = doc ?? (typeof document !== 'undefined' ? document : null)
+  if (root?.body == null) {
+    throw new Error('project shell overlay portal requires document.body')
+  }
+  return root.body
+}
+
+/**
+ * Quasar teleports QDialog/QMenu/etc. into global nodes under `document.body` by default.
+ * `changeGlobalNodesTarget` reparents those nodes (same hook AppFullscreen uses).
+ *
+ * @param {boolean} frameActive
+ * @param {Pick<Document, 'body' | 'getElementById'> | null | undefined} [doc]
+ * @returns {HTMLElement | null}
+ */
+export function resolveProjectShellOverlayPortalTarget(frameActive, doc) {
+  if (!frameActive) {
+    return resolveDocumentBody(doc)
+  }
+  return resolveProjectShellOverlayPortalMount(true, doc)
+}
+
+/**
+ * @param {boolean} frameActive
+ * @param {Pick<Document, 'body' | 'getElementById'> | null | undefined} [doc]
+ */
+export function syncProjectShellOverlayPortalTarget(frameActive, doc) {
+  if (doc == null && typeof document === 'undefined') return
+
+  const target = resolveProjectShellOverlayPortalTarget(frameActive, doc)
+  if (target == null) return
+
+  changeGlobalNodesTarget(target)
+}
+
+/** Restore Quasar’s default portal parent when leaving the project shell. */
+export function resetProjectShellOverlayPortalTarget(doc) {
+  if (doc == null && typeof document === 'undefined') return
+  changeGlobalNodesTarget(resolveDocumentBody(doc))
+}

--- a/src/layouts/projects/projectShellOverlayPortal.test.js
+++ b/src/layouts/projects/projectShellOverlayPortal.test.js
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import { before, beforeEach, mock, test } from 'node:test'
+import { PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID } from './projectShellFrame.js'
+
+/** @type {typeof import('./projectShellOverlayPortal.js')} */
+let overlayPortal
+
+/** @type {unknown[]} */
+let changeGlobalNodesTargetCalls = []
+
+/**
+ * @param {Record<string, unknown>} [elements]
+ * @returns {Pick<Document, 'body' | 'getElementById'>}
+ */
+function createDocumentFixture(elements = {}) {
+  const body = { nodeName: 'BODY' }
+  return {
+    body,
+    getElementById: (id) => elements[id] ?? null,
+  }
+}
+
+before(async () => {
+  if (!mock.module) return
+
+  mock.module('quasar/src/utils/private.config/nodes.js', {
+    namedExports: {
+      changeGlobalNodesTarget: (target) => {
+        changeGlobalNodesTargetCalls.push(target)
+      },
+    },
+  })
+
+  overlayPortal = await import(
+    `./projectShellOverlayPortal.js?test=${Date.now()}`,
+  )
+})
+
+beforeEach(() => {
+  changeGlobalNodesTargetCalls = []
+})
+
+const overlayPortalTests = { skip: !mock.module }
+
+test('inactive overlay portal target is document body', overlayPortalTests, () => {
+  const body = { nodeName: 'BODY' }
+  const doc = createDocumentFixture()
+  doc.body = body
+
+  assert.equal(
+    overlayPortal.resolveProjectShellOverlayPortalTarget(false, doc),
+    body,
+  )
+})
+
+test('active overlay portal target resolves frame portal mount', overlayPortalTests, () => {
+  const portal = { id: PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+  })
+
+  assert.equal(
+    overlayPortal.resolveProjectShellOverlayPortalTarget(true, doc),
+    portal,
+  )
+})
+
+test(
+  'active overlay portal target does not fall back to body when mount is missing',
+  overlayPortalTests,
+  () => {
+  const body = { nodeName: 'BODY' }
+  const doc = createDocumentFixture()
+  doc.body = body
+
+  assert.equal(
+    overlayPortal.resolveProjectShellOverlayPortalTarget(true, doc),
+    null,
+  )
+  },
+)
+
+test(
+  'sync skips changeGlobalNodesTarget when frame is active but portal mount is absent',
+  overlayPortalTests,
+  () => {
+  const body = { nodeName: 'BODY' }
+  const doc = createDocumentFixture()
+  doc.body = body
+
+  overlayPortal.syncProjectShellOverlayPortalTarget(true, doc)
+
+  assert.equal(changeGlobalNodesTargetCalls.length, 0)
+  },
+)
+
+test(
+  'sync reparents Quasar global nodes to frame portal when mount exists',
+  overlayPortalTests,
+  () => {
+  const portal = { id: PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID }
+  const doc = createDocumentFixture({
+    [PROJECT_SHELL_FRAME_PORTAL_ELEMENT_ID]: portal,
+  })
+
+  overlayPortal.syncProjectShellOverlayPortalTarget(true, doc)
+
+  assert.deepEqual(changeGlobalNodesTargetCalls, [portal])
+  },
+)
+
+test('sync restores document body when desktop frame is inactive', overlayPortalTests, () => {
+  const body = { nodeName: 'BODY' }
+  const doc = createDocumentFixture()
+  doc.body = body
+
+  overlayPortal.syncProjectShellOverlayPortalTarget(false, doc)
+
+  assert.deepEqual(changeGlobalNodesTargetCalls, [body])
+})
+
+test('resetProjectShellOverlayPortalTarget restores document body', overlayPortalTests, () => {
+  const body = { nodeName: 'BODY' }
+  const doc = createDocumentFixture()
+  doc.body = body
+
+  overlayPortal.resetProjectShellOverlayPortalTarget(doc)
+
+  assert.deepEqual(changeGlobalNodesTargetCalls, [body])
+})

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="dr-page column no-wrap">
+  <q-page class="dr-page column fit no-wrap">
     <div class="dr-header row items-center q-px-md q-pt-md q-pb-sm">
       <div class="row items-center q-gutter-xs">
         <q-btn
@@ -599,7 +599,7 @@ import { shouldEnableDebugOnBoot } from '../../features/dungeon-runner/debug/mod
 import { buildStateFromReplayEnvelope } from '../../features/dungeon-runner/debug/replaySession.js'
 import { exportReplayEnvelope, importReplayEnvelope } from '../../features/dungeon-runner/debug/replay.js'
 import { chooseRandombotAction } from '../../features/dungeon-runner/bots/randombot.js'
-import { chooseNnActionWithFallback } from '../../features/dungeon-runner/nn/runtime.js'
+import { chooseNnActionWithFallback, warmNnModelCache } from '../../features/dungeon-runner/nn/runtime.js'
 import { createModelFailureRecovery } from '../../features/dungeon-runner/nn/recovery.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
 import { pickDefaultModelId, validateSelectedModels } from '../../features/dungeon-runner/models/discovery.js'
@@ -611,6 +611,13 @@ import {
   DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS,
   runPresentationIntervalTick,
 } from '../../features/dungeon-runner/ui/dungeonRunnerPresentationInterval.js'
+import { buildAiTurnRunToken } from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnToken.js'
+import {
+  consumeAiTurnPrefetch,
+  resetAiTurnPrefetch,
+  startAiTurnPrefetch,
+} from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js'
+import { createPipelineStepLogger } from '../../features/dungeon-runner/nn/nnPipelineTrace.js'
 import {
   dungeonRunnerAssetPack,
   dungeonRunnerEquipmentSymbolRuntimePath,
@@ -824,7 +831,51 @@ let presentationTimerId = null
 let aiTurnTimerId = null
 let autoResolveTimerId = null
 let aiTurnInFlight = false
+let lastAppliedAiTurnToken = null
+let presentationInputWasLocked = false
 let lastPresentationTraceKey = null
+let lastScheduleSkipKey = ''
+let lastPrimeSkipTraceKey = ''
+/** @type {Promise<void> | null} */
+let nnModelsWarmPromise = null
+
+const AI_TURN_SCHEDULE_DELAY_MS = 300
+
+function aiTurnTrace(baseContext = {}) {
+  return createPipelineStepLogger('AITurn', debugMode.value, {
+    matchId: match.value?.id ?? null,
+    ...baseContext,
+  })
+}
+
+const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
+  'gameplay-locked',
+  'timer-pending',
+  'in-flight',
+  'already-applied-token',
+  'deferred-post-dungeon',
+])
+
+function logAiTurnScheduleSkip(reason, detail = {}) {
+  if (!debugMode.value) return
+  const key = `${reason}:${detail.runToken ?? detail.activeKind ?? ''}`
+  if (SCHEDULE_SKIP_THROTTLE_REASONS.has(reason) && key === lastScheduleSkipKey) return
+  lastScheduleSkipKey = key
+  console.warn('[DungeonRunner][AITurn][Schedule] skip', reason, detail)
+}
+
+function logAiTurnPrimeSkip(reason, detail = {}) {
+  if (!debugMode.value) return
+  const key = `${reason}:${detail.runToken ?? detail.phase ?? detail.seatId ?? detail.roleType ?? ''}`
+  if (key === lastPrimeSkipTraceKey) return
+  lastPrimeSkipTraceKey = key
+  aiTurnTrace()('prefetch.prime.skip', { reason, ...detail })
+}
+
+function scheduleAiTurnOnPresentationTick() {
+  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value) return
+  scheduleAiTurnIfReady()
+}
 const uiAssets = dungeonRunnerAssetPack
 
 watch(presentationSpeedProfile, (next) => {
@@ -1173,7 +1224,7 @@ onMounted(() => {
   presentationTimerId = window.setInterval(() => {
     runPresentationIntervalTick(presentationOrchestrator, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS, {
       syncPresentationLabel,
-      scheduleAiTurnIfReady,
+      scheduleAiTurnIfReady: scheduleAiTurnOnPresentationTick,
       scheduleHumanAutoResolveIfReady,
     })
   }, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS)
@@ -1280,6 +1331,10 @@ function startNewMatch() {
   nnDebugTraceText.value = ''
   nnDebugTraceHistory.value = []
   presentationOrchestrator.clear()
+  lastAppliedAiTurnToken = null
+  resetAiTurnPrefetch()
+  presentationInputWasLocked = false
+  nnModelsWarmPromise = preloadNnModelsForSetup(setupSnapshot)
   syncPresentationLabel()
 }
 
@@ -1323,11 +1378,35 @@ function rematch() {
   nnDebugTraceText.value = ''
   nnDebugTraceHistory.value = []
   presentationOrchestrator.clear()
+  lastAppliedAiTurnToken = null
+  resetAiTurnPrefetch()
+  presentationInputWasLocked = false
+  nnModelsWarmPromise = preloadNnModelsForSetup(setupSnapshot)
   syncPresentationLabel()
+}
+
+function preloadNnModelsForSetup(setupSnapshot) {
+  const modelIds = [
+    ...new Set(
+      (setupSnapshot?.opponents ?? [])
+        .filter((opponent) => opponent.type === 'nn')
+        .map((opponent) => opponent.modelId ?? 'latest'),
+    ),
+  ]
+  if (!modelIds.length) return Promise.resolve()
+  return warmNnModelCache(modelIds)
+}
+
+async function ensureNnModelsReady() {
+  await nnModelsWarmPromise?.catch(() => {})
 }
 
 function backToSetup() {
   match.value = null
+  lastAppliedAiTurnToken = null
+  resetAiTurnPrefetch()
+  nnModelsWarmPromise = null
+  presentationInputWasLocked = false
   deferredPostDungeonState.value = null
   clearCurrentMatch(window.localStorage)
   nnDebugTraceText.value = ''
@@ -1340,6 +1419,7 @@ function takeHumanAction(action) {
   if (!match.value || !humanSeatId.value) {
     return
   }
+  resetAiTurnPrefetch()
   if (gameplayInputLocked.value) {
     return
   }
@@ -1458,57 +1538,103 @@ function confirmVorpalDeclaration() {
 }
 
 async function runAiTurn() {
-  if (aiTurnInFlight) return
+  const trace = aiTurnTrace()
+  if (aiTurnInFlight) {
+    trace('run.skip', { reason: 'in-flight' })
+    return
+  }
+  if (gameplayInputLocked.value) {
+    trace('run.skip', {
+      reason: 'gameplay-locked',
+      activePresentation: activePresentation.value?.kind ?? null,
+      queueMs: presentationOrchestrator.getQueueSnapshot().reduce((sum, item) => sum + item.remainingMs, 0),
+    })
+    return
+  }
   if (
     !match.value ||
     (match.value.state.phase !== 'bidding' &&
       match.value.state.phase !== 'dungeon' &&
       match.value.state.phase !== 'pick-adventurer')
   ) {
+    trace('run.skip', { reason: 'phase-not-actionable', phase: match.value?.state?.phase ?? null })
     return
   }
   const seatId = match.value.state.turn.activeSeatId
-  if (!seatId || seatId === humanSeatId.value) return
-  const runToken = `${match.value.id}:${match.value.state.turn.turnNumber}:${match.value.state.phase}:${seatId}`
+  if (!seatId || seatId === humanSeatId.value) {
+    trace('run.skip', { reason: 'not-ai-seat', seatId, humanSeatId: humanSeatId.value })
+    return
+  }
+  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+  if (runToken === lastAppliedAiTurnToken) {
+    trace('run.skip', { reason: 'duplicate-token', runToken, lastAppliedAiTurnToken })
+    return
+  }
   aiTurnInFlight = true
   try {
-  if (debugMode.value) {
-    console.log('[DungeonRunner][AITurn][Start]', {
-      phase: match.value.state.phase,
-      seatId,
-      humanSeatId: humanSeatId.value,
-      turnNumber: match.value.state.turn.turnNumber,
-    })
-  }
+  trace('run.begin', {
+    runToken,
+    phase: match.value.state.phase,
+    seatId,
+    turnNumber: match.value.state.turn.turnNumber,
+    biddingSubphase: match.value.state.bidding?.subphase ?? null,
+    revealedMonsterCard: match.value.state.bidding?.revealedMonsterCard ?? null,
+    dungeonSubphase: match.value.state.dungeon?.subphase ?? null,
+  })
   const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
   const roleType = seat?.role?.type
   let action = null
   if (roleType === 'nn') {
     const modelId = seat.role.modelId ?? 'latest'
-    if (debugMode.value) console.log('[DungeonRunner][AITurn][NN]', { seatId, modelId })
     if (nnFailureRecovery.isCoolingDown(modelId)) {
+      trace('choose.randombot', { reason: 'model-cooldown', modelId })
       action = chooseRandombotAction(match.value.state, { seatId })
     } else {
-      action = await chooseNnActionWithFallback(match.value.state, { seatId }, nnRuntimeOptions(modelId))
+      await ensureNnModelsReady()
+      action = await consumeAiTurnPrefetch(runToken, (step, detail) => trace(step, detail))
+      if (action) {
+        trace('choose.prefetch-hit', { modelId, actionType: action.type })
+      } else {
+        trace('choose.nn.begin', { modelId })
+        action = await chooseNnActionWithFallback(match.value.state, { seatId }, nnRuntimeOptions(modelId))
+        trace('choose.nn.done', { modelId, actionType: action?.type ?? null, fallbackReason: action?.meta?.fallbackReason ?? null })
+      }
       if (action?.meta?.fallbackReason === 'MODEL_LOAD_FAILED') {
-        action = await handleNnModelFailure(seat, modelId, seatId, action)
+        // Use the safe fallback for this turn; recovery UI must not block the AI pipeline.
+        void handleNnModelFailure(seat, modelId, seatId, action)
       }
     }
   } else {
-    if (debugMode.value) console.log('[DungeonRunner][AITurn][Randombot]', { seatId })
+    trace('choose.randombot', { seatId })
     action = chooseRandombotAction(match.value.state, { seatId })
   }
-  if (debugMode.value) console.log('[DungeonRunner][AITurn][Action]', { seatId, action })
-  if (!action) return
-  if (!match.value) return
-  const currentToken = `${match.value.id}:${match.value.state.turn.turnNumber}:${match.value.state.phase}:${match.value.state.turn.activeSeatId}`
-  if (runToken !== currentToken) return
+  if (!action) {
+    trace('choose.empty', { seatId, roleType })
+    action = chooseRandombotAction(match.value.state, { seatId })
+  }
+  if (!action) {
+    trace('run.abort', { reason: 'no-action' })
+    return
+  }
+  if (!match.value) {
+    trace('run.abort', { reason: 'match-cleared' })
+    return
+  }
+  const currentToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+  if (runToken !== currentToken) {
+    trace('run.abort', { reason: 'stale-token', runToken, currentToken })
+    return
+  }
   const prevState = match.value.state
   if (humanSeatId.value) {
     previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
   }
   const result = applyAction(prevState, action, { seatId })
-  if (!result.ok) return
+  if (!result.ok) {
+    trace('run.abort', { reason: 'apply-failed', actionType: action.type })
+    return
+  }
+  lastAppliedAiTurnToken = runToken
   const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
   if (deferExit) {
     deferredPostDungeonState.value = result.state
@@ -1517,10 +1643,68 @@ async function runAiTurn() {
     deferredPostDungeonState.value = null
     match.value = { ...match.value, state: result.state }
   }
+  trace('run.applied', {
+    actionType: action.type,
+    nextRunToken: buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state }),
+    phaseAfter: match.value.state.phase,
+    turnAfterSeatId: match.value.state.turn.activeSeatId,
+    deferExit,
+  })
   enqueuePresentationTransition(prevState, result.state, action, seatId, roleType ?? 'randombot')
+  if (debugMode.value) {
+    const snap = presentationOrchestrator.getQueueSnapshot()
+    trace('presentation.enqueued', {
+      queue: snap.map((item) => item.kind),
+      queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
+    })
+  }
+  primeAiTurnPrefetch()
   } finally {
     aiTurnInFlight = false
+    trace('run.finally', { inFlight: false })
   }
+}
+
+function primeAiTurnPrefetch() {
+  const trace = aiTurnTrace()
+  if (!match.value || isHumanTurn.value) {
+    logAiTurnPrimeSkip(!match.value ? 'no-match' : 'human-turn')
+    return
+  }
+  const state = match.value.state
+  const seatId = state.turn?.activeSeatId
+  if (!seatId || seatId === humanSeatId.value) {
+    logAiTurnPrimeSkip('not-ai-seat', { seatId })
+    return
+  }
+  if (
+    state.phase !== 'bidding' &&
+    state.phase !== 'dungeon' &&
+    state.phase !== 'pick-adventurer'
+  ) {
+    logAiTurnPrimeSkip('phase', { phase: state.phase })
+    return
+  }
+  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state })
+  if (!runToken || runToken === lastAppliedAiTurnToken) {
+    logAiTurnPrimeSkip('token-not-ready', { runToken })
+    return
+  }
+  const seat = state.seats.find((candidate) => candidate.id === seatId)
+  if (seat?.role?.type !== 'nn') {
+    logAiTurnPrimeSkip('not-nn-seat', { roleType: seat?.role?.type ?? null })
+    return
+  }
+  lastPrimeSkipTraceKey = ''
+  const modelId = seat.role.modelId ?? 'latest'
+  startAiTurnPrefetch({
+    runToken,
+    trace: (step, detail) => trace(step, detail),
+    compute: async () => {
+      await ensureNnModelsReady()
+      return chooseNnActionWithFallback(state, { seatId }, nnRuntimeOptions(modelId))
+    },
+  })
 }
 
 function shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState) {
@@ -1627,7 +1811,23 @@ function enrichPresentationForViewer(head) {
 function syncPresentationLabel() {
   activePresentation.value = enrichPresentationForViewer(presentationOrchestrator.getActiveAnimation())
   activePresentationLabel.value = activePresentation.value?.label ?? ''
-  gameplayInputLocked.value = presentationOrchestrator.isGameplayInputLocked()
+  const locked = presentationOrchestrator.isGameplayInputLocked()
+  gameplayInputLocked.value = locked
+  if (presentationInputWasLocked && !locked) {
+    lastScheduleSkipKey = ''
+    lastPrimeSkipTraceKey = ''
+    if (debugMode.value) {
+      const snap = presentationOrchestrator.getQueueSnapshot()
+      aiTurnTrace()('presentation.unlock', {
+        queuedKinds: snap.map((item) => item.kind),
+        isHumanTurn: isHumanTurn.value,
+        activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
+      })
+    }
+    scheduleAiTurnIfReady()
+    scheduleHumanAutoResolveIfReady()
+  }
+  presentationInputWasLocked = locked
   if (presentationTraceEnabled()) {
     const a = activePresentation.value
     const key = a ? `${a.id}:${a.kind}` : 'idle'
@@ -1655,21 +1855,59 @@ function humanDungeonAutoRevealGapMs() {
 }
 
 function scheduleAiTurnIfReady() {
-  if (aiTurnInFlight) return
-  if (deferredPostDungeonState.value) return
-  if (!match.value || gameplayInputLocked.value || isHumanTurn.value) return
+  if (aiTurnInFlight) {
+    logAiTurnScheduleSkip('in-flight')
+    return
+  }
+  if (deferredPostDungeonState.value) {
+    logAiTurnScheduleSkip('deferred-post-dungeon')
+    return
+  }
+  if (!match.value || isHumanTurn.value) {
+    return
+  }
+  if (gameplayInputLocked.value) {
+    const snap = presentationOrchestrator.getQueueSnapshot()
+    const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+    logAiTurnScheduleSkip('gameplay-locked', {
+      activeKind: snap[0]?.kind ?? null,
+      queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
+      queueKinds: snap.map((item) => item.kind),
+      runToken,
+    })
+    primeAiTurnPrefetch()
+    if (aiTurnTimerId) {
+      window.clearTimeout(aiTurnTimerId)
+      aiTurnTimerId = null
+    }
+    return
+  }
+  primeAiTurnPrefetch()
   if (
     match.value.state.phase !== 'bidding' &&
     match.value.state.phase !== 'dungeon' &&
     match.value.state.phase !== 'pick-adventurer'
   ) {
+    logAiTurnScheduleSkip('phase-not-actionable', { phase: match.value.state.phase })
     return
   }
-  if (aiTurnTimerId) return
+  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+  if (runToken && runToken === lastAppliedAiTurnToken) {
+    logAiTurnScheduleSkip('already-applied-token', { runToken })
+    return
+  }
+  if (aiTurnTimerId) {
+    logAiTurnScheduleSkip('timer-pending', { runToken })
+    return
+  }
+  if (debugMode.value) {
+    aiTurnTrace()('schedule.timer-armed', { runToken, delayMs: AI_TURN_SCHEDULE_DELAY_MS })
+  }
   aiTurnTimerId = window.setTimeout(() => {
     aiTurnTimerId = null
+    if (debugMode.value) aiTurnTrace()('schedule.timer-fired', { runToken })
     void runAiTurn()
-  }, 900)
+  }, AI_TURN_SCHEDULE_DELAY_MS)
 }
 
 function scheduleHumanAutoResolveIfReady() {
@@ -1755,6 +1993,7 @@ function nnRuntimeOptions(modelId) {
   if (!debugMode.value) return { modelId }
   return {
     modelId,
+    pipelineTrace: true,
     debugTrace: true,
     debugLogger(trace) {
       const payload = {
@@ -1856,6 +2095,9 @@ function importReplay() {
 .dr-page {
   flex: 1 1 0;
   min-height: 0;
+  min-width: 0;
+  width: 100%;
+  overflow: hidden;
 }
 
 .dr-scroll {


### PR DESCRIPTION
## Summary

Closes #125.

- Adds a **desktop phone frame** to the shared **project shell**: at `md+` (≥1024px), Game Timer, Movie Vote, and Dungeon Runner render in a centered ~390px portrait column with dark gutters; below `md`, layout stays full-bleed.
- Extracts testable frame logic (`desktopPhoneFrame.js`, `projectShellFrame.js`) for breakpoint gating, column width shrink, and height cap (`min(90dvh, width × 19.5/9)`).
- Scopes Quasar overlays and **Notify** to the frame column on desktop via portal target sync and shell-level notify framing helpers.
- Updates `CONTEXT.md` glossary for **desktop phone frame** / **project shell** alignment.

Also on this branch (Dungeon Runner follow-ups tied to framed presentation):

- NN runtime pipeline trace + worker hooks for AI turn debugging.
- AI turn prefetch/token modules and related page wiring.
- Presentation motion registry updates for ghost-flight coordinate cloning inside the frame.

## Test plan

- [ ] At ≥1024px width: each mobile **project** shows centered frame, gutters, no horizontal scroll on shell.
- [ ] At &lt;1024px: full-bleed unchanged; resize across `md` without reload.
- [ ] Desktop: confirm dialogs, menus, and **Notify** toasts appear inside the frame column (Game Timer, Movie Vote, Dungeon Runner).
- [ ] Fullscreen toggle on Game Timer / Dungeon Runner still uses whole-tab fullscreen.
- [ ] `npm test` (frame/portal/notify unit tests + dungeon-runner additions).