### PR TITLE
Share Firebase RTDB core between star-room and completed match replay archive

### DIFF
--- a/docs/adr/0005-shared-firebase-rtdb-core.md
+++ b/docs/adr/0005-shared-firebase-rtdb-core.md
@@ -1,0 +1,9 @@
+# Shared Firebase RTDB core (star-room and replay archive)
+
+After #116, Game Timer and Movie Vote share `createRoomRtdbApi` for **app-scoped room paths**. Dungeon Runner still duplicated Firebase config read, RTDB sanitization, and `setRtdb` for the **completed match replay archive** (`dungeonRunnerCompletedMatches/`). #131 dedupes that without changing archive paths, **replay envelope** shape, or upload opt-out when Firebase is unset.
+
+We introduce `createRtdbCore({ configuredBehavior, label? })` in the star-room P2P feature: one app-wide RTDB `Database` singleton, shared `sanitizeForRtdb` / `setRtdb`, and `configuredBehavior: 'throw' | 'null'` on `getDatabase()`. Star-room **projects** bind `'throw'` with a product `label` for missing-env errors; Dungeon Runner binds `'null'` (optional `label`) so **match over** upload stays a no-op when env is incomplete. `createRoomRtdbApi` and `dungeon-runner/firebase/rtdb.js` remain thin wrappers—the latter keeps its frozen export surface so `completedMatchReplayUpload` does not change import paths.
+
+**Considered options:** Extend `createRoomRtdbApi` with `roomsRoot` for the archive (rejected: “room” API and **room suffix** semantics do not fit match-id keys). Import only sanitize from shared code while keeping separate DB init in Dungeon Runner (rejected: leaves duplicate singleton and config read).
+
+**Consequences:** Tests move shared behavior to `createRtdbCore.test.js`; Dungeon Runner tests cover nullable config, archive paths, and re-export wiring only. Acceptance: scenarios in #131 (no upload without config, unchanged write path/envelope, star-room throw on miss, one Firebase app per session, one sanitization fix for rooms and archive).

--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -179,6 +179,7 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - Each **match** has exactly one **human player seat**; the human is not an **opponent** in **setup**.
 - A **completed match replay** is a **replay envelope** captured when **match over** is reached.
 - The **completed match replay archive** holds **completed match replay** envelopes keyed by match id; each key is written at most once from the browser; **archive listing** at the root is allowed for maintainer ingest.
+- **Completed match replay archive** writes use the same RTDB payload sanitization as star-room **projects** (Game Timer, Movie Vote); they are not a separate Firebase stack—only the path and optional-upload behavior differ (see [ADR 0005](../../../docs/adr/0005-shared-firebase-rtdb-core.md)).
 - **History** supplies the ordered actions recorded in a **replay envelope**.
 - **TF.js model sync** runs in portfolio-site after dungeon-runner promote; default NN opponents load **web deployed latest** without setup changes.
 

--- a/src/features/dungeon-runner/firebase/rtdb.js
+++ b/src/features/dungeon-runner/firebase/rtdb.js
@@ -1,71 +1,23 @@
-import { getApps, initializeApp } from 'firebase/app'
-import { getDatabase, ref, set } from 'firebase/database'
+import { ref } from 'firebase/database'
+import { createRtdbCore } from '../../p2p/firebase/createRtdbCore.js'
 
 /** RTDB root for completed **match over** payloads ([Replay envelope contract (v1)](../CONTRACT.md#replay-envelope-contract-v1)). */
 const COMPLETED_MATCHES_ROOT = 'dungeonRunnerCompletedMatches'
 
-/** @param {Record<string, unknown>} env */
-function envString(env, key) {
-  const fromMeta = String(env[key] ?? '').trim()
-  if (fromMeta) return fromMeta
-  const fromProcess =
-    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
-  return String(fromProcess ?? '').trim()
-}
-
-/** @returns {import('firebase/app').FirebaseOptions | null} */
-function readFirebaseConfig() {
-  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
-  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
-  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
-  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
-  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
-
-  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
-    return null
-  }
-
-  /** @type {import('firebase/app').FirebaseOptions} */
-  const config = {
-    apiKey,
-    authDomain,
-    databaseURL,
-    projectId,
-    appId,
-  }
-
-  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
-  if (storageBucket) config.storageBucket = storageBucket
-
-  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
-  if (messagingSenderId) config.messagingSenderId = messagingSenderId
-
-  return config
-}
-
-/** @type {import('firebase/database').Database | null} */
-let databaseInstance = null
+const core = createRtdbCore({ configuredBehavior: 'null' })
 
 /**
  * @returns {boolean}
  */
 export function isDungeonRunnerFirebaseConfigured() {
-  return readFirebaseConfig() !== null
+  return core.isConfigured()
 }
 
 /**
  * @returns {import('firebase/database').Database | null}
  */
 export function getDungeonRunnerDatabase() {
-  if (databaseInstance) return databaseInstance
-
-  const config = readFirebaseConfig()
-  if (!config) return null
-
-  const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
-  databaseInstance = getDatabase(app)
-  return databaseInstance
+  return core.getDatabase()
 }
 
 /**
@@ -83,35 +35,11 @@ export function dungeonRunnerCompletedMatchPath(matchId) {
  * @returns {import('firebase/database').DatabaseReference | null}
  */
 export function dungeonRunnerCompletedMatchRef(matchId) {
+  if (!isDungeonRunnerFirebaseConfigured()) return null
   const db = getDungeonRunnerDatabase()
   if (!db) return null
   return ref(db, dungeonRunnerCompletedMatchPath(matchId))
 }
 
-/**
- * RTDB rejects `undefined` anywhere in the tree. v1 envelopes may omit optional
- * fields (`createdAt`, `presentationSpeedProfile`) as undefined before write.
- * @param {unknown} value
- * @returns {unknown}
- */
-export function sanitizeForRtdb(value) {
-  if (value === undefined) return null
-  if (value === null || typeof value !== 'object') return value
-  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
-  /** @type {Record<string, unknown>} */
-  const out = {}
-  for (const [key, child] of Object.entries(value)) {
-    if (child === undefined) continue
-    out[key] = sanitizeForRtdb(child)
-  }
-  return out
-}
-
-/**
- * @param {import('firebase/database').DatabaseReference} dbRef
- * @param {unknown} value
- * @returns {Promise<void>}
- */
-export function setRtdb(dbRef, value) {
-  return set(dbRef, sanitizeForRtdb(value))
-}
+export const sanitizeForRtdb = core.sanitizeForRtdb
+export const setRtdb = core.setRtdb

--- a/src/features/dungeon-runner/firebase/rtdb.test.js
+++ b/src/features/dungeon-runner/firebase/rtdb.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { afterEach, mock, test } from 'node:test'
+import { test } from 'node:test'
 
 const REQUIRED_FIREBASE_ENV = {
   VITE_FIREBASE_API_KEY: 'test-api-key',
@@ -89,16 +89,6 @@ test('dungeonRunnerCompletedMatchPath maps matchId under dungeonRunnerCompletedM
   )
 })
 
-test('getDungeonRunnerDatabase returns the same instance (lazy singleton)', async () => {
-  await withFirebaseEnv({}, async () => {
-    const { getDungeonRunnerDatabase } = await import(`./rtdb.js?singleton=${Date.now()}`)
-    const first = getDungeonRunnerDatabase()
-    const second = getDungeonRunnerDatabase()
-    assert.ok(first)
-    assert.equal(first, second)
-  })
-})
-
 test('dungeonRunnerCompletedMatchRef points at dungeonRunnerCompletedMatches/{matchId}', async () => {
   await withFirebaseEnv({}, async () => {
     const { dungeonRunnerCompletedMatchRef } = await import(`./rtdb.js?ref=${Date.now()}`)
@@ -116,88 +106,20 @@ test('dungeonRunnerCompletedMatchRef returns null when Firebase is not configure
   })
 })
 
-test('sanitizeForRtdb drops undefined keys (RTDB rejects undefined)', async () => {
-  const { sanitizeForRtdb } = await import('./rtdb.js')
-  const out = sanitizeForRtdb({
-    version: 1,
-    seed: 4242,
-    setup: { totalSeats: 2, opponents: [{ role: 'random' }] },
-    history: [{ type: 'bid', value: undefined }],
-    presentationSpeedProfile: undefined,
-  })
-  assert.deepEqual(out, {
-    version: 1,
-    seed: 4242,
-    setup: { totalSeats: 2, opponents: [{ role: 'random' }] },
-    history: [{ type: 'bid' }],
-  })
+test('dungeon runner RTDB module exposes the frozen public surface', async () => {
+  const mod = await import('./rtdb.js')
+  assert.equal(typeof mod.isDungeonRunnerFirebaseConfigured, 'function')
+  assert.equal(typeof mod.getDungeonRunnerDatabase, 'function')
+  assert.equal(typeof mod.dungeonRunnerCompletedMatchPath, 'function')
+  assert.equal(typeof mod.dungeonRunnerCompletedMatchRef, 'function')
+  assert.equal(typeof mod.sanitizeForRtdb, 'function')
+  assert.equal(typeof mod.setRtdb, 'function')
 })
 
-test('sanitizeForRtdb preserves null and nested undefined removal', async () => {
+test('sanitizeForRtdb is wired from shared RTDB core', async () => {
+  const { createRtdbCore } = await import('../../p2p/firebase/createRtdbCore.js')
+  const core = createRtdbCore({ configuredBehavior: 'null' })
   const { sanitizeForRtdb } = await import('./rtdb.js')
   assert.equal(sanitizeForRtdb(undefined), null)
-  assert.deepEqual(sanitizeForRtdb({ kept: null, dropped: undefined }), { kept: null })
-})
-
-test('setRtdb returns a promise without throwing synchronously when configured', async () => {
-  await withFirebaseEnv({}, async () => {
-    const { setRtdb, dungeonRunnerCompletedMatchRef } = await import(`./rtdb.js?setp=${Date.now()}`)
-    const matchRef = dungeonRunnerCompletedMatchRef('match-promise')
-    assert.ok(matchRef)
-    let result
-    assert.doesNotThrow(() => {
-      result = setRtdb(matchRef, {
-        version: 1,
-        seed: 1,
-        presentationSpeedProfile: undefined,
-      })
-    })
-    assert.ok(result instanceof Promise)
-  })
-})
-
-test(
-  'setRtdb calls Firebase set with sanitized payload',
-  { skip: !mock.module },
-  async () => {
-    const actual = await import('firebase/database')
-    /** @type {Array<{ value: unknown }>} */
-    const setCalls = []
-    mock.module('firebase/database', {
-      namedExports: {
-        ...actual,
-        set: async (_ref, value) => {
-          setCalls.push({ value })
-        },
-      },
-    })
-
-    await withFirebaseEnv({}, async () => {
-      const { setRtdb, dungeonRunnerCompletedMatchRef } = await import(
-        `./rtdb.js?set=${Date.now()}`,
-      )
-      const matchRef = dungeonRunnerCompletedMatchRef('match-set-test')
-      assert.ok(matchRef)
-      await setRtdb(matchRef, {
-        version: 1,
-        createdAt: '2026-01-01T00:00:00.000Z',
-        seed: 42,
-        setup: { totalSeats: 2, opponents: [] },
-        history: [],
-        presentationSpeedProfile: undefined,
-      })
-      assert.equal(setCalls.length, 1)
-      assert.deepEqual(setCalls[0].value, {
-        version: 1,
-        createdAt: '2026-01-01T00:00:00.000Z',
-        seed: 42,
-        setup: { totalSeats: 2, opponents: [] },
-        history: [],
-      })
-    })
-  },
-)
-
-afterEach(() => {
-  mock.reset()
+  assert.equal(sanitizeForRtdb, core.sanitizeForRtdb)
 })

--- a/src/features/p2p/firebase/createRoomRtdbApi.js
+++ b/src/features/p2p/firebase/createRoomRtdbApi.js
@@ -1,67 +1,5 @@
-import { getApps, initializeApp } from 'firebase/app'
-import { getDatabase, ref, set } from 'firebase/database'
-
-/** @param {Record<string, unknown>} env */
-function envString(env, key) {
-  const fromMeta = String(env[key] ?? '').trim()
-  if (fromMeta) return fromMeta
-  const fromProcess =
-    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
-  return String(fromProcess ?? '').trim()
-}
-
-/** @returns {import('firebase/app').FirebaseOptions | null} */
-function readFirebaseConfig() {
-  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
-  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
-  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
-  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
-  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
-
-  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
-    return null
-  }
-
-  /** @type {import('firebase/app').FirebaseOptions} */
-  const config = {
-    apiKey,
-    authDomain,
-    databaseURL,
-    projectId,
-    appId,
-  }
-
-  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
-  if (storageBucket) config.storageBucket = storageBucket
-
-  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
-  if (messagingSenderId) config.messagingSenderId = messagingSenderId
-
-  return config
-}
-
-/** @type {import('firebase/database').Database | null} */
-let databaseInstance = null
-
-/**
- * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
- * optional fields as undefined (e.g. snapshot `totalGameStartedAt`, `players[].bankedMsByRound`).
- * @param {unknown} value
- * @returns {unknown}
- */
-function sanitizeForRtdb(value) {
-  if (value === undefined) return null
-  if (value === null || typeof value !== 'object') return value
-  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
-  /** @type {Record<string, unknown>} */
-  const out = {}
-  for (const [key, child] of Object.entries(value)) {
-    if (child === undefined) continue
-    out[key] = sanitizeForRtdb(child)
-  }
-  return out
-}
+import { ref } from 'firebase/database'
+import { createRtdbCore } from './createRtdbCore.js'
 
 /**
  * @param {{ roomsRoot: string, label: string }} options
@@ -74,46 +12,21 @@ function sanitizeForRtdb(value) {
  * }}
  */
 export function createRoomRtdbApi({ roomsRoot, label }) {
-  function getDatabaseInstance() {
-    if (databaseInstance) return databaseInstance
-
-    const config = readFirebaseConfig()
-    if (!config) {
-      const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
-      const required = [
-        'VITE_FIREBASE_API_KEY',
-        'VITE_FIREBASE_AUTH_DOMAIN',
-        'VITE_FIREBASE_DATABASE_URL',
-        'VITE_FIREBASE_PROJECT_ID',
-        'VITE_FIREBASE_APP_ID',
-      ]
-      const missing = required.filter((key) => !envString(env, key))
-      const missingHint =
-        missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
-      throw new Error(
-        `${label} is not configured. Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
-      )
-    }
-
-    const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
-    databaseInstance = getDatabase(app)
-    return databaseInstance
-  }
+  const { getDatabase, sanitizeForRtdb, setRtdb } = createRtdbCore({
+    configuredBehavior: 'throw',
+    label,
+  })
 
   function roomPath(suffix) {
     return `${roomsRoot}/${suffix}`
   }
 
   function roomRef(suffix) {
-    return ref(getDatabaseInstance(), roomPath(suffix))
-  }
-
-  function setRtdb(dbRef, value) {
-    return set(dbRef, sanitizeForRtdb(value))
+    return ref(getDatabase(), roomPath(suffix))
   }
 
   return {
-    getDatabase: getDatabaseInstance,
+    getDatabase,
     roomPath,
     roomRef,
     sanitizeForRtdb,

--- a/src/features/p2p/firebase/createRoomRtdbApi.test.js
+++ b/src/features/p2p/firebase/createRoomRtdbApi.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mock, test } from 'node:test'
+import test from 'node:test'
 
 const REQUIRED_FIREBASE_ENV = {
   VITE_FIREBASE_API_KEY: 'test-api-key',
@@ -45,47 +45,7 @@ test('createRoomRtdbApi returns the room RTDB contract', async () => {
   assert.equal(typeof api.setRtdb, 'function')
 })
 
-test('sanitizeForRtdb drops undefined keys and maps top-level undefined to null', async () => {
-  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
-  const { sanitizeForRtdb } = createRoomRtdbApi({
-    roomsRoot: 'gameTimerRooms',
-    label: TEST_LABEL,
-  })
-  assert.equal(sanitizeForRtdb(undefined), null)
-  const out = sanitizeForRtdb({
-    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
-    activePlayerId: null,
-    totalGameStartedAt: undefined,
-    round: 1,
-  })
-  assert.deepEqual(out, {
-    players: [{ id: 'a', name: 'Alice' }],
-    activePlayerId: null,
-    round: 1,
-  })
-})
-
-test('sanitizeForRtdb preserves null and matches game-timer semantics', async () => {
-  const { sanitizeForRtdb: gameTimerSanitize } = await import(
-    '../../game-timer/firebase/rtdb.js',
-  )
-  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
-  const { sanitizeForRtdb } = createRoomRtdbApi({
-    roomsRoot: 'gameTimerRooms',
-    label: TEST_LABEL,
-  })
-  const fixture = {
-    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
-    activePlayerId: null,
-    totalGameStartedAt: undefined,
-    round: 1,
-  }
-  assert.equal(sanitizeForRtdb(undefined), null)
-  assert.deepEqual(sanitizeForRtdb({ kept: null, dropped: undefined }), { kept: null })
-  assert.deepEqual(sanitizeForRtdb(fixture), gameTimerSanitize(fixture))
-})
-
-test('getDatabase throws when Firebase env is missing', async () => {
+test('getDatabase throws with product label when Firebase env is missing', async () => {
   await withFirebaseEnv(
     {
       VITE_FIREBASE_API_KEY: undefined,
@@ -107,64 +67,11 @@ test('getDatabase throws when Firebase env is missing', async () => {
         (err) => {
           assert.ok(err instanceof Error)
           assert.match(err.message, new RegExp(TEST_LABEL))
-          assert.match(err.message, /VITE_FIREBASE_\*/)
-          assert.match(err.message, /\.env\.example/)
           return true
         },
       )
     },
   )
-})
-
-test('getDatabase error lists missing VITE_FIREBASE_* keys', async () => {
-  await withFirebaseEnv(
-    {
-      VITE_FIREBASE_AUTH_DOMAIN: undefined,
-      VITE_FIREBASE_DATABASE_URL: undefined,
-      VITE_FIREBASE_PROJECT_ID: undefined,
-      VITE_FIREBASE_APP_ID: undefined,
-    },
-    async () => {
-      const { createRoomRtdbApi } = await import(
-        `./createRoomRtdbApi.js?partial=${Date.now()}`,
-      )
-      const { getDatabase } = createRoomRtdbApi({
-        roomsRoot: 'gameTimerRooms',
-        label: TEST_LABEL,
-      })
-      assert.throws(
-        () => getDatabase(),
-        (err) => {
-          assert.ok(err instanceof Error)
-          assert.match(err.message, /Missing:/)
-          assert.match(err.message, /VITE_FIREBASE_AUTH_DOMAIN/)
-          assert.match(err.message, /VITE_FIREBASE_DATABASE_URL/)
-          assert.match(err.message, /VITE_FIREBASE_PROJECT_ID/)
-          assert.match(err.message, /VITE_FIREBASE_APP_ID/)
-          assert.doesNotMatch(err.message, /VITE_FIREBASE_API_KEY/)
-          return true
-        },
-      )
-    },
-  )
-})
-
-test('two factory instances share the same getDatabase singleton', async () => {
-  await withFirebaseEnv({}, async () => {
-    const { createRoomRtdbApi } = await import(
-      `./createRoomRtdbApi.js?singleton=${Date.now()}`
-    )
-    const timerApi = createRoomRtdbApi({
-      roomsRoot: 'gameTimerRooms',
-      label: TEST_LABEL,
-    })
-    const voteApi = createRoomRtdbApi({
-      roomsRoot: 'movieVoteRooms',
-      label: 'Movie Vote Firebase RTDB',
-    })
-    assert.equal(timerApi.getDatabase(), voteApi.getDatabase())
-    assert.equal(timerApi.getDatabase(), timerApi.getDatabase())
-  })
 })
 
 test('roomPath and roomRef use the supplied roomsRoot', async () => {
@@ -183,64 +90,20 @@ test('roomPath and roomRef use the supplied roomsRoot', async () => {
   })
 })
 
-test('setRtdb returns a promise without throwing synchronously when configured', async () => {
-  await withFirebaseEnv({}, async () => {
-    const { createRoomRtdbApi } = await import(
-      `./createRoomRtdbApi.js?setp=${Date.now()}`,
-    )
-    const { setRtdb, roomRef } = createRoomRtdbApi({
-      roomsRoot: 'gameTimerRooms',
-      label: TEST_LABEL,
-    })
-    const ref = roomRef('promise-room')
-    let result
-    assert.doesNotThrow(() => {
-      result = setRtdb(ref, {
-        round: 1,
-        totalGameStartedAt: undefined,
-      })
-    })
-    assert.ok(result instanceof Promise)
+test('sanitizeForRtdb matches game-timer shim semantics', async () => {
+  const { sanitizeForRtdb: gameTimerSanitize } = await import(
+    '../../game-timer/firebase/rtdb.js',
+  )
+  const { createRoomRtdbApi } = await import('./createRoomRtdbApi.js')
+  const { sanitizeForRtdb } = createRoomRtdbApi({
+    roomsRoot: 'gameTimerRooms',
+    label: TEST_LABEL,
   })
+  const fixture = {
+    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
+    activePlayerId: null,
+    totalGameStartedAt: undefined,
+    round: 1,
+  }
+  assert.deepEqual(sanitizeForRtdb(fixture), gameTimerSanitize(fixture))
 })
-
-test(
-  'setRtdb calls Firebase set with sanitized payload',
-  { skip: !mock.module },
-  async () => {
-    const actual = await import('firebase/database')
-    /** @type {Array<{ value: unknown }>} */
-    const setCalls = []
-    mock.module('firebase/database', {
-      namedExports: {
-        ...actual,
-        set: async (_ref, value) => {
-          setCalls.push({ value })
-        },
-      },
-    })
-
-    await withFirebaseEnv({}, async () => {
-      const { createRoomRtdbApi } = await import(
-        `./createRoomRtdbApi.js?set=${Date.now()}`,
-      )
-      const { setRtdb, roomRef } = createRoomRtdbApi({
-        roomsRoot: 'gameTimerRooms',
-        label: TEST_LABEL,
-      })
-      const ref = roomRef('set-test')
-      await setRtdb(ref, {
-        players: [{ id: 'a', bankedMsByRound: undefined }],
-        activePlayerId: null,
-        totalGameStartedAt: undefined,
-        round: 1,
-      })
-      assert.equal(setCalls.length, 1)
-      assert.deepEqual(setCalls[0].value, {
-        players: [{ id: 'a' }],
-        activePlayerId: null,
-        round: 1,
-      })
-    })
-  },
-)

--- a/src/features/p2p/firebase/createRtdbCore.js
+++ b/src/features/p2p/firebase/createRtdbCore.js
@@ -1,0 +1,120 @@
+import { getApps, initializeApp } from 'firebase/app'
+import { getDatabase as firebaseGetDatabase, set } from 'firebase/database'
+
+const REQUIRED_ENV_KEYS = [
+  'VITE_FIREBASE_API_KEY',
+  'VITE_FIREBASE_AUTH_DOMAIN',
+  'VITE_FIREBASE_DATABASE_URL',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_APP_ID',
+]
+
+/** @param {Record<string, unknown>} env */
+function envString(env, key) {
+  const fromMeta = String(env[key] ?? '').trim()
+  if (fromMeta) return fromMeta
+  const fromProcess =
+    typeof process !== 'undefined' && process.env ? process.env[key] : undefined
+  return String(fromProcess ?? '').trim()
+}
+
+/** @returns {import('firebase/app').FirebaseOptions | null} */
+function readFirebaseConfig() {
+  const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+  const apiKey = envString(env, 'VITE_FIREBASE_API_KEY')
+  const authDomain = envString(env, 'VITE_FIREBASE_AUTH_DOMAIN')
+  const databaseURL = envString(env, 'VITE_FIREBASE_DATABASE_URL')
+  const projectId = envString(env, 'VITE_FIREBASE_PROJECT_ID')
+  const appId = envString(env, 'VITE_FIREBASE_APP_ID')
+
+  if (!apiKey || !authDomain || !databaseURL || !projectId || !appId) {
+    return null
+  }
+
+  /** @type {import('firebase/app').FirebaseOptions} */
+  const config = {
+    apiKey,
+    authDomain,
+    databaseURL,
+    projectId,
+    appId,
+  }
+
+  const storageBucket = envString(env, 'VITE_FIREBASE_STORAGE_BUCKET')
+  if (storageBucket) config.storageBucket = storageBucket
+
+  const messagingSenderId = envString(env, 'VITE_FIREBASE_MESSAGING_SENDER_ID')
+  if (messagingSenderId) config.messagingSenderId = messagingSenderId
+
+  return config
+}
+
+/** @type {import('firebase/database').Database | null} */
+let databaseInstance = null
+
+/**
+ * RTDB rejects `undefined` anywhere in the tree; Pinia/JS objects often omit
+ * optional fields as undefined (e.g. snapshot `totalGameStartedAt`, `players[].bankedMsByRound`).
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sanitizeForRtdb(value) {
+  if (value === undefined) return null
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map((item) => sanitizeForRtdb(item))
+  /** @type {Record<string, unknown>} */
+  const out = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (child === undefined) continue
+    out[key] = sanitizeForRtdb(child)
+  }
+  return out
+}
+
+/**
+ * @param {{ configuredBehavior: 'throw' | 'null', label?: string }} options
+ * @returns {{
+ *   getDatabase: () => import('firebase/database').Database | null,
+ *   isConfigured: () => boolean,
+ *   sanitizeForRtdb: (value: unknown) => unknown,
+ *   setRtdb: (dbRef: import('firebase/database').DatabaseReference, value: unknown) => Promise<void>,
+ * }}
+ */
+export function createRtdbCore({ configuredBehavior, label }) {
+  function isConfigured() {
+    return readFirebaseConfig() !== null
+  }
+
+  function getDatabase() {
+    if (databaseInstance) return databaseInstance
+
+    const config = readFirebaseConfig()
+    if (!config) {
+      if (configuredBehavior === 'null') return null
+
+      const env = typeof import.meta.env !== 'undefined' ? import.meta.env : {}
+      const missing = REQUIRED_ENV_KEYS.filter((key) => !envString(env, key))
+      const missingHint =
+        missing.length > 0 ? ` Missing: ${missing.join(', ')}.` : ''
+      const labelPrefix = label ? `${label} is not configured. ` : ''
+      throw new Error(
+        `${labelPrefix}Set VITE_FIREBASE_* in .env (see .env.example).${missingHint}`,
+      )
+    }
+
+    const app = getApps().length > 0 ? getApps()[0] : initializeApp(config)
+    databaseInstance = firebaseGetDatabase(app)
+    return databaseInstance
+  }
+
+  function setRtdb(dbRef, value) {
+    return set(dbRef, sanitizeForRtdb(value))
+  }
+
+  return {
+    getDatabase,
+    isConfigured,
+    sanitizeForRtdb,
+    setRtdb,
+  }
+}

--- a/src/features/p2p/firebase/createRtdbCore.test.js
+++ b/src/features/p2p/firebase/createRtdbCore.test.js
@@ -1,0 +1,388 @@
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+
+const REQUIRED_FIREBASE_ENV = {
+  VITE_FIREBASE_API_KEY: 'test-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
+  VITE_FIREBASE_PROJECT_ID: 'test-project',
+  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
+}
+
+const TEST_LABEL = 'Test Firebase RTDB'
+
+/** @param {Record<string, string | undefined>} overrides */
+async function withFirebaseEnv(overrides, fn) {
+  const saved = {}
+  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+    saved[key] = process.env[key]
+    delete process.env[key]
+  }
+  for (const [key, value] of Object.entries({ ...REQUIRED_FIREBASE_ENV, ...overrides })) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  try {
+    return await fn()
+  } finally {
+    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
+test('createRtdbCore returns the core RTDB contract', async () => {
+  const { createRtdbCore } = await import('./createRtdbCore.js')
+  const core = createRtdbCore({ configuredBehavior: 'throw', label: TEST_LABEL })
+  assert.equal(typeof core.getDatabase, 'function')
+  assert.equal(typeof core.isConfigured, 'function')
+  assert.equal(typeof core.sanitizeForRtdb, 'function')
+  assert.equal(typeof core.setRtdb, 'function')
+})
+
+test('isConfigured is false when all required Firebase env keys are missing', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?missing=${Date.now()}`
+      )
+      const { isConfigured } = createRtdbCore({ configuredBehavior: 'null' })
+      assert.equal(isConfigured(), false)
+    },
+  )
+})
+
+test('isConfigured is false when required Firebase env is partial', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?partial=${Date.now()}`
+      )
+      const { isConfigured } = createRtdbCore({ configuredBehavior: 'null' })
+      assert.equal(isConfigured(), false)
+    },
+  )
+})
+
+test('isConfigured is false when required Firebase env is whitespace only', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: '   ',
+      VITE_FIREBASE_AUTH_DOMAIN: '\t',
+      VITE_FIREBASE_DATABASE_URL: ' ',
+      VITE_FIREBASE_PROJECT_ID: '',
+      VITE_FIREBASE_APP_ID: '  \n  ',
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?ws=${Date.now()}`
+      )
+      const { isConfigured } = createRtdbCore({ configuredBehavior: 'null' })
+      assert.equal(isConfigured(), false)
+    },
+  )
+})
+
+test('isConfigured is true when all required Firebase env keys are set', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { createRtdbCore } = await import(`./createRtdbCore.js?ok=${Date.now()}`)
+    const { isConfigured } = createRtdbCore({ configuredBehavior: 'null' })
+    assert.equal(isConfigured(), true)
+  })
+})
+
+test('sanitizeForRtdb drops undefined keys and maps top-level undefined to null', async () => {
+  const { createRtdbCore } = await import('./createRtdbCore.js')
+  const { sanitizeForRtdb } = createRtdbCore({ configuredBehavior: 'null' })
+  assert.equal(sanitizeForRtdb(undefined), null)
+  const out = sanitizeForRtdb({
+    players: [{ id: 'a', name: 'Alice', bankedMsByRound: undefined }],
+    activePlayerId: null,
+    totalGameStartedAt: undefined,
+    round: 1,
+  })
+  assert.deepEqual(out, {
+    players: [{ id: 'a', name: 'Alice' }],
+    activePlayerId: null,
+    round: 1,
+  })
+})
+
+test('sanitizeForRtdb preserves null and sanitizes nested arrays', async () => {
+  const { createRtdbCore } = await import('./createRtdbCore.js')
+  const { sanitizeForRtdb } = createRtdbCore({ configuredBehavior: 'null' })
+  assert.deepEqual(sanitizeForRtdb({ kept: null, dropped: undefined }), { kept: null })
+  assert.deepEqual(
+    sanitizeForRtdb({
+      items: [{ a: undefined, b: 1 }, undefined],
+    }),
+    { items: [{ b: 1 }, null] },
+  )
+})
+
+test('getDatabase with throw behavior throws when Firebase env is missing', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?throw-missing=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({
+        configuredBehavior: 'throw',
+        label: TEST_LABEL,
+      })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, new RegExp(TEST_LABEL))
+          assert.match(err.message, /VITE_FIREBASE_\*/)
+          assert.match(err.message, /\.env\.example/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('getDatabase with throw behavior throws when Firebase env is whitespace only', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: ' ',
+      VITE_FIREBASE_AUTH_DOMAIN: '',
+      VITE_FIREBASE_DATABASE_URL: '\t',
+      VITE_FIREBASE_PROJECT_ID: '  ',
+      VITE_FIREBASE_APP_ID: '\n',
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?throw-ws=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({
+        configuredBehavior: 'throw',
+        label: TEST_LABEL,
+      })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, new RegExp(TEST_LABEL))
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('getDatabase with throw behavior lists missing VITE_FIREBASE_* keys', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?throw-partial=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({
+        configuredBehavior: 'throw',
+        label: TEST_LABEL,
+      })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.match(err.message, /Missing:/)
+          assert.match(err.message, /VITE_FIREBASE_AUTH_DOMAIN/)
+          assert.match(err.message, /VITE_FIREBASE_DATABASE_URL/)
+          assert.match(err.message, /VITE_FIREBASE_PROJECT_ID/)
+          assert.match(err.message, /VITE_FIREBASE_APP_ID/)
+          assert.doesNotMatch(err.message, /VITE_FIREBASE_API_KEY/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('getDatabase with null behavior returns null when Firebase env is missing', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?null-missing=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({ configuredBehavior: 'null' })
+      assert.equal(getDatabase(), null)
+    },
+  )
+})
+
+test('getDatabase with null behavior returns null when Firebase env is whitespace only', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: ' ',
+      VITE_FIREBASE_AUTH_DOMAIN: '',
+      VITE_FIREBASE_DATABASE_URL: '\t',
+      VITE_FIREBASE_PROJECT_ID: '  ',
+      VITE_FIREBASE_APP_ID: '\n',
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?null-ws=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({ configuredBehavior: 'null' })
+      assert.equal(getDatabase(), null)
+    },
+  )
+})
+
+test('getDatabase with throw behavior omits label prefix when label is omitted', async () => {
+  await withFirebaseEnv(
+    {
+      VITE_FIREBASE_API_KEY: undefined,
+      VITE_FIREBASE_AUTH_DOMAIN: undefined,
+      VITE_FIREBASE_DATABASE_URL: undefined,
+      VITE_FIREBASE_PROJECT_ID: undefined,
+      VITE_FIREBASE_APP_ID: undefined,
+    },
+    async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?throw-nolabel=${Date.now()}`
+      )
+      const { getDatabase } = createRtdbCore({ configuredBehavior: 'throw' })
+      assert.throws(
+        () => getDatabase(),
+        (err) => {
+          assert.ok(err instanceof Error)
+          assert.doesNotMatch(err.message, /is not configured/)
+          assert.match(err.message, /Set VITE_FIREBASE_\*/)
+          return true
+        },
+      )
+    },
+  )
+})
+
+test('two core bindings share the same getDatabase singleton when configured', async () => {
+  await withFirebaseEnv({}, async () => {
+    const { createRtdbCore } = await import(
+      `./createRtdbCore.js?singleton=${Date.now()}`
+    )
+    const throwCore = createRtdbCore({
+      configuredBehavior: 'throw',
+      label: 'Throw binding',
+    })
+    const nullCore = createRtdbCore({ configuredBehavior: 'null' })
+    assert.equal(throwCore.getDatabase(), nullCore.getDatabase())
+    assert.equal(throwCore.getDatabase(), throwCore.getDatabase())
+  })
+})
+
+test('star-room RTDB shims share the core app-wide singleton', async () => {
+  await withFirebaseEnv({}, async () => {
+    const nonce = Date.now()
+    const { getGameTimerDatabase } = await import(
+      `../../game-timer/firebase/rtdb.js?gt=${nonce}`,
+    )
+    const { getMovieVoteDatabase } = await import(
+      `../../movie-vote/firebase/rtdb.js?mv=${nonce}`,
+    )
+    assert.equal(getGameTimerDatabase(), getMovieVoteDatabase())
+  })
+})
+
+test('setRtdb returns a promise without throwing synchronously when configured', async () => {
+  await withFirebaseEnv({}, async () => {
+    const actual = await import('firebase/database')
+    const { createRtdbCore } = await import(
+      `./createRtdbCore.js?setp=${Date.now()}`
+    )
+    const { setRtdb, getDatabase } = createRtdbCore({
+      configuredBehavior: 'throw',
+      label: TEST_LABEL,
+    })
+    const ref = actual.ref(getDatabase(), 'test/set-promise')
+    let result
+    assert.doesNotThrow(() => {
+      result = setRtdb(ref, {
+        round: 1,
+        totalGameStartedAt: undefined,
+      })
+    })
+    assert.ok(result instanceof Promise)
+  })
+})
+
+afterEach(() => {
+  mock.reset()
+})
+
+test(
+  'setRtdb calls Firebase set with sanitized payload',
+  { skip: !mock.module },
+  async () => {
+    const actual = await import('firebase/database')
+    /** @type {Array<{ value: unknown }>} */
+    const setCalls = []
+    mock.module('firebase/database', {
+      namedExports: {
+        ...actual,
+        set: async (_ref, value) => {
+          setCalls.push({ value })
+        },
+      },
+    })
+
+    await withFirebaseEnv({}, async () => {
+      const { createRtdbCore } = await import(
+        `./createRtdbCore.js?set=${Date.now()}`
+      )
+      const { setRtdb, getDatabase } = createRtdbCore({
+        configuredBehavior: 'throw',
+        label: TEST_LABEL,
+      })
+      const ref = actual.ref(getDatabase(), 'test/set-sanitize')
+      await setRtdb(ref, {
+        players: [{ id: 'a', bankedMsByRound: undefined }],
+        activePlayerId: null,
+        totalGameStartedAt: undefined,
+        round: 1,
+      })
+      assert.equal(setCalls.length, 1)
+      assert.deepEqual(setCalls[0].value, {
+        players: [{ id: 'a' }],
+        activePlayerId: null,
+        round: 1,
+      })
+    })
+  },
+)


### PR DESCRIPTION
## Summary

- Introduces `createRtdbCore` in star-room P2P: one app-wide RTDB singleton, shared config read, `sanitizeForRtdb`, and `setRtdb`, with `configuredBehavior: 'throw' | 'null'` on `getDatabase()`.
- Refactors `createRoomRtdbApi` to delegate to the core (`'throw'` + product label); Game Timer and Movie Vote shims stay unchanged at call sites.
- Refactors Dungeon Runner `firebase/rtdb.js` to delegate to the core (`'null'`), preserving the frozen export surface for `completedMatchReplayUpload`.
- Adds ADR 0005 and a Dungeon Runner glossary relationship noting archive writes share sanitization with star-room **projects**.

Closes #131. Implements #136 and #137.

## Test plan

- [x] `node --experimental-test-module-mocks --test` on `createRtdbCore`, `createRoomRtdbApi`, dungeon-runner RTDB + upload, game-timer RTDB, movie-vote RTDB (66 pass)
- [x] Manual smoke: Dungeon Runner **match over** without Firebase env (no error); Game Timer **Host room** shows configuration error when unset / hosts when configured