### PR TITLE
Fix polymorph on final dungeon card (#144)

### DIFF
--- a/src/features/dungeon-runner/engine/kernel.js
+++ b/src/features/dungeon-runner/engine/kernel.js
@@ -341,6 +341,15 @@ const EQUIP_POLY = 'M_POLY'
 const EQUIP_FIRE_AXE = 'B_AXE'
 const EQUIP_HEAL_POT = new Set(['B_HEAL', 'R_HEAL'])
 
+/**
+ * @param {NonNullable<ReturnType<typeof createInitialMatchState>['dungeon']>} dungeon
+ * @param {string | null | undefined} currentMonster
+ */
+function canOfferPolymorph(dungeon, currentMonster) {
+  const inPlay = new Set(dungeon.inPlayEquipmentIds ?? [])
+  return !dungeon.polySpent && inPlay.has(EQUIP_POLY) && currentMonster != null
+}
+
 /** @type {readonly string[]} */
 export const EQUIPMENT_IDS = catalogRules.equipmentIds
 
@@ -699,7 +708,7 @@ function applyRevealOrContinueAction(state, actor) {
 
   const inPlay = new Set(d0.inPlayEquipmentIds ?? [])
   const axeLegal = !d0.axeSpent && inPlay.has(EQUIP_FIRE_AXE)
-  const polyLegal = !d0.polySpent && inPlay.has(EQUIP_POLY) && remaining.length > 0
+  const polyLegal = canOfferPolymorph(d0, current)
   if (axeLegal) {
     return {
       ...state,
@@ -808,9 +817,7 @@ function applyFireAxeDeclineAction(state, actor) {
     return null
   }
   const d0 = state.dungeon
-  const inPlay = new Set(d0.inPlayEquipmentIds ?? [])
-  const polyLegal = !d0.polySpent && inPlay.has(EQUIP_POLY) && d0.currentMonster != null && (d0.remainingMonsters?.length ?? 0) > 0
-  if (polyLegal) {
+  if (canOfferPolymorph(d0, d0.currentMonster)) {
     return applyDungeonStepAction(state, DUNGEON_SUBPHASES.PICK_POLYMORPH)
   }
   return applyMonsterCombatHits(state, d0)

--- a/src/features/dungeon-runner/engine/kernel.test.js
+++ b/src/features/dungeon-runner/engine/kernel.test.js
@@ -292,7 +292,7 @@ test('dungeon decision sequence advances through python-style subphases', () => 
   assert.equal(result.state.phase, MATCH_PHASES.PICK_ADVENTURER)
 })
 
-test('declining fire axe does not open polymorph when no next monster exists', () => {
+test('declining fire axe on final monster still offers polymorph (#144)', () => {
   const base = createInitialMatchState(
     { totalSeats: 2, opponents: [{ type: 'randombot' }] },
     { seed: 6231 },
@@ -308,7 +308,7 @@ test('declining fire axe does not open polymorph when no next monster exists', (
       ...base.dungeon,
       subphase: DUNGEON_SUBPHASES.VORPAL,
       remainingMonsters: ['goblin'],
-      hp: 2,
+      hp: 20,
       inPlayEquipmentIds: ['B_AXE', 'M_POLY'],
       polySpent: false,
       axeSpent: false,
@@ -320,9 +320,70 @@ test('declining fire axe does not open polymorph when no next monster exists', (
   assert.equal(state.dungeon.subphase, DUNGEON_SUBPHASES.PICK_FIRE_AXE)
   const decline = applyAction(state, { type: ACTION_TYPES.DECLINE_FIRE_AXE }, { seatId })
   assert.equal(decline.ok, true)
-  assert.equal(decline.state.dungeon.subphase, null)
-  assert.equal(decline.state.phase, MATCH_PHASES.PICK_ADVENTURER)
-  assert.equal(decline.state.scoreboard[seatId].lives, 2)
+  assert.equal(decline.state.dungeon.subphase, DUNGEON_SUBPHASES.PICK_POLYMORPH)
+  assert.deepEqual(
+    getLegalActions(decline.state, { seatId }).map((action) => action.type),
+    [ACTION_TYPES.USE_POLYMORPH, ACTION_TYPES.DECLINE_POLYMORPH],
+  )
+})
+
+test('reveal on final monster offers polymorph when only mage poly is in play (#144)', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 6232 },
+  )
+  const seatId = base.seats[0].id
+  const state = {
+    ...base,
+    hero: 'MAGE',
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...base.turn, activeSeatId: seatId },
+    bidding: { ...base.bidding, runnerSeatId: seatId, dungeonMonsters: ['goblin'] },
+    dungeon: {
+      ...base.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['goblin'],
+      hp: 20,
+      inPlayEquipmentIds: ['M_POLY'],
+      polySpent: false,
+      axeSpent: true,
+    },
+  }
+  const reveal = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(reveal.ok, true)
+  assert.equal(reveal.state.dungeon.subphase, DUNGEON_SUBPHASES.PICK_POLYMORPH)
+  assert.equal(reveal.state.dungeon.currentMonster, 'goblin')
+  assert.deepEqual(reveal.state.dungeon.remainingMonsters, [])
+})
+
+test('using polymorph on final monster clears dungeon successfully (#144)', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 6233 },
+  )
+  const seatId = base.seats[0].id
+  const state = {
+    ...base,
+    hero: 'MAGE',
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...base.turn, activeSeatId: seatId },
+    bidding: { ...base.bidding, runnerSeatId: seatId, dungeonMonsters: ['goblin'] },
+    dungeon: {
+      ...base.dungeon,
+      subphase: DUNGEON_SUBPHASES.PICK_POLYMORPH,
+      currentMonster: 'goblin',
+      remainingMonsters: [],
+      hp: 20,
+      inPlayEquipmentIds: ['M_POLY'],
+      polySpent: false,
+    },
+  }
+  const used = applyAction(state, { type: ACTION_TYPES.USE_POLYMORPH }, { seatId })
+  assert.equal(used.ok, true)
+  assert.equal(used.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(used.state.scoreboard[seatId].successes, 1)
+  assert.equal(used.state.dungeon.inPlayEquipmentIds.includes('M_POLY'), false)
 })
 
 test('reveal skips pick-fire-axe when B_AXE not in play (warrior center loadout)', () => {


### PR DESCRIPTION
## Summary

- Offer polymorph whenever there is a revealed monster and `M_POLY` is in play, instead of requiring `remainingMonsters.length > 0`.
- Centralize that check in `canOfferPolymorph` for reveal and post–fire-axe decline paths.
- Add kernel regression tests for final-card reveal, fire-axe decline chaining, and successful clear via polymorph use.

Fixes #144.

## Test plan

- [x] `node --test src/features/dungeon-runner/engine/kernel.test.js`
- [ ] Manual: one-monster dungeon as runner with Polymorph — final reveal should glow polymorph; Use clears the run; Decline fights normally