### PR TITLE
Fix pick-adventurer seat when dungeon runner is eliminated (#146)

### DIFF
--- a/src/features/dungeon-runner/engine/kernel.js
+++ b/src/features/dungeon-runner/engine/kernel.js
@@ -557,12 +557,13 @@ function findNextActiveSeatId(state, seatId, passedSeatIds) {
   return null
 }
 
+function pickAdventurerSeatId(state, runnerSeatId, scoreboard) {
+  if (!scoreboard[runnerSeatId]?.eliminated) return runnerSeatId
+  return findNextActiveSeatId(state, runnerSeatId, []) ?? runnerSeatId
+}
+
 function enterPickAdventurerPhase(state, runnerSeatId, scoreboard, result) {
-  const runnerScore = scoreboard[runnerSeatId]
-  const seatIndex = state.seats.findIndex((seat) => seat.id === runnerSeatId)
-  const pickSeatId = runnerScore?.eliminated
-    ? state.seats[(seatIndex - 1 + state.seats.length) % state.seats.length]?.id ?? runnerSeatId
-    : runnerSeatId
+  const pickSeatId = pickAdventurerSeatId(state, runnerSeatId, scoreboard)
   return {
     ...state,
     phase: MATCH_PHASES.PICK_ADVENTURER,
@@ -596,6 +597,8 @@ function enterPickAdventurerPhase(state, runnerSeatId, scoreboard, result) {
 
 function applyChooseNextAdventurerAction(state, action, actor) {
   if (state.phase !== MATCH_PHASES.PICK_ADVENTURER) return null
+  const designatedPickerId = state.pickAdventurer?.activeSeatId ?? null
+  if (!designatedPickerId || actor.seatId !== designatedPickerId) return null
   const loadout = catalogRules.adventurerLoadouts[action.hero] ?? catalogRules.defaultLoadout
   const shuffledDeck = shuffle(createInitialMonsterDeck(), state.rng)
   return {

--- a/src/features/dungeon-runner/engine/kernel.test.js
+++ b/src/features/dungeon-runner/engine/kernel.test.js
@@ -801,6 +801,84 @@ test('runner clears dungeon via reveal chain and enters pick-adventurer', () => 
   assert.equal(reveal.state.scoreboard[runnerId].successes, 1)
 })
 
+test('eliminated runner yields pick to next surviving seat in turn order (#146)', () => {
+  const state = createInitialMatchState(
+    {
+      totalSeats: 4,
+      opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+    },
+    { seed: 2 },
+  )
+  const runnerId = state.seats[2].id
+  const nextSurvivorId = state.seats[3].id
+  const previousSeatId = state.seats[1].id
+  const dungeonState = {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerId },
+    bidding: { ...state.bidding, runnerSeatId: runnerId, dungeonMonsters: ['dragon'] },
+    scoreboard: {
+      ...state.scoreboard,
+      [runnerId]: { successes: 0, lives: 1, eliminated: false },
+    },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['dragon'],
+      hp: 1,
+      inPlayEquipmentIds: [],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+  const result = applyAction(dungeonState, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: runnerId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(result.state.scoreboard[runnerId].eliminated, true)
+  assert.equal(result.state.lastDungeonRun?.runnerSeatId, runnerId)
+  assert.equal(result.state.turn.activeSeatId, nextSurvivorId)
+  assert.equal(result.state.pickAdventurer.activeSeatId, nextSurvivorId)
+  assert.notEqual(result.state.turn.activeSeatId, previousSeatId)
+  assert.equal(getLegalActions(result.state, { seatId: runnerId }).length, 0)
+  assert.equal(getLegalActions(result.state, { seatId: nextSurvivorId }).length, 4)
+})
+
+test('runner who survives failure still picks next adventurer (#146)', () => {
+  const state = createInitialMatchState(
+    {
+      totalSeats: 4,
+      opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+    },
+    { seed: 2 },
+  )
+  const runnerId = state.seats[2].id
+  const dungeonState = {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerId },
+    bidding: { ...state.bidding, runnerSeatId: runnerId, dungeonMonsters: ['goblin'] },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['goblin'],
+      hp: 1,
+      inPlayEquipmentIds: [],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+  const result = applyAction(dungeonState, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: runnerId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(result.state.scoreboard[runnerId].eliminated, false)
+  assert.equal(result.state.turn.activeSeatId, runnerId)
+  assert.equal(getLegalActions(result.state, { seatId: runnerId }).length, 4)
+})
+
 test('runner failure in dungeon transitions to pick-adventurer with life loss', () => {
   const state = createInitialMatchState(
     {


### PR DESCRIPTION
## Summary

- After a dungeon run, the seat that picks the next adventurer and leads the next bidding round is chosen via `pickAdventurerSeatId`: the runner when still in the match, otherwise the next non-eliminated seat in turn order (reusing `findNextActiveSeatId`).
- Fixes a bug where an eliminated runner handed pick-adventurer to the **previous** seat in the seat list instead of the **next** survivor.
- `applyChooseNextAdventurerAction` now requires the actor to match `pickAdventurer.activeSeatId`, so only the designated picker can choose.

Closes #146.

## Test plan

- [x] `node --test src/features/dungeon-runner/engine/kernel.test.js` (including new `#146` cases)
- [ ] Play a match where a runner is eliminated on a failed dungeon run and confirm the next seat in turn order picks the adventurer
- [ ] Play a match where the runner survives a failed run and confirm they still pick