### PR TITLE
Star-room: shared Firebase RTDB adapter factory (#116)

### DIFF
--- a/src/features/game-timer/firebase/rtdb.js
+++ b/src/features/game-timer/firebase/rtdb.js
@@ -1,122 +1,17 @@
-import { getApps, initializeApp } from 'firebase/app'
-import { getDatabase, ref, set } from 'firebase/database'
+import { createRoomRtdbApi } from '../../p2p/firebase/createRoomRtdbApi.js'
 
-const ROOMS_ROOT = 'gameTimerRooms'
+const {
+  getDatabase,
+  roomPath,
+  roomRef,
+  sanitizeForRtdb,
+  setRtdb,
+} = createRoomRtdbApi({
+  roomsRoot: 'gameTimerRooms',
+  label: 'Game Timer Firebase RTDB',
+})
 
-/** @param {Record<string, unknown>} env */
-function envString(env, key) {
-  const fromMeta = String(env[key] ?? '').trim()
-  if (fromMeta) return fromMeta
-  const fromProcess =
-    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
-  return String(fromProcess ?? '').trim()
-}
-
-/** @returns {import('firebase/app').FirebaseOptions | null} */
-function readFirebaseConfig() {
-  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
-  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
-  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
-  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
-  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
-
-  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
-    return null
-  }
-
-  /** @type {import('firebase/app').FirebaseOptions} */
-  const config = {
-    apiKey,
-    authDomain,
-    databaseURL,
-    projectId,
-    appId,
-  }
-
-  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
-  if (storageBucket) config.storageBucket = storageBucket
-
-  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
-  if (messagingSenderId) config.messagingSenderId = messagingSenderId
-
-  return config
-}
-
-/** @type {import('firebase/database').Database | null} */
-let databaseInstance = null
-
-// getGameTimerDatabase() throws when required VITE_FIREBASE_* vars are unset.
-/**
- * @returns {import('firebase/database').Database}
- */
-export function getGameTimerDatabase() {
-  if (databaseInstance) return databaseInstance
-
-  const config = readFirebaseConfig()
-  if (!config) {
-    const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-    const required = [
-      'VITE_FIREBASE_API_KEY',
-      'VITE_FIREBASE_AUTH_DOMAIN',
-      'VITE_FIREBASE_DATABASE_URL',
-      'VITE_FIREBASE_PROJECT_ID',
-      'VITE_FIREBASE_APP_ID',
-    ]
-    const missing = required.filter((key) => !envString(env, key))
-    const missingHint =
-      missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
-    throw new Error(
-      `Game Timer Firebase RTDB is not configured. Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
-    )
-  }
-
-  const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
-  databaseInstance = getDatabase(app)
-  return databaseInstance
-}
-
-/**
- * RTDB path for a room suffix (no leading slash).
- * @param {string} suffix
- * @returns {string}
- */
-export function gameTimerRoomPath(suffix) {
-  return `${ROOMS_ROOT}/${suffix}`
-}
-
-/**
- * @param {string} suffix
- * @returns {import('firebase/database').DatabaseReference}
- */
-export function gameTimerRoomRef(suffix) {
-  return ref(getGameTimerDatabase(), gameTimerRoomPath(suffix))
-}
-
-/**
- * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
- * optional fields as undefined (e.g. snapshot `totalGameStartedAt`, `players[].bankedMsByRound`).
- * @param {unknown} value
- * @returns {unknown}
- */
-export function sanitizeForRtdb(value) {
-  if (value === undefined) return null
-  if (value === null || typeof value !== 'object') return value
-  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
-  /** @type {Record<string, unknown>} */
-  const out = {}
-  for (const [key, child] of Object.entries(value)) {
-    if (child === undefined) continue
-    out[key] = sanitizeForRtdb(child)
-  }
-  return out
-}
-
-/**
- * @param {import('firebase/database').DatabaseReference} dbRef
- * @param {unknown} value
- * @returns {Promise<void>}
- */
-export function setRtdb(dbRef, value) {
-  return set(dbRef, sanitizeForRtdb(value))
-}
+export const getGameTimerDatabase = getDatabase
+export const gameTimerRoomPath = roomPath
+export const gameTimerRoomRef = roomRef
+export { sanitizeForRtdb, setRtdb }

--- a/src/features/game-timer/firebase/rtdb.test.js
+++ b/src/features/game-timer/firebase/rtdb.test.js
@@ -60,6 +60,34 @@ test('gameTimerRoomPath maps suffix under gameTimerRooms', async () => {
   assert.equal(gameTimerRoomPath('abc123'), 'gameTimerRooms/abc123')
 })
 
+test('getGameTimerDatabase error lists missing VITE_FIREBASE_* keys', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { getGameTimerDatabase } = await import(`./rtdb.js?partial=${Date.now()}`)
+      assert.throws(
+        () => getGameTimerDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, /Game Timer Firebase RTDB/)
+          assert.match(err.message, /Missing:/)
+          assert.match(err.message, /VITE_FIREBASE_AUTH_DOMAIN/)
+          assert.match(err.message, /VITE_FIREBASE_DATABASE_URL/)
+          assert.match(err.message, /VITE_FIREBASE_PROJECT_ID/)
+          assert.match(err.message, /VITE_FIREBASE_APP_ID/)
+          assert.doesNotMatch(err.message, /VITE_FIREBASE_API_KEY/)
+          return true
+        },
+      )
+    },
+  )
+})
+
 test('getGameTimerDatabase returns the same instance (lazy singleton)', async () => {
   await withFirebaseEnv({}, async () => {
     const { getGameTimerDatabase } = await import(`./rtdb.js?singleton=${Date.now()}`)
@@ -78,8 +106,18 @@ test('gameTimerRoomRef points at gameTimerRooms/{suffix}', async () => {
   })
 })
 
+test('game timer RTDB module exposes the frozen public surface', async () => {
+  const mod = await import('./rtdb.js')
+  assert.equal(typeof mod.getGameTimerDatabase, 'function')
+  assert.equal(typeof mod.gameTimerRoomPath, 'function')
+  assert.equal(typeof mod.gameTimerRoomRef, 'function')
+  assert.equal(typeof mod.sanitizeForRtdb, 'function')
+  assert.equal(typeof mod.setRtdb, 'function')
+})
+
 test('sanitizeForRtdb drops undefined keys (RTDB rejects undefined)', async () => {
   const { sanitizeForRtdb } = await import('./rtdb.js')
+  assert.equal(sanitizeForRtdb(undefined), null)
   const out = sanitizeForRtdb({
     players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
     activePlayerId: null,
@@ -90,5 +128,20 @@ test('sanitizeForRtdb drops undefined keys (RTDB rejects undefined)', async () =
     players: [{ id: 'a', name: 'Alice' }],
     activePlayerId: null,
     round: 1,
+  })
+})
+
+test('setRtdb returns a promise without throwing synchronously when configured', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { setRtdb, gameTimerRoomRef } = await import(`./rtdb.js?set=${Date.now()}`)
+    const ref = gameTimerRoomRef('promise-room')
+    let result
+    assert.doesNotThrow(() => {
+      result = setRtdb(ref, {
+        round: 1,
+        totalGameStartedAt: undefined,
+      })
+    })
+    assert.ok(result instanceof Promise)
   })
 })

--- a/src/features/movie-vote/firebase/rtdb.js
+++ b/src/features/movie-vote/firebase/rtdb.js
@@ -1,122 +1,17 @@
-import { getApps, initializeApp } from 'firebase/app'
-import { getDatabase, ref, set } from 'firebase/database'
+import { createRoomRtdbApi } from '../../p2p/firebase/createRoomRtdbApi.js'
 
-const ROOMS_ROOT = 'movieVoteRooms'
+const {
+  getDatabase,
+  roomPath,
+  roomRef,
+  sanitizeForRtdb,
+  setRtdb,
+} = createRoomRtdbApi({
+  roomsRoot: 'movieVoteRooms',
+  label: 'Movie Vote Firebase RTDB',
+})
 
-/** @param {Record<string, unknown>} env */
-function envString(env, key) {
-  const fromMeta = String(env[key] ?? '').trim()
-  if (fromMeta) return fromMeta
-  const fromProcess =
-    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
-  return String(fromProcess ?? '').trim()
-}
-
-/** @returns {import('firebase/app').FirebaseOptions | null} */
-function readFirebaseConfig() {
-  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
-  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
-  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
-  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
-  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
-
-  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
-    return null
-  }
-
-  /** @type {import('firebase/app').FirebaseOptions} */
-  const config = {
-    apiKey,
-    authDomain,
-    databaseURL,
-    projectId,
-    appId,
-  }
-
-  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
-  if (storageBucket) config.storageBucket = storageBucket
-
-  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
-  if (messagingSenderId) config.messagingSenderId = messagingSenderId
-
-  return config
-}
-
-/** @type {import('firebase/database').Database | null} */
-let databaseInstance = null
-
-// getMovieVoteDatabase() throws when required VITE_FIREBASE_* vars are unset.
-/**
- * @returns {import('firebase/database').Database}
- */
-export function getMovieVoteDatabase() {
-  if (databaseInstance) return databaseInstance
-
-  const config = readFirebaseConfig()
-  if (!config) {
-    const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-    const required = [
-      'VITE_FIREBASE_API_KEY',
-      'VITE_FIREBASE_AUTH_DOMAIN',
-      'VITE_FIREBASE_DATABASE_URL',
-      'VITE_FIREBASE_PROJECT_ID',
-      'VITE_FIREBASE_APP_ID',
-    ]
-    const missing = required.filter((key) => !envString(env, key))
-    const missingHint =
-      missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
-    throw new Error(
-      `Movie Vote Firebase RTDB is not configured. Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
-    )
-  }
-
-  const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
-  databaseInstance = getDatabase(app)
-  return databaseInstance
-}
-
-/**
- * RTDB path for a room suffix (no leading slash).
- * @param {string} suffix
- * @returns {string}
- */
-export function movieVoteRoomPath(suffix) {
-  return `${ROOMS_ROOT}/${suffix}`
-}
-
-/**
- * @param {string} suffix
- * @returns {import('firebase/database').DatabaseReference}
- */
-export function movieVoteRoomRef(suffix) {
-  return ref(getMovieVoteDatabase(), movieVoteRoomPath(suffix))
-}
-
-/**
- * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
- * optional fields as undefined (e.g. ballotMovies[].customKey for TMDB picks).
- * @param {unknown} value
- * @returns {unknown}
- */
-export function sanitizeForRtdb(value) {
-  if (value === undefined) return null
-  if (value === null || typeof value !== 'object') return value
-  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
-  /** @type {Record<string, unknown>} */
-  const out = {}
-  for (const [key, child] of Object.entries(value)) {
-    if (child === undefined) continue
-    out[key] = sanitizeForRtdb(child)
-  }
-  return out
-}
-
-/**
- * @param {import('firebase/database').DatabaseReference} dbRef
- * @param {unknown} value
- * @returns {Promise<void>}
- */
-export function setRtdb(dbRef, value) {
-  return set(dbRef, sanitizeForRtdb(value))
-}
+export const getMovieVoteDatabase = getDatabase
+export const movieVoteRoomPath = roomPath
+export const movieVoteRoomRef = roomRef
+export { sanitizeForRtdb, setRtdb }

--- a/src/features/movie-vote/firebase/rtdb.test.js
+++ b/src/features/movie-vote/firebase/rtdb.test.js
@@ -45,6 +45,7 @@ test('getMovieVoteDatabase throws when Firebase env is missing', async () => {
         () => getMovieVoteDatabase(),
         (err) => {
           assert.ok(err instanceof Error)
+          assert.match(err.message, /Movie Vote Firebase RTDB/)
           assert.match(err.message, /VITE_FIREBASE_\*/)
           assert.match(err.message, /\.env\.example/)
           return true

--- a/src/features/p2p/CONTEXT.md
+++ b/src/features/p2p/CONTEXT.md
@@ -84,6 +84,8 @@ Stopping live RTDB listeners and writes without discarding persisted **room** id
 
 Clients may read and write only under known **app-scoped room paths** and the portfolio **completed match replay** archive root—not at the database root. No Firebase sign-in is required; **stable client identity** remains the in-room principal.
 
+Star-room **projects** (Game Timer, Movie Vote) share one write-sanitization path for payloads bound for those **app-scoped room paths**; the **completed match replay** archive uses the same Firebase project but a separate write path.
+
 _Avoid_: “Anonymous Firebase auth” when meaning this model (Firebase Auth is not used); “secured database” implying account login.
 
 ### Room suffix gate

--- a/src/features/p2p/firebase/createRoomRtdbApi.js
+++ b/src/features/p2p/firebase/createRoomRtdbApi.js
@@ -1,0 +1,122 @@
+import { getApps, initializeApp } from 'firebase/app'
+import { getDatabase, ref, set } from 'firebase/database'
+
+/** @param {Record<string, unknown>} env */
+function envString(env, key) {
+  const fromMeta = String(env[key] ?? '').trim()
+  if (fromMeta) return fromMeta
+  const fromProcess =
+    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
+  return String(fromProcess ?? '').trim()
+}
+
+/** @returns {import('firebase/app').FirebaseOptions | null} */
+function readFirebaseConfig() {
+  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
+  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
+  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
+  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
+  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
+
+  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
+    return null
+  }
+
+  /** @type {import('firebase/app').FirebaseOptions} */
+  const config = {
+    apiKey,
+    authDomain,
+    databaseURL,
+    projectId,
+    appId,
+  }
+
+  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
+  if (storageBucket) config.storageBucket = storageBucket
+
+  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
+  if (messagingSenderId) config.messagingSenderId = messagingSenderId
+
+  return config
+}
+
+/** @type {import('firebase/database').Database | null} */
+let databaseInstance = null
+
+/**
+ * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
+ * optional fields as undefined (e.g. snapshot `totalGameStartedAt`, `players[].bankedMsByRound`).
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sanitizeForRtdb(value) {
+  if (value === undefined) return null
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
+  /** @type {Record<string, unknown>} */
+  const out = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (child === undefined) continue
+    out[key] = sanitizeForRtdb(child)
+  }
+  return out
+}
+
+/**
+ * @param {{ roomsRoot: string, label: string }} options
+ * @returns {{
+ *   getDatabase: () => import('firebase/database').Database,
+ *   roomPath: (suffix: string) => string,
+ *   roomRef: (suffix: string) => import('firebase/database').DatabaseReference,
+ *   sanitizeForRtdb: (value: unknown) => unknown,
+ *   setRtdb: (dbRef: import('firebase/database').DatabaseReference, value: unknown) => Promise<void>,
+ * }}
+ */
+export function createRoomRtdbApi({ roomsRoot, label }) {
+  function getDatabaseInstance() {
+    if (databaseInstance) return databaseInstance
+
+    const config = readFirebaseConfig()
+    if (!config) {
+      const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+      const required = [
+        'VITE_FIREBASE_API_KEY',
+        'VITE_FIREBASE_AUTH_DOMAIN',
+        'VITE_FIREBASE_DATABASE_URL',
+        'VITE_FIREBASE_PROJECT_ID',
+        'VITE_FIREBASE_APP_ID',
+      ]
+      const missing = required.filter((key) => !envString(env, key))
+      const missingHint =
+        missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
+      throw new Error(
+        `${label} is not configured. Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
+      )
+    }
+
+    const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
+    databaseInstance = getDatabase(app)
+    return databaseInstance
+  }
+
+  function roomPath(suffix) {
+    return `${roomsRoot}/${suffix}`
+  }
+
+  function roomRef(suffix) {
+    return ref(getDatabaseInstance(), roomPath(suffix))
+  }
+
+  function setRtdb(dbRef, value) {
+    return set(dbRef, sanitizeForRtdb(value))
+  }
+
+  return {
+    getDatabase: getDatabaseInstance,
+    roomPath,
+    roomRef,
+    sanitizeForRtdb,
+    setRtdb,
+  }
+}

--- a/src/features/p2p/firebase/createRoomRtdbApi.test.js
+++ b/src/features/p2p/firebase/createRoomRtdbApi.test.js
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+
+const REQUIRED_FIREBASE_ENV = {
+  VITE_FIREBASE_API_KEY: 'test-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
+  VITE_FIREBASE_PROJECT_ID: 'test-project',
+  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
+}
+
+const TEST_LABEL = 'Star Room Firebase RTDB'
+
+/** @param {Record<string, string | undefined>} overrides */
+async function withFirebaseEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+    saved[key] = process.env[key]
+    delete process.env[key]
+  }
+  for (const [key, value] of Object.entries({ ...REQUIRED_FIREBASE_ENV, ...overrides })) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  try {
+    return await fn()
+  } finally {
+    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
+test('createRoomRtdbApi returns the room RTDB contract', async () => {
+  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
+  const api = createRoomRtdbApi({
+    roomsRoot: 'gameTimerRooms',
+    label: TEST_LABEL,
+  })
+  assert.equal(typeof api.getDatabase, 'function')
+  assert.equal(typeof api.roomPath, 'function')
+  assert.equal(typeof api.roomRef, 'function')
+  assert.equal(typeof api.sanitizeForRtdb, 'function')
+  assert.equal(typeof api.setRtdb, 'function')
+})
+
+test('sanitizeForRtdb drops undefined keys and maps top-level undefined to null', async () => {
+  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
+  const { sanitizeForRtdb } = createRoomRtdbApi({
+    roomsRoot: 'gameTimerRooms',
+    label: TEST_LABEL,
+  })
+  assert.equal(sanitizeForRtdb(undefined), null)
+  const out = sanitizeForRtdb({
+    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
+    activePlayerId: null,
+    totalGameStartedAt: undefined,
+    round: 1,
+  })
+  assert.deepEqual(out, {
+    players: [{ id: 'a', name: 'Alice' }],
+    activePlayerId: null,
+    round: 1,
+  })
+})
+
+test('sanitizeForRtdb preserves null and matches game-timer semantics', async () => {
+  const { sanitizeForRtdb: gameTimerSanitize } = await import(
+    '../../game-timer/firebase/rtdb.js',
+  )
+  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
+  const { sanitizeForRtdb } = createRoomRtdbApi({
+    roomsRoot: 'gameTimerRooms',
+    label: TEST_LABEL,
+  })
+  const fixture = {
+    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
+    activePlayerId: null,
+    totalGameStartedAt: undefined,
+    round: 1,
+  }
+  assert.equal(sanitizeForRtdb(undefined), null)
+  assert.deepEqual(sanitizeForRtdb({ kept: null, dropped: undefined }), { kept: null })
+  assert.deepEqual(sanitizeForRtdb(fixture), gameTimerSanitize(fixture))
+})
+
+test('getDatabase throws when Firebase env is missing', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRoomRtdbApi } = await import(
+        `./createRoomRtdbApi.js?missing=${Date.now()}`
+      )
+      const { getDatabase } = createRoomRtdbApi({
+        roomsRoot: 'gameTimerRooms',
+        label: TEST_LABEL,
+      })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, new RegExp(TEST_LABEL))
+          assert.match(err.message, /VITE_FIREBASE_\*/)
+          assert.match(err.message, /\.env\.example/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('getDatabase error lists missing VITE_FIREBASE_* keys', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRoomRtdbApi } = await import(
+        `./createRoomRtdbApi.js?partial=${Date.now()}`,
+      )
+      const { getDatabase } = createRoomRtdbApi({
+        roomsRoot: 'gameTimerRooms',
+        label: TEST_LABEL,
+      })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, /Missing:/)
+          assert.match(err.message, /VITE_FIREBASE_AUTH_DOMAIN/)
+          assert.match(err.message, /VITE_FIREBASE_DATABASE_URL/)
+          assert.match(err.message, /VITE_FIREBASE_PROJECT_ID/)
+          assert.match(err.message, /VITE_FIREBASE_APP_ID/)
+          assert.doesNotMatch(err.message, /VITE_FIREBASE_API_KEY/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('two factory instances share the same getDatabase singleton', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { createRoomRtdbApi } = await import(
+      `./createRoomRtdbApi.js?singleton=${Date.now()}`
+    )
+    const timerApi = createRoomRtdbApi({
+      roomsRoot: 'gameTimerRooms',
+      label: TEST_LABEL,
+    })
+    const voteApi = createRoomRtdbApi({
+      roomsRoot: 'movieVoteRooms',
+      label: 'Movie Vote Firebase RTDB',
+    })
+    assert.equal(timerApi.getDatabase(), voteApi.getDatabase())
+    assert.equal(timerApi.getDatabase(), timerApi.getDatabase())
+  })
+})
+
+test('roomPath and roomRef use the supplied roomsRoot', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { createRoomRtdbApi } = await import(
+      `./createRoomRtdbApi.js?ref=${Date.now()}`
+    )
+    const { roomPath, roomRef } = createRoomRtdbApi({
+      roomsRoot: 'movieVoteRooms',
+      label: TEST_LABEL,
+    })
+    assert.equal(roomPath('abc123'), 'movieVoteRooms/abc123')
+    const ref = roomRef('abc123')
+    assert.equal(ref.key, 'abc123')
+    assert.equal(ref.parent?.key, 'movieVoteRooms')
+  })
+})
+
+test('setRtdb returns a promise without throwing synchronously when configured', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { createRoomRtdbApi } = await import(
+      `./createRoomRtdbApi.js?setp=${Date.now()}`,
+    )
+    const { setRtdb, roomRef } = createRoomRtdbApi({
+      roomsRoot: 'gameTimerRooms',
+      label: TEST_LABEL,
+    })
+    const ref = roomRef('promise-room')
+    let result
+    assert.doesNotThrow(() => {
+      result = setRtdb(ref, {
+        round: 1,
+        totalGameStartedAt: undefined,
+      })
+    })
+    assert.ok(result instanceof Promise)
+  })
+})
+
+test(
+  'setRtdb calls Firebase set with sanitized payload',
+  { skip: !mock.module },
+  async () => {
+    const actual = await import('firebase/database')
+    /** @type {Array<{ value: unknown }>} */
+    const setCalls = []
+    mock.module('firebase/database', {
+      namedExports: {
+        ...actual,
+        set: async (_ref, value) => {
+          setCalls.push({ value })
+        },
+      },
+    })
+
+    await withFirebaseEnv({}, async () => {
+      const { createRoomRtdbApi } = await import(
+        `./createRoomRtdbApi.js?set=${Date.now()}`,
+      )
+      const { setRtdb, roomRef } = createRoomRtdbApi({
+        roomsRoot: 'gameTimerRooms',
+        label: TEST_LABEL,
+      })
+      const ref = roomRef('set-test')
+      await setRtdb(ref, {
+        players: [{ id: 'a', bankedMsByRound: undefined }],
+        activePlayerId: null,
+        totalGameStartedAt: undefined,
+        round: 1,
+      })
+      assert.equal(setCalls.length, 1)
+      assert.deepEqual(setCalls[0].value, {
+        players: [{ id: 'a' }],
+        activePlayerId: null,
+        round: 1,
+      })
+    })
+  },
+)


### PR DESCRIPTION
## Summary

- Add `createRoomRtdbApi` under `src/features/p2p/firebase/` — shared Firebase config read, one lazy RTDB handle, write sanitization, and room path/ref helpers parameterized by **app-scoped room path** root and project label.
- Replace duplicated logic in Game Timer and Movie Vote with thin wrappers that re-export the same public surface (`get*Database`, `*RoomPath`, `*RoomRef`, `sanitizeForRtdb`, `setRtdb`).
- Glossary: **Path-scoped RTDB access** notes Game Timer and Movie Vote share write sanitization for **app-scoped room paths**; **completed match replay** stays separate (#131).

Closes #116, #132, #133, #134.

## Invariants

- `gameTimerRooms` / `movieVoteRooms` roots unchanged
- **Room** session imports unchanged
- One shared database singleton across both star-room **projects**

## Test plan

- [x] `node --test src/features/p2p/firebase/createRoomRtdbApi.test.js`
- [x] `node --test src/features/game-timer/firebase/rtdb.test.js`
- [x] `node --test src/features/game-timer/p2p/protocol.test.js`
- [x] `node --test src/features/movie-vote/firebase/rtdb.test.js`
- [ ] Manual: Game Timer host/join + state sync (two tabs)
- [ ] Manual: Movie Vote host/join + nomination sync (two tabs)