### PR TITLE
End match when player seat loses

### DIFF
--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -50,6 +50,24 @@ The single seat whose setup role is `human` after seat shuffle, identified by **
 
 _Avoid_: Assuming `seat-1`; conflating with **Non-NN history step** or **Randombot** steps without `modelId`.
 
+### Eliminated
+
+A seat with no lives remaining after losing **dungeon runs** as the runner (two failures from the starting two lives); that seat takes no further turns for the rest of the **match**.
+
+_Avoid_: “Out,” “dead,” “removed from play” without tying to lives; treating a single failed **dungeon run** as **eliminated** while lives remain.
+
+### Elimination end (human)
+
+The **match** is over for the **human player seat** once that seat is **eliminated**; remaining **opponent** play may finish without presentation before **match over** is recorded. A brief **finishing match** state may appear while that remainder resolves. The end dialog uses elimination-focused copy and does not name the winning **opponent**.
+
+_Avoid_: “Forfeit,” “concede,” “quit”; implying the whole **match** stops for all seats when only the human is **eliminated** (under normal rules **opponents** continue until one wins); showing the winning **opponent** on the elimination end dialog.
+
+### Defeat (human, not eliminated)
+
+The human lost **match over** while still having lives (e.g. an **opponent** reached two wins first). The end dialog names the winning seat as today.
+
+_Avoid_: Using elimination end copy when the human was not **eliminated**; conflating with **Elimination end (human)**.
+
 ### History
 
 Ordered canonical actions and RNG step metadata that fully determine how a **match** unfolded.
@@ -176,6 +194,8 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - **Adventurer identity** fields are **ui** only; the engine/kernel consumes **catalog rules** only, not **ui**.
 - **Equipment** and **monster** definitions are consulted during **dungeon runs** and bidding within a **match**.
 - A **match** contains one or more **dungeon runs** before **match over**.
+- **Elimination end (human)** and **Defeat (human, not eliminated)** use different end-dialog copy; only the latter names the winning seat.
+- Headless completion of remaining **opponent** play after human **elimination** uses the same action choosers as live play (not a simplified bot).
 - Each **match** has exactly one **human player seat**; the human is not an **opponent** in **setup**.
 - A **completed match replay** is a **replay envelope** captured when **match over** is reached.
 - The **completed match replay archive** holds **completed match replay** envelopes keyed by match id; each key is written at most once from the browser; **archive listing** at the root is allowed for maintainer ingest.

--- a/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
+++ b/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
@@ -1,11 +1,67 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { MATCH_PHASES } from '../engine/kernel.js'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
+import {
+  DEFAULT_MAX_HEADLESS_ACTIONS,
+  runHeadlessMatchCompletion,
+} from '../ui/headlessMatchCompletionRunner.js'
+import { needsHeadlessCompletion } from '../ui/humanEliminationCompletionPolicy.js'
 import {
   UPLOADED_MATCH_IDS_STORAGE_KEY,
   createCompletedMatchReplayUploadTracker,
   maybeUploadCompletedMatchReplay,
 } from './completedMatchReplayUpload.js'
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+function seatByRole(state, roleType) {
+  return state.seats.find((seat) => seat.role.type === roleType)
+}
+
+function humanEliminatedBeforeMatchOver(state, humanSeatId) {
+  const opponent = state.seats.find(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  )
+  assert.ok(opponent)
+  return {
+    ...state,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    scoreboard: {
+      ...state.scoreboard,
+      [humanSeatId]: {
+        ...state.scoreboard[humanSeatId],
+        lives: 0,
+        eliminated: true,
+        successes: 0,
+      },
+    },
+    turn: { ...state.turn, activeSeatId: opponent.id, turnNumber: state.turn.turnNumber + 1 },
+    pickAdventurer: {
+      ...state.pickAdventurer,
+      activeSeatId: opponent.id,
+    },
+  }
+}
+
+async function buildHeadlessCompletedFourPlayerMatch(seed) {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  return { initial, human, result }
+}
 
 /** @param {Record<string, unknown>} overrides */
 function sampleMatch(overrides = {}) {
@@ -363,4 +419,26 @@ test('createCompletedMatchReplayUploadTracker exposes maybeUpload', () => {
   const tracker = createCompletedMatchReplayUploadTracker(createMemoryStorage())
   assert.equal(typeof tracker.maybeUpload, 'function')
   assert.doesNotThrow(() => tracker.maybeUpload(null))
+})
+
+test('maybeUpload uploads headless-completed multi-seat match replay envelope', async () => {
+  const { initial, result } = await buildHeadlessCompletedFourPlayerMatch(8801)
+  const { deps, setCalls } = createDeps()
+  const match = {
+    id: 'match-headless-complete',
+    setup: FOUR_PLAYER_SETUP,
+    state: result.state,
+    presentationSpeedProfile: 'brisk',
+  }
+
+  assert.ok(match.state.history.length > initial.history.length)
+
+  maybeUploadCompletedMatchReplay(match, deps)
+
+  assert.equal(setCalls.length, 1)
+  assert.equal(setCalls[0].matchId, 'match-headless-complete')
+  assert.equal(setCalls[0].envelope.seed, initial.rng.seed)
+  assert.deepEqual(setCalls[0].envelope.setup, FOUR_PLAYER_SETUP)
+  assert.deepEqual(setCalls[0].envelope.history, match.state.history)
+  assert.equal(setCalls[0].envelope.presentationSpeedProfile, 'brisk')
 })

--- a/src/features/dungeon-runner/persistence/currentMatch.test.js
+++ b/src/features/dungeon-runner/persistence/currentMatch.test.js
@@ -1,5 +1,24 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import {
+  ACTION_TYPES,
+  DUNGEON_SUBPHASES,
+  MATCH_PHASES,
+  applyAction,
+  createInitialMatchState,
+} from '../engine/kernel.js'
+import {
+  buildDeferredDungeonOutcomeDisplayState,
+  DEFAULT_MAX_HEADLESS_ACTIONS,
+  resolveHeadlessCompletionStartState,
+  runMaybeHeadlessMatchCompletionFromState,
+} from '../ui/headlessMatchCompletionRunner.js'
+import {
+  getMatchOverEndDialogVariant,
+  MATCH_OVER_END_VARIANTS,
+  needsHeadlessCompletion,
+} from '../ui/humanEliminationCompletionPolicy.js'
 import {
   CURRENT_MATCH_SCHEMA_VERSION,
   clearCurrentMatch,
@@ -7,6 +26,35 @@ import {
   loadCurrentMatch,
   persistCurrentMatch,
 } from './currentMatch.js'
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+function seatByRole(state, roleType) {
+  return state.seats.find((seat) => seat.role.type === roleType)
+}
+
+function lethalRevealDungeonState(state, runnerSeatId) {
+  return {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerSeatId },
+    bidding: { ...state.bidding, runnerSeatId, dungeonMonsters: ['dragon'] },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['dragon'],
+      hp: 3,
+      inPlayEquipmentIds: ['W_VORPAL'],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+}
 
 function createMemoryStorage() {
   const map = new Map()
@@ -129,6 +177,49 @@ test('persisted match may include presentationSpeedProfile', () => {
   const loaded = loadCurrentMatch(storage)
   assert.equal(loaded.ok, true)
   assert.equal(loaded.match.presentationSpeedProfile, 'brisk')
+})
+
+test('persisted eliminated-before-match-over resumes headless completion to match over', async () => {
+  const storage = createMemoryStorage()
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9100 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+    },
+    turn: { ...initial.turn, activeSeatId: human.id },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  const { displayState } = buildDeferredDungeonOutcomeDisplayState(onLastLife, eliminated.state)
+  assert.equal(displayState.phase, MATCH_PHASES.DUNGEON)
+  assert.equal(needsHeadlessCompletion(eliminated.state, human.id), true)
+
+  persistCurrentMatch(storage, {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: 'm-headless-resume',
+    setup: FOUR_PLAYER_SETUP,
+    state: displayState,
+    history: eliminated.state.history,
+  })
+
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(decideResumeFlow(storage).mode, 'resume-or-start-new')
+
+  const start = resolveHeadlessCompletionStartState(loaded.match.state, human.id)
+  const completion = await runMaybeHeadlessMatchCompletionFromState(start, {
+    humanPlayerSeatId: human.id,
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(completion.ran, true)
+  assert.equal(completion.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(getMatchOverEndDialogVariant(completion.state, human.id), MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
 })
 
 test('invalid presentationSpeedProfile rejects persisted match', () => {

--- a/src/features/dungeon-runner/release.integration.test.js
+++ b/src/features/dungeon-runner/release.integration.test.js
@@ -268,15 +268,12 @@ test('persistent dungeon outcome dialog locks all background interactions while 
       page.indexOf(':disable="dungeonOutcomeDialogOpen"', page.indexOf('aria-label="Start new match"')) > -1,
     'start-new should be disabled when outcome dialog is open',
   )
-  const disabledActionBindings = page.match(/:disable="gameplayInputLocked \|\| dungeonOutcomeDialogOpen"/g) ?? []
+  const disabledActionBindings = page.match(/:disable="humanGameplayBlocked"/g) ?? []
   assert.ok(
     disabledActionBindings.length >= 4,
-    `expected gameplay action buttons to gate on dungeonOutcomeDialogOpen (found ${disabledActionBindings.length})`,
+    `expected gameplay action buttons to gate on humanGameplayBlocked (found ${disabledActionBindings.length})`,
   )
-  assert.equal(
-    page.includes('if (!token?.hasModal || dungeonOutcomeDialogOpen.value) return'),
-    true,
-  )
+  assert.equal(page.includes('if (!token?.hasModal || humanGameplayBlocked.value) return'), true)
   assert.equal(page.includes('equipmentModalActionsDisabled'), true)
   assert.equal(page.includes('z-index: 10100 !important'), true)
 })
@@ -332,4 +329,61 @@ test('completed match replay upload has no debug or host gate on page', () => {
   assert.equal(uploadBlock.includes('debugMode'), false)
   assert.equal(uploadBlock.includes('localhost'), false)
   assert.equal(uploadBlock.includes('shouldEnableDebugOnBoot'), false)
+})
+
+test('dungeon runner page wires headless match completion after human elimination', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes('runMaybeHeadlessMatchCompletionFromState'), true)
+  assert.equal(page.includes('createLivePlayActionChooser'), true)
+  assert.equal(page.includes('maybeRunHeadlessMatchCompletion'), true)
+  assert.equal(page.includes('teardownForHeadlessMatchCompletion'), true)
+  assert.equal(page.includes('abandonScheduledInferenceQueue'), true)
+  assert.equal(page.includes('data-testid="finishing-match-overlay"'), true)
+  assert.equal(page.includes('headlessCompletionInFlight'), true)
+})
+
+test('continueFromDungeonOutcome triggers headless completion when policy requires it', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const fnIdx = page.indexOf('async function continueFromDungeonOutcome()')
+  assert.ok(fnIdx >= 0)
+  const fnBlock = page.slice(fnIdx, fnIdx + 520)
+  assert.equal(fnBlock.includes('await maybeRunHeadlessMatchCompletion()'), true)
+})
+
+test('resume on mount may run headless completion without spectator scheduling', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const mountedIdx = page.indexOf('onMounted(() => {')
+  assert.ok(mountedIdx >= 0)
+  const mountedBlock = page.slice(mountedIdx, mountedIdx + 1200)
+  assert.equal(mountedBlock.includes('void maybeRunHeadlessMatchCompletion()'), true)
+  assert.equal(mountedBlock.includes('scheduleAiTurnIfReady'), false)
+})
+
+test('live AI scheduling is gated while headless completion runs', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes("logAiTurnScheduleSkip('headless-completion')"), true)
+  assert.equal(page.includes("trace('run.skip', { reason: 'headless-completion' })"), true)
+  assert.equal(page.includes("logAiTurnPrimeSkip('headless-completion')"), true)
+})
+
+test('human gameplay is blocked while headless completion runs', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes('const humanGameplayBlocked = computed('), true)
+  assert.equal(page.includes('headlessCompletionInFlight.value'), true)
+  const takeHumanIdx = page.indexOf('function takeHumanAction(action)')
+  assert.ok(takeHumanIdx >= 0)
+  const takeHumanBlock = page.slice(takeHumanIdx, takeHumanIdx + 280)
+  assert.equal(takeHumanBlock.includes('humanGameplayBlocked.value'), true)
+  assert.equal(page.includes(':disable="humanGameplayBlocked"'), true)
+})
+
+test('runAiTurn delegates action choice to createLivePlayActionChooser', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const fnIdx = page.indexOf('async function runAiTurn()')
+  assert.ok(fnIdx >= 0)
+  const fnBlock = page.slice(fnIdx, fnIdx + 2200)
+  assert.equal(fnBlock.includes('createLivePlayActionChooser'), true)
+  assert.equal(fnBlock.includes('tryConsumePrefetch'), true)
+  assert.equal(fnBlock.includes('chooseNnActionWithFallback'), false)
+  assert.equal(fnBlock.includes('chooseRandombotAction'), false)
 })

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
@@ -1,0 +1,282 @@
+import { chooseRandombotAction } from '../bots/randombot.js'
+import { chooseNnActionWithFallback } from '../nn/runtime.js'
+import { isNnAdventurerPickEnabled } from '../setup/nnAdventurerPick.js'
+import { MATCH_PHASES, applyAction } from '../engine/kernel.js'
+import { isHumanEliminated, needsHeadlessCompletion } from './humanEliminationCompletionPolicy.js'
+
+export const DEFAULT_MAX_HEADLESS_ACTIONS = 500
+
+export const HEADLESS_COMPLETION_ERROR_CODES = {
+  SAFETY_CAP: 'SAFETY_CAP',
+  NOT_ACTIONABLE: 'NOT_ACTIONABLE',
+  NO_ACTIVE_SEAT: 'NO_ACTIVE_SEAT',
+  HUMAN_TURN_UNEXPECTED: 'HUMAN_TURN_UNEXPECTED',
+  NO_ACTION: 'NO_ACTION',
+  APPLY_FAILED: 'APPLY_FAILED',
+}
+
+const ACTIONABLE_PHASES = new Set([
+  MATCH_PHASES.BIDDING,
+  MATCH_PHASES.DUNGEON,
+  MATCH_PHASES.PICK_ADVENTURER,
+])
+
+export function shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState) {
+  return (
+    prevState.phase === MATCH_PHASES.DUNGEON &&
+    nextState.phase === MATCH_PHASES.PICK_ADVENTURER &&
+    nextState.lastDungeonRun != null
+  )
+}
+
+/**
+ * Mirrors live deferral after a dungeon exit that must wait for outcome acknowledgement.
+ * @returns {{ displayState: typeof prevState, deferredState: typeof nextState | null }}
+ */
+export function buildDeferredDungeonOutcomeDisplayState(prevState, nextState) {
+  if (!shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState)) {
+    return { displayState: nextState, deferredState: null }
+  }
+  return {
+    displayState: { ...nextState, phase: MATCH_PHASES.DUNGEON },
+    deferredState: nextState,
+  }
+}
+
+/**
+ * After reload, persisted match state may still show dungeon phase while pick-adventurer
+ * is already active (outcome dialog was deferred). Headless completion needs pick-adventurer.
+ */
+export function resolveHeadlessCompletionStartState(state, humanPlayerSeatId) {
+  if (
+    state?.phase === MATCH_PHASES.DUNGEON &&
+    state.lastDungeonRun != null &&
+    isHumanEliminated(state, humanPlayerSeatId) &&
+    state.pickAdventurer?.activeSeatId
+  ) {
+    return { ...state, phase: MATCH_PHASES.PICK_ADVENTURER }
+  }
+  return state
+}
+
+/** Mirrors continueFromDungeonOutcome applying deferredPostDungeonState before headless completion. */
+export function resolveStateAfterDungeonOutcomeContinue(displayedState, deferredPostDungeonState) {
+  if (deferredPostDungeonState) {
+    return deferredPostDungeonState
+  }
+  return displayedState
+}
+
+/** Mirrors `headlessCompletionInFlight` / finishing-match overlay visibility on the page. */
+export function shouldShowFinishingMatchOverlay(headlessCompletionInFlight) {
+  return headlessCompletionInFlight === true
+}
+
+/** Mirrors live AI scheduling / prefetch gates while headless completion runs. */
+export function shouldBlockLiveAiPipelineWhileHeadless(headlessCompletionInFlight) {
+  return headlessCompletionInFlight === true
+}
+
+export function createHeadlessCompletionFlightGate() {
+  let inFlight = false
+  return {
+    get inFlight() {
+      return inFlight
+    },
+    tryStart() {
+      if (inFlight) return false
+      inFlight = true
+      return true
+    },
+    finish() {
+      inFlight = false
+    },
+  }
+}
+
+/**
+ * Mirrors `maybeRunHeadlessMatchCompletion` engine work (policy, start-state resolve, runner).
+ * @param {import('../engine/kernel.js').ReturnType<typeof import('../engine/kernel.js').createInitialMatchState>} state
+ */
+export async function runMaybeHeadlessMatchCompletionFromState(state, options) {
+  const humanPlayerSeatId = options.humanPlayerSeatId
+  const chooseAction = options.chooseAction
+  const gate = options.gate ?? createHeadlessCompletionFlightGate()
+  const afterFlightStart = options.afterFlightStart
+
+  if (!needsHeadlessCompletion(state, humanPlayerSeatId)) {
+    return { ran: false, state, gate, skippedReason: 'NOT_NEEDED' }
+  }
+  if (!gate.tryStart()) {
+    return { ran: false, state, gate, skippedReason: 'IN_FLIGHT' }
+  }
+  try {
+    await afterFlightStart?.()
+    const startState = resolveHeadlessCompletionStartState(state, humanPlayerSeatId)
+    const result = await runHeadlessMatchCompletion(startState, {
+      chooseAction,
+      humanPlayerSeatId,
+      maxActions: options.maxActions,
+      yieldEvery: options.yieldEvery,
+    })
+    if (result.ok) {
+      return {
+        ran: true,
+        state: result.state,
+        gate,
+        actionCount: result.actionCount,
+        overlayVisible: shouldShowFinishingMatchOverlay(gate.inFlight),
+      }
+    }
+    return {
+      ran: true,
+      state: startState,
+      gate,
+      failed: true,
+      errorCode: result.errorCode,
+      actionCount: result.actionCount,
+      overlayVisible: shouldShowFinishingMatchOverlay(gate.inFlight),
+    }
+  } finally {
+    gate.finish()
+  }
+}
+
+/**
+ * Mirrors `continueFromDungeonOutcome` then `maybeRunHeadlessMatchCompletion`.
+ */
+export async function runContinueFromDeferredThenHeadlessCompletion(options) {
+  const continued = resolveStateAfterDungeonOutcomeContinue(
+    options.displayedState,
+    options.deferredPostDungeonState ?? null,
+  )
+  return runMaybeHeadlessMatchCompletionFromState(continued, {
+    humanPlayerSeatId: options.humanPlayerSeatId,
+    chooseAction: options.chooseAction,
+    gate: options.gate,
+    maxActions: options.maxActions,
+    yieldEvery: options.yieldEvery,
+    afterFlightStart: options.afterFlightStart,
+  })
+}
+
+/**
+ * @param {import('../engine/kernel.js').ReturnType<typeof import('../engine/kernel.js').createInitialMatchState>} state
+ * @param {{
+ *   chooseAction: (ctx: { state: typeof state, seatId: string }) => Promise<{ type: string } | null> | { type: string } | null
+ *   humanPlayerSeatId: string
+ *   maxActions?: number
+ *   yieldEvery?: number
+ * }} options
+ */
+export async function runHeadlessMatchCompletion(state, options) {
+  const maxActions = options.maxActions ?? DEFAULT_MAX_HEADLESS_ACTIONS
+  const chooseAction = options.chooseAction
+  const humanPlayerSeatId = options.humanPlayerSeatId
+  let currentState = state
+  let actionCount = 0
+
+  while (currentState.phase !== MATCH_PHASES.MATCH_OVER) {
+    if (actionCount >= maxActions) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.SAFETY_CAP,
+      }
+    }
+    if (!ACTIONABLE_PHASES.has(currentState.phase)) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.NOT_ACTIONABLE,
+      }
+    }
+    const seatId = currentState.turn?.activeSeatId
+    if (!seatId) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.NO_ACTIVE_SEAT,
+      }
+    }
+    if (seatId === humanPlayerSeatId) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.HUMAN_TURN_UNEXPECTED,
+      }
+    }
+    const action = await chooseAction({ state: currentState, seatId })
+    if (!action) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.NO_ACTION,
+      }
+    }
+    const result = applyAction(currentState, action, { seatId })
+    if (!result.ok) {
+      return {
+        ok: false,
+        state: currentState,
+        actionCount,
+        errorCode: HEADLESS_COMPLETION_ERROR_CODES.APPLY_FAILED,
+      }
+    }
+    currentState = result.state
+    actionCount += 1
+    if (options.yieldEvery && actionCount % options.yieldEvery === 0) {
+      await Promise.resolve()
+    }
+  }
+
+  return { ok: true, state: currentState, actionCount }
+}
+
+/**
+ * Mirrors live AI turn chooser semantics (Randombot, NN with cooldown/fallback, adventurer pick flag).
+ * @param {{
+ *   nnFailureRecovery: { isCoolingDown: (modelId: string) => boolean }
+ *   ensureNnModelsReady?: () => Promise<void>
+ *   nnRuntimeOptions: (modelId: string) => object
+ *   isNnAdventurerPickEnabled?: () => boolean
+ *   chooseNnAction?: typeof chooseNnActionWithFallback
+ *   tryConsumePrefetch?: (ctx: { state: object, seatId: string, runToken?: string }) => Promise<{ type: string } | null> | { type: string } | null
+ * }} deps
+ */
+export function createLivePlayActionChooser(deps) {
+  const adventurerPickEnabled = deps.isNnAdventurerPickEnabled ?? isNnAdventurerPickEnabled
+  const chooseNn = deps.chooseNnAction ?? chooseNnActionWithFallback
+  return async function chooseAction({ state, seatId, runToken }) {
+    const seat = state.seats.find((candidate) => candidate.id === seatId)
+    const roleType = seat?.role?.type
+    let action = null
+    if (roleType === 'nn') {
+      const modelId = seat.role.modelId ?? 'latest'
+      if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !adventurerPickEnabled()) {
+        action = chooseRandombotAction(state, { seatId })
+      } else if (deps.nnFailureRecovery.isCoolingDown(modelId)) {
+        action = chooseRandombotAction(state, { seatId })
+      } else {
+        await deps.ensureNnModelsReady?.()
+        if (deps.tryConsumePrefetch) {
+          action = await deps.tryConsumePrefetch({ state, seatId, runToken })
+        }
+        if (!action) {
+          action = await chooseNn(state, { seatId }, deps.nnRuntimeOptions(modelId))
+        }
+      }
+    } else {
+      action = chooseRandombotAction(state, { seatId })
+    }
+    if (!action) {
+      action = chooseRandombotAction(state, { seatId })
+    }
+    return action
+  }
+}

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
@@ -1,0 +1,437 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import {
+  ACTION_TYPES,
+  DUNGEON_SUBPHASES,
+  MATCH_PHASES,
+  applyAction,
+  createInitialMatchState,
+  getLegalActions,
+} from '../engine/kernel.js'
+import {
+  getMatchOverEndDialogVariant,
+  MATCH_OVER_END_VARIANTS,
+  needsHeadlessCompletion,
+} from './humanEliminationCompletionPolicy.js'
+import { buildMatchOverSummary } from './matchOverSummaryBuilder.js'
+import {
+  buildDeferredDungeonOutcomeDisplayState,
+  createHeadlessCompletionFlightGate,
+  createLivePlayActionChooser,
+  DEFAULT_MAX_HEADLESS_ACTIONS,
+  HEADLESS_COMPLETION_ERROR_CODES,
+  resolveHeadlessCompletionStartState,
+  resolveStateAfterDungeonOutcomeContinue,
+  runContinueFromDeferredThenHeadlessCompletion,
+  runHeadlessMatchCompletion,
+  shouldBlockLiveAiPipelineWhileHeadless,
+  shouldShowFinishingMatchOverlay,
+} from './headlessMatchCompletionRunner.js'
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+function seatByRole(state, roleType) {
+  return state.seats.find((seat) => seat.role.type === roleType)
+}
+
+function humanEliminatedBeforeMatchOver(state, humanSeatId) {
+  const opponent = state.seats.find(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  )
+  assert.ok(opponent)
+  return {
+    ...state,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    scoreboard: {
+      ...state.scoreboard,
+      [humanSeatId]: {
+        ...state.scoreboard[humanSeatId],
+        lives: 0,
+        eliminated: true,
+        successes: 0,
+      },
+    },
+    turn: { ...state.turn, activeSeatId: opponent.id, turnNumber: state.turn.turnNumber + 1 },
+    pickAdventurer: {
+      ...state.pickAdventurer,
+      activeSeatId: opponent.id,
+    },
+  }
+}
+
+function lethalRevealDungeonState(state, runnerSeatId) {
+  return {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerSeatId },
+    bidding: { ...state.bidding, runnerSeatId, dungeonMonsters: ['dragon'] },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['dragon'],
+      hp: 3,
+      inPlayEquipmentIds: ['W_VORPAL'],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+}
+
+test('runHeadlessMatchCompletion reaches match over with injected randombot chooser on multi-seat setup', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 4242 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+
+  const chooseAction = async ({ state, seatId }) => chooseRandombotAction(state, { seatId })
+
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction,
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(result.state.matchWinnerSeatId != null, true)
+  assert.equal(result.state.scoreboard[human.id].eliminated, true)
+  assert.ok(result.actionCount > 0)
+  assert.equal(result.errorCode, undefined)
+})
+
+test('runHeadlessMatchCompletion auto-acks deferred dungeon exit without leaving dungeon phase stuck', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9001 })
+  const human = seatByRole(initial, 'human')
+  const opponent = initial.seats.find((seat) => seat.role.type === 'randombot' && seat.id !== human.id)
+  assert.ok(human)
+  assert.ok(opponent)
+
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+      [opponent.id]: { ...initial.scoreboard[opponent.id], eliminated: false },
+    },
+    turn: { ...initial.turn, activeSeatId: human.id },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  assert.equal(eliminated.state.scoreboard[human.id].eliminated, true)
+  assert.equal(eliminated.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(needsHeadlessCompletion(eliminated.state, human.id), true)
+
+  const result = await runHeadlessMatchCompletion(eliminated.state, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+})
+
+test('resolveHeadlessCompletionStartState promotes deferred dungeon display to pick-adventurer', () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9001 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const onLastLife = lethalRevealDungeonState(initial, human.id)
+  onLastLife.scoreboard = {
+    ...onLastLife.scoreboard,
+    [human.id]: { ...onLastLife.scoreboard[human.id], lives: 1, eliminated: false },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  const persistedDeferred = { ...eliminated.state, phase: MATCH_PHASES.DUNGEON }
+
+  const resolved = resolveHeadlessCompletionStartState(persistedDeferred, human.id)
+  assert.equal(resolved.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(resolved.turn.activeSeatId, eliminated.state.turn.activeSeatId)
+})
+
+test('runHeadlessMatchCompletion reaches match over from reloaded deferred dungeon display', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9001 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const onLastLife = lethalRevealDungeonState(initial, human.id)
+  onLastLife.scoreboard = {
+    ...onLastLife.scoreboard,
+    [human.id]: { ...onLastLife.scoreboard[human.id], lives: 1, eliminated: false },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  const start = resolveHeadlessCompletionStartState(
+    { ...eliminated.state, phase: MATCH_PHASES.DUNGEON },
+    human.id,
+  )
+
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+})
+
+test('createLivePlayActionChooser matches randombot for randombot seats', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 11 })
+  const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
+  assert.ok(bot)
+  const chooser = createLivePlayActionChooser({
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+  })
+  const action = await chooser({ state: initial, seatId: bot.id })
+  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: bot.id }))
+})
+
+test('createLivePlayActionChooser uses randombot when nn model is cooling down', async () => {
+  const setup = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const initial = createInitialMatchState(setup, { seed: 12 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const chooser = createLivePlayActionChooser({
+    nnFailureRecovery: { isCoolingDown: () => true },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => true,
+  })
+  const action = await chooser({ state: initial, seatId: nnSeat.id })
+  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: nnSeat.id }))
+})
+
+test('buildDeferredDungeonOutcomeDisplayState defers pick-adventurer behind dungeon phase', () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9001 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const onLastLife = lethalRevealDungeonState(initial, human.id)
+  onLastLife.scoreboard = {
+    ...onLastLife.scoreboard,
+    [human.id]: { ...onLastLife.scoreboard[human.id], lives: 1, eliminated: false },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  const { displayState, deferredState } = buildDeferredDungeonOutcomeDisplayState(onLastLife, eliminated.state)
+  assert.equal(displayState.phase, MATCH_PHASES.DUNGEON)
+  assert.equal(deferredState?.phase, MATCH_PHASES.PICK_ADVENTURER)
+  const continued = resolveStateAfterDungeonOutcomeContinue(displayState, deferredState)
+  assert.equal(continued.phase, MATCH_PHASES.PICK_ADVENTURER)
+})
+
+test('createLivePlayActionChooser uses randombot on pick-adventurer when nn pick flag is off', async () => {
+  const setup = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const initial = createInitialMatchState(setup, { seed: 13 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const pickState = {
+    ...initial,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    turn: { ...initial.turn, activeSeatId: nnSeat.id },
+    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
+  }
+  const chooser = createLivePlayActionChooser({
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => false,
+  })
+  const action = await chooser({ state: pickState, seatId: nnSeat.id })
+  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
+})
+
+test('createLivePlayActionChooser uses nn path when model ready and pick enabled', async () => {
+  const setup = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const initial = createInitialMatchState(setup, { seed: 14 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const pickState = {
+    ...initial,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    turn: { ...initial.turn, activeSeatId: nnSeat.id },
+    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
+  }
+  let nnCallCount = 0
+  let lastNnOptions = null
+  const chooser = createLivePlayActionChooser({
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({ modelId: 'latest', samplingMode: 'greedy' }),
+    isNnAdventurerPickEnabled: () => true,
+    chooseNnAction: async (state, actor, options) => {
+      nnCallCount += 1
+      lastNnOptions = options
+      return chooseRandombotAction(state, { seatId: actor.seatId })
+    },
+  })
+  const action = await chooser({ state: pickState, seatId: nnSeat.id })
+  assert.equal(nnCallCount, 1)
+  assert.deepEqual(lastNnOptions, { modelId: 'latest', samplingMode: 'greedy' })
+  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
+})
+
+test('headless completion appends actions to state history through match over', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 4242 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  const historyBefore = start.history.length
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.ok(result.state.history.length > historyBefore)
+  assert.ok(result.actionCount > 0)
+  assert.equal(result.state.history.length, historyBefore + result.actionCount)
+})
+
+function survivingOpponentCount(state, humanSeatId) {
+  return state.seats.filter(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  ).length
+}
+
+function buildFourPlayerDeferredEliminationContinue(seed) {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+    },
+    turn: { ...initial.turn, activeSeatId: human.id },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  const { displayState, deferredState } = buildDeferredDungeonOutcomeDisplayState(onLastLife, eliminated.state)
+  assert.equal(displayState.phase, MATCH_PHASES.DUNGEON)
+  assert.ok(deferredState)
+  assert.ok(survivingOpponentCount(deferredState, human.id) >= 2)
+  assert.equal(needsHeadlessCompletion(deferredState, human.id), true)
+  return { human, displayState, deferredState }
+}
+
+test('continue from deferred dungeon runs headless orchestration with overlay flight semantics', async () => {
+  const { human, displayState, deferredState } = buildFourPlayerDeferredEliminationContinue(9003)
+  const gate = createHeadlessCompletionFlightGate()
+  const chooseAction = async ({ state, seatId }) => chooseRandombotAction(state, { seatId })
+  let sawOverlayDuringRun = false
+
+  const completion = await runContinueFromDeferredThenHeadlessCompletion({
+    displayedState: displayState,
+    deferredPostDungeonState: deferredState,
+    humanPlayerSeatId: human.id,
+    chooseAction,
+    gate,
+    afterFlightStart: () => {
+      assert.equal(gate.inFlight, true)
+      assert.equal(shouldShowFinishingMatchOverlay(gate.inFlight), true)
+      assert.equal(shouldBlockLiveAiPipelineWhileHeadless(gate.inFlight), true)
+      sawOverlayDuringRun = true
+    },
+  })
+
+  assert.equal(sawOverlayDuringRun, true)
+  assert.equal(gate.inFlight, false)
+  assert.equal(shouldShowFinishingMatchOverlay(gate.inFlight), false)
+  assert.equal(completion.ran, true)
+  assert.equal(completion.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(getMatchOverEndDialogVariant(completion.state, human.id), MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  const summary = buildMatchOverSummary({
+    state: completion.state,
+    humanPlayerSeatId: human.id,
+    seats: completion.state.seats,
+  })
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.showWinner, false)
+})
+
+test('headless orchestration skips duplicate start while in flight', async () => {
+  const { human, displayState, deferredState } = buildFourPlayerDeferredEliminationContinue(9004)
+  const gate = createHeadlessCompletionFlightGate()
+  assert.equal(gate.tryStart(), true)
+  const blocked = await runContinueFromDeferredThenHeadlessCompletion({
+    displayedState: displayState,
+    deferredPostDungeonState: deferredState,
+    humanPlayerSeatId: human.id,
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    gate,
+  })
+  assert.equal(blocked.ran, false)
+  assert.equal(blocked.skippedReason, 'IN_FLIGHT')
+  gate.finish()
+})
+
+test('createLivePlayActionChooser consumes prefetch before nn inference', async () => {
+  const setup = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const initial = createInitialMatchState(setup, { seed: 99 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  let nnCalled = false
+  const chooser = createLivePlayActionChooser({
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => true,
+    chooseNnAction: async () => {
+      nnCalled = true
+      return { type: 'PASS' }
+    },
+    tryConsumePrefetch: async () => ({ type: 'DRAW' }),
+  })
+  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
+  assert.equal(action.type, 'DRAW')
+  assert.equal(nnCalled, false)
+})
+
+test('runHeadlessMatchCompletion fails closed when safety cap exceeded', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 1 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const opponent = initial.seats.find((seat) => seat.role.type === 'randombot')
+  assert.ok(opponent)
+  const start = {
+    ...initial,
+    turn: { ...initial.turn, activeSeatId: opponent.id },
+  }
+
+  const chooseAction = async ({ state, seatId }) => {
+    const legal = getLegalActions(state, { seatId })
+    return legal[0] ?? null
+  }
+
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction,
+    humanPlayerSeatId: human.id,
+    maxActions: 3,
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(result.errorCode, HEADLESS_COMPLETION_ERROR_CODES.SAFETY_CAP)
+  assert.equal(result.state.phase !== MATCH_PHASES.MATCH_OVER, true)
+  assert.equal(result.actionCount, 3)
+})

--- a/src/features/dungeon-runner/ui/humanEliminationCompletionPolicy.js
+++ b/src/features/dungeon-runner/ui/humanEliminationCompletionPolicy.js
@@ -1,0 +1,24 @@
+import { MATCH_PHASES } from '../engine/kernel.js'
+
+export const MATCH_OVER_END_VARIANTS = {
+  VICTORY: 'victory',
+  DEFEAT_NOT_ELIMINATED: 'defeat-not-eliminated',
+  ELIMINATION_END_HUMAN: 'elimination-end-human',
+}
+
+export function isHumanEliminated(state, humanPlayerSeatId) {
+  if (!state?.scoreboard || !humanPlayerSeatId) return false
+  return !!state.scoreboard[humanPlayerSeatId]?.eliminated
+}
+
+export function needsHeadlessCompletion(state, humanPlayerSeatId) {
+  return isHumanEliminated(state, humanPlayerSeatId) && state?.phase !== MATCH_PHASES.MATCH_OVER
+}
+
+export function getMatchOverEndDialogVariant(state, humanPlayerSeatId) {
+  if (!state || state.phase !== MATCH_PHASES.MATCH_OVER || !humanPlayerSeatId) return null
+  const winnerSeatId = state.matchWinnerSeatId
+  if (winnerSeatId === humanPlayerSeatId) return MATCH_OVER_END_VARIANTS.VICTORY
+  if (isHumanEliminated(state, humanPlayerSeatId)) return MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN
+  return MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED
+}

--- a/src/features/dungeon-runner/ui/humanEliminationCompletionPolicy.test.js
+++ b/src/features/dungeon-runner/ui/humanEliminationCompletionPolicy.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MATCH_PHASES } from '../engine/kernel.js'
+import {
+  getMatchOverEndDialogVariant,
+  isHumanEliminated,
+  MATCH_OVER_END_VARIANTS,
+  needsHeadlessCompletion,
+} from './humanEliminationCompletionPolicy.js'
+
+test('isHumanEliminated is false when human seat has lives remaining', () => {
+  assert.equal(
+    isHumanEliminated(
+      {
+        scoreboard: {
+          'seat-1': { lives: 2, eliminated: false },
+        },
+      },
+      'seat-1',
+    ),
+    false,
+  )
+})
+
+test('needsHeadlessCompletion is true when human is eliminated before match over', () => {
+  assert.equal(
+    needsHeadlessCompletion(
+      {
+        phase: MATCH_PHASES.PICK_ADVENTURER,
+        scoreboard: { 'seat-1': { eliminated: true } },
+      },
+      'seat-1',
+    ),
+    true,
+  )
+})
+
+test('getMatchOverEndDialogVariant is defeat-not-eliminated when human lost with lives left', () => {
+  assert.equal(
+    getMatchOverEndDialogVariant(
+      {
+        phase: MATCH_PHASES.MATCH_OVER,
+        matchWinnerSeatId: 'seat-2',
+        scoreboard: {
+          'seat-1': { eliminated: false, lives: 1 },
+          'seat-2': { eliminated: false },
+        },
+      },
+      'seat-1',
+    ),
+    MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED,
+  )
+})
+
+test('getMatchOverEndDialogVariant is elimination-end-human when human was eliminated', () => {
+  assert.equal(
+    getMatchOverEndDialogVariant(
+      {
+        phase: MATCH_PHASES.MATCH_OVER,
+        matchWinnerSeatId: 'seat-2',
+        scoreboard: {
+          'seat-1': { eliminated: true, lives: 0 },
+          'seat-2': { eliminated: false },
+        },
+      },
+      'seat-1',
+    ),
+    MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN,
+  )
+})
+
+test('getMatchOverEndDialogVariant is victory when human seat won match over', () => {
+  assert.equal(
+    getMatchOverEndDialogVariant(
+      {
+        phase: MATCH_PHASES.MATCH_OVER,
+        matchWinnerSeatId: 'seat-1',
+        scoreboard: { 'seat-1': { eliminated: false } },
+      },
+      'seat-1',
+    ),
+    MATCH_OVER_END_VARIANTS.VICTORY,
+  )
+})
+
+test('needsHeadlessCompletion is false at match over even if human was eliminated', () => {
+  assert.equal(
+    needsHeadlessCompletion(
+      {
+        phase: MATCH_PHASES.MATCH_OVER,
+        scoreboard: { 'seat-1': { eliminated: true } },
+      },
+      'seat-1',
+    ),
+    false,
+  )
+})
+
+test('isHumanEliminated is true when human seat scoreboard entry is eliminated', () => {
+  assert.equal(
+    isHumanEliminated(
+      {
+        scoreboard: {
+          'seat-1': { lives: 0, eliminated: true },
+        },
+      },
+      'seat-1',
+    ),
+    true,
+  )
+})

--- a/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
+++ b/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
+import { createLivePlayActionChooser } from './headlessMatchCompletionRunner.js'
+
+const RANDOMBOT_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'randombot' }],
+}
+
+const NN_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
+
+function expectedActionType(state, seatId, deps) {
+  const seat = state.seats.find((candidate) => candidate.id === seatId)
+  const roleType = seat?.role?.type
+  if (roleType === 'nn') {
+    const modelId = seat.role.modelId ?? 'latest'
+    if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !deps.isNnAdventurerPickEnabled()) {
+      return chooseRandombotAction(state, { seatId })?.type ?? null
+    }
+    if (deps.nnFailureRecovery.isCoolingDown(modelId)) {
+      return chooseRandombotAction(state, { seatId })?.type ?? null
+    }
+    return deps.fallbackActionType
+  }
+  return chooseRandombotAction(state, { seatId })?.type ?? null
+}
+
+test('createLivePlayActionChooser matches inline live AI action types for randombot seats', async () => {
+  const initial = createInitialMatchState(RANDOMBOT_SETUP, { seed: 21 })
+  const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
+  assert.ok(bot)
+  const deps = {
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => true,
+    fallbackActionType: 'PASS',
+  }
+  const chooser = createLivePlayActionChooser(deps)
+  const action = await chooser({ state: initial, seatId: bot.id })
+  assert.equal(action?.type ?? null, expectedActionType(initial, bot.id, deps))
+})
+
+test('createLivePlayActionChooser matches inline live AI action types when nn is cooling down', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 22 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const deps = {
+    nnFailureRecovery: { isCoolingDown: () => true },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => true,
+    fallbackActionType: 'PASS',
+  }
+  const chooser = createLivePlayActionChooser(deps)
+  const action = await chooser({ state: initial, seatId: nnSeat.id })
+  assert.equal(action?.type ?? null, expectedActionType(initial, nnSeat.id, deps))
+})
+
+test('createLivePlayActionChooser matches inline live AI action types on nn pick-adventurer when pick disabled', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 23 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const pickState = {
+    ...initial,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    turn: { ...initial.turn, activeSeatId: nnSeat.id },
+    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
+  }
+  const deps = {
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => false,
+    fallbackActionType: 'PASS',
+  }
+  const chooser = createLivePlayActionChooser(deps)
+  const action = await chooser({ state: pickState, seatId: nnSeat.id })
+  assert.equal(action?.type ?? null, expectedActionType(pickState, nnSeat.id, deps))
+})
+
+test('createLivePlayActionChooser matches inline live AI action types on nn inference path', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 24 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const deps = {
+    nnFailureRecovery: { isCoolingDown: () => false },
+    nnRuntimeOptions: () => ({}),
+    isNnAdventurerPickEnabled: () => true,
+    fallbackActionType: 'DRAW',
+  }
+  const chooser = createLivePlayActionChooser({
+    ...deps,
+    chooseNnAction: async () => ({ type: deps.fallbackActionType }),
+  })
+  const action = await chooser({ state: initial, seatId: nnSeat.id })
+  assert.equal(action?.type ?? null, expectedActionType(initial, nnSeat.id, deps))
+})

--- a/src/features/dungeon-runner/ui/matchOverEndDialog.integration.test.js
+++ b/src/features/dungeon-runner/ui/matchOverEndDialog.integration.test.js
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import {
+  ACTION_TYPES,
+  DUNGEON_SUBPHASES,
+  MATCH_PHASES,
+  applyAction,
+  createInitialMatchState,
+} from '../engine/kernel.js'
+import {
+  buildDeferredDungeonOutcomeDisplayState,
+  DEFAULT_MAX_HEADLESS_ACTIONS,
+  resolveHeadlessCompletionStartState,
+  resolveStateAfterDungeonOutcomeContinue,
+  runHeadlessMatchCompletion,
+} from './headlessMatchCompletionRunner.js'
+import {
+  getMatchOverEndDialogVariant,
+  MATCH_OVER_END_VARIANTS,
+  needsHeadlessCompletion,
+} from './humanEliminationCompletionPolicy.js'
+import { buildMatchOverSummary } from './matchOverSummaryBuilder.js'
+
+const ONE_V_ONE_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'randombot' }],
+}
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+const THREE_PLAYER_SETUP = {
+  totalSeats: 3,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }],
+}
+
+function seatByRole(state, roleType) {
+  return state.seats.find((seat) => seat.role.type === roleType)
+}
+
+function survivingOpponentCount(state, humanSeatId) {
+  return state.seats.filter(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  ).length
+}
+
+async function assertMultiSeatLethalEliminationHeadlessEndDialog(setup, seed) {
+  const initial = createInitialMatchState(setup, { seed })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+    },
+    turn: { ...initial.turn, activeSeatId: human.id },
+  }
+  const eliminated = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  assert.equal(eliminated.state.scoreboard[human.id].eliminated, true)
+  assert.equal(eliminated.state.scoreboard[human.id].lives, 0)
+  assert.equal(eliminated.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.ok(survivingOpponentCount(eliminated.state, human.id) >= 2)
+  assert.equal(needsHeadlessCompletion(eliminated.state, human.id), true)
+
+  const completion = await runHeadlessMatchCompletion(eliminated.state, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(completion.ok, true)
+  assert.equal(completion.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(completion.state.matchWinnerSeatId != null, true)
+  assert.notEqual(completion.state.matchWinnerSeatId, human.id)
+
+  const variant = getMatchOverEndDialogVariant(completion.state, human.id)
+  const summary = buildMatchOverSummary({
+    state: completion.state,
+    humanPlayerSeatId: human.id,
+    seats: completion.state.seats,
+  })
+
+  assert.equal(variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.showWinner, false)
+  assert.equal(summary.winnerLabel, null)
+}
+
+function lethalRevealDungeonState(state, runnerSeatId) {
+  return {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerSeatId },
+    bidding: { ...state.bidding, runnerSeatId, dungeonMonsters: ['dragon'] },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: ['dragon'],
+      hp: 3,
+      inPlayEquipmentIds: ['W_VORPAL'],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+}
+
+function emptyClearDungeonState(state, runnerSeatId, scoreboardPatch = {}) {
+  return {
+    ...state,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...state.turn, activeSeatId: runnerSeatId },
+    bidding: { ...state.bidding, runnerSeatId, dungeonMonsters: [] },
+    scoreboard: {
+      ...state.scoreboard,
+      ...scoreboardPatch,
+    },
+    dungeon: {
+      ...state.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: [],
+      hp: 1,
+      inPlayEquipmentIds: [],
+      discardedRunMonsters: [],
+      polySpent: true,
+      axeSpent: true,
+    },
+  }
+}
+
+test('4-player lethal elimination then headless completion yields elimination-end-human without winner row', async () => {
+  await assertMultiSeatLethalEliminationHeadlessEndDialog(FOUR_PLAYER_SETUP, 9001)
+})
+
+test('deferred dungeon outcome continue then headless completion yields elimination-end-human', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9003 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+    },
+    turn: { ...initial.turn, activeSeatId: human.id },
+  }
+  const prevState = onLastLife
+  const eliminated = applyAction(prevState, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(eliminated.ok, true)
+  assert.equal(eliminated.state.scoreboard[human.id].eliminated, true)
+
+  const { displayState, deferredState } = buildDeferredDungeonOutcomeDisplayState(
+    prevState,
+    eliminated.state,
+  )
+  assert.equal(displayState.phase, MATCH_PHASES.DUNGEON)
+  assert.ok(deferredState)
+  assert.equal(deferredState.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(needsHeadlessCompletion(deferredState, human.id), true)
+
+  const continued = resolveStateAfterDungeonOutcomeContinue(displayState, deferredState)
+  const start = resolveHeadlessCompletionStartState(continued, human.id)
+  const completion = await runHeadlessMatchCompletion(start, {
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+
+  assert.equal(completion.ok, true)
+  assert.equal(completion.state.phase, MATCH_PHASES.MATCH_OVER)
+
+  const variant = getMatchOverEndDialogVariant(completion.state, human.id)
+  const summary = buildMatchOverSummary({
+    state: completion.state,
+    humanPlayerSeatId: human.id,
+    seats: completion.state.seats,
+  })
+  assert.equal(variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.showWinner, false)
+})
+
+test('3-player lethal elimination then headless completion yields elimination-end-human without winner row', async () => {
+  await assertMultiSeatLethalEliminationHeadlessEndDialog(THREE_PLAYER_SETUP, 9002)
+})
+
+test('1v1 lethal dungeon elimination yields elimination-end-human summary without winner row', () => {
+  const initial = createInitialMatchState(ONE_V_ONE_SETUP, { seed: 2001 })
+  const human = seatByRole(initial, 'human')
+  const opponent = seatByRole(initial, 'randombot')
+  assert.ok(human)
+  assert.ok(opponent)
+
+  const onLastLife = {
+    ...lethalRevealDungeonState(initial, human.id),
+    scoreboard: {
+      ...initial.scoreboard,
+      [human.id]: { ...initial.scoreboard[human.id], lives: 1, eliminated: false },
+    },
+  }
+  const result = applyAction(onLastLife, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId: human.id })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(result.state.matchWinnerSeatId, opponent.id)
+  assert.equal(result.state.scoreboard[human.id].eliminated, true)
+  assert.equal(result.state.scoreboard[human.id].lives, 0)
+
+  const variant = getMatchOverEndDialogVariant(result.state, human.id)
+  const summary = buildMatchOverSummary({
+    state: result.state,
+    humanPlayerSeatId: human.id,
+    seats: result.state.seats,
+  })
+
+  assert.equal(variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.showWinner, false)
+  assert.equal(summary.winnerLabel, null)
+})
+
+test('1v1 opponent two successes while human has lives yields defeat-not-eliminated summary with winner label', () => {
+  const initial = createInitialMatchState(ONE_V_ONE_SETUP, { seed: 1 })
+  const human = seatByRole(initial, 'human')
+  const opponent = seatByRole(initial, 'randombot')
+  assert.ok(human)
+  assert.ok(opponent)
+
+  const opponentOneWinFromClear = emptyClearDungeonState(initial, opponent.id, {
+    [opponent.id]: { ...initial.scoreboard[opponent.id], successes: 1 },
+    [human.id]: { ...initial.scoreboard[human.id], lives: 2, eliminated: false },
+  })
+  const result = applyAction(
+    opponentOneWinFromClear,
+    { type: ACTION_TYPES.REVEAL_OR_CONTINUE },
+    { seatId: opponent.id },
+  )
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal(result.state.matchWinnerSeatId, opponent.id)
+  assert.equal(result.state.scoreboard[opponent.id].successes, 2)
+  assert.equal(result.state.scoreboard[human.id].eliminated, false)
+  assert.ok((result.state.scoreboard[human.id].lives ?? 0) > 0)
+
+  const variant = getMatchOverEndDialogVariant(result.state, human.id)
+  const summary = buildMatchOverSummary({
+    state: result.state,
+    humanPlayerSeatId: human.id,
+    seats: result.state.seats,
+  })
+
+  assert.equal(variant, MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED)
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED)
+  assert.equal(summary.showWinner, true)
+  assert.equal(summary.winnerLabel, opponent.label)
+})

--- a/src/features/dungeon-runner/ui/matchOverSummaryBuilder.js
+++ b/src/features/dungeon-runner/ui/matchOverSummaryBuilder.js
@@ -1,0 +1,54 @@
+import { MATCH_PHASES } from '../engine/kernel.js'
+import {
+  getMatchOverEndDialogVariant,
+  MATCH_OVER_END_VARIANTS,
+} from './humanEliminationCompletionPolicy.js'
+
+const FALLBACK_SUMMARY = {
+  variant: null,
+  showWinner: false,
+  title: 'Match over',
+  message: 'The match has ended.',
+  winnerLabel: null,
+}
+
+export function buildMatchOverSummary({ state = null, humanPlayerSeatId = null, seats = [] } = {}) {
+  if (!state || state.phase !== MATCH_PHASES.MATCH_OVER) return { ...FALLBACK_SUMMARY }
+
+  const variant = getMatchOverEndDialogVariant(state, humanPlayerSeatId)
+  const winnerSeatId = state.matchWinnerSeatId
+  const winnerSeat = seats.find((seat) => seat.id === winnerSeatId)
+  const winnerLabel = winnerSeat?.label ?? winnerSeatId ?? 'Unknown'
+
+  if (variant === MATCH_OVER_END_VARIANTS.VICTORY) {
+    return {
+      variant,
+      showWinner: true,
+      title: 'Victory!',
+      message: 'You won the match. Great run.',
+      winnerLabel,
+    }
+  }
+
+  if (variant === MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN) {
+    return {
+      variant,
+      showWinner: false,
+      title: 'Eliminated',
+      message: 'You were eliminated from the match.',
+      winnerLabel: null,
+    }
+  }
+
+  if (variant === MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED) {
+    return {
+      variant,
+      showWinner: true,
+      title: 'Defeat',
+      message: `${winnerLabel} won this match.`,
+      winnerLabel,
+    }
+  }
+
+  return { ...FALLBACK_SUMMARY, variant }
+}

--- a/src/features/dungeon-runner/ui/matchOverSummaryBuilder.test.js
+++ b/src/features/dungeon-runner/ui/matchOverSummaryBuilder.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MATCH_PHASES } from '../engine/kernel.js'
+import { MATCH_OVER_END_VARIANTS } from './humanEliminationCompletionPolicy.js'
+import { buildMatchOverSummary } from './matchOverSummaryBuilder.js'
+
+test('buildMatchOverSummary uses victory variant with winner row for human winner', () => {
+  const summary = buildMatchOverSummary({
+    state: {
+      phase: MATCH_PHASES.MATCH_OVER,
+      matchWinnerSeatId: 'seat-1',
+      scoreboard: { 'seat-1': { eliminated: false } },
+    },
+    humanPlayerSeatId: 'seat-1',
+    seats: [{ id: 'seat-1', label: 'You' }],
+  })
+
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.VICTORY)
+  assert.equal(summary.showWinner, true)
+  assert.equal(summary.winnerLabel, 'You')
+})
+
+test('buildMatchOverSummary uses defeat-not-eliminated variant with opponent winner label', () => {
+  const summary = buildMatchOverSummary({
+    state: {
+      phase: MATCH_PHASES.MATCH_OVER,
+      matchWinnerSeatId: 'seat-2',
+      scoreboard: {
+        'seat-1': { eliminated: false, lives: 1 },
+        'seat-2': { eliminated: false },
+      },
+    },
+    humanPlayerSeatId: 'seat-1',
+    seats: [
+      { id: 'seat-1', label: 'You' },
+      { id: 'seat-2', label: 'Bot A' },
+    ],
+  })
+
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.DEFEAT_NOT_ELIMINATED)
+  assert.equal(summary.showWinner, true)
+  assert.equal(summary.winnerLabel, 'Bot A')
+})
+
+test('buildMatchOverSummary uses elimination-end-human variant without winner row', () => {
+  const summary = buildMatchOverSummary({
+    state: {
+      phase: MATCH_PHASES.MATCH_OVER,
+      matchWinnerSeatId: 'seat-2',
+      scoreboard: {
+        'seat-1': { eliminated: true },
+        'seat-2': { eliminated: false },
+      },
+    },
+    humanPlayerSeatId: 'seat-1',
+    seats: [
+      { id: 'seat-1', label: 'You' },
+      { id: 'seat-2', label: 'Bot A' },
+    ],
+  })
+
+  assert.equal(summary.variant, MATCH_OVER_END_VARIANTS.ELIMINATION_END_HUMAN)
+  assert.equal(summary.showWinner, false)
+  assert.equal(summary.winnerLabel, null)
+  assert.equal(typeof summary.title, 'string')
+  assert.equal(typeof summary.message, 'string')
+})

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -311,7 +311,7 @@
                 size="lg"
                 class="col-12 col-sm-auto"
                 :label="actionLabel(action)"
-                :disable="gameplayInputLocked || dungeonOutcomeDialogOpen"
+                :disable="humanGameplayBlocked"
                 @click="takeHumanAction(action)"
               />
               <q-btn-dropdown
@@ -322,7 +322,7 @@
                 size="lg"
                 class="col-12 col-sm-auto"
                 label="Sacrifice equipment"
-                :disable="gameplayInputLocked || dungeonOutcomeDialogOpen"
+                :disable="humanGameplayBlocked"
               >
                 <q-list dense>
                   <q-item
@@ -352,7 +352,7 @@
                     class="dr-hero-pick-grid__btn full-width"
                     :label="getHeroIdentity(action.hero).shortLabel"
                     :aria-label="actionLabel(action)"
-                    :disable="gameplayInputLocked || dungeonOutcomeDialogOpen"
+                    :disable="humanGameplayBlocked"
                     @click="takeHumanAction(action)"
                   />
                 </div>
@@ -368,7 +368,7 @@
                   size="lg"
                   class="col-12 col-sm-auto"
                   :label="actionLabel(action)"
-                  :disable="gameplayInputLocked || dungeonOutcomeDialogOpen"
+                  :disable="humanGameplayBlocked"
                   @click="takeHumanAction(action)"
                 />
               </template>
@@ -477,7 +477,9 @@
         <div class="text-overline dr-outcome-kicker">Match complete</div>
         <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">{{ matchOverSummary.title }}</div>
         <div class="text-body1 q-mb-xs">{{ matchOverSummary.message }}</div>
-        <div class="text-body2 q-mb-md">Winner: {{ matchOverSummary.winnerLabel }}</div>
+        <div v-if="matchOverSummary.showWinner" class="text-body2 q-mb-md">
+          Winner: {{ matchOverSummary.winnerLabel }}
+        </div>
         <div class="row q-gutter-sm justify-end">
           <q-btn color="primary" unelevated label="Rematch" class="dr-outcome-btn" @click="rematch" />
           <q-btn flat color="primary" label="Back to setup" class="dr-outcome-btn-secondary" @click="backToSetup" />
@@ -536,7 +538,7 @@
             color="primary"
             unelevated
             label="Confirm"
-            :disable="!selectedVorpalSpecies || gameplayInputLocked"
+            :disable="!selectedVorpalSpecies || humanGameplayBlocked"
             @click="confirmVorpalDeclaration"
           />
         </div>
@@ -567,6 +569,14 @@
         </div>
       </q-card>
     </q-dialog>
+
+    <q-inner-loading
+      :showing="headlessCompletionInFlight"
+      data-testid="finishing-match-overlay"
+      class="dr-finishing-match-overlay"
+    >
+      <q-spinner size="50px" color="primary" />
+    </q-inner-loading>
 
     <DungeonRunnerHelpDialog v-model="helpOpen" />
   </q-page>
@@ -600,8 +610,11 @@ import { isNnAdventurerPickEnabled } from '../../features/dungeon-runner/setup/n
 import { shouldEnableDebugOnBoot } from '../../features/dungeon-runner/debug/mode.js'
 import { buildStateFromReplayEnvelope } from '../../features/dungeon-runner/debug/replaySession.js'
 import { exportReplayEnvelope, importReplayEnvelope } from '../../features/dungeon-runner/debug/replay.js'
-import { chooseRandombotAction } from '../../features/dungeon-runner/bots/randombot.js'
-import { chooseNnActionWithFallback, warmNnModelCache } from '../../features/dungeon-runner/nn/runtime.js'
+import {
+  abandonScheduledInferenceQueue,
+  chooseNnActionWithFallback,
+  warmNnModelCache,
+} from '../../features/dungeon-runner/nn/runtime.js'
 import { createModelFailureRecovery } from '../../features/dungeon-runner/nn/recovery.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
 import { pickDefaultModelId, validateSelectedModels } from '../../features/dungeon-runner/models/discovery.js'
@@ -653,6 +666,13 @@ import {
   buildDungeonOutcomeSummary,
   isDungeonOutcomeDialogOpen,
 } from '../../features/dungeon-runner/ui/dungeonOutcomeDialog.js'
+import { MATCH_OVER_END_VARIANTS } from '../../features/dungeon-runner/ui/humanEliminationCompletionPolicy.js'
+import {
+  createLivePlayActionChooser,
+  runMaybeHeadlessMatchCompletionFromState,
+  shouldDeferDungeonExitUntilOutcomeAck,
+} from '../../features/dungeon-runner/ui/headlessMatchCompletionRunner.js'
+import { buildMatchOverSummary } from '../../features/dungeon-runner/ui/matchOverSummaryBuilder.js'
 import MonsterCardFace from '../../components/dungeon-runner/MonsterCardFace.vue'
 import DungeonRunnerHelpDialog from '../../features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue'
 import { closeDeckSplay, createMemoryAidState, setMemoryAidEnabled, tapDeck } from '../../features/dungeon-runner/ui/memoryAidState.js'
@@ -856,6 +876,7 @@ const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
   'in-flight',
   'already-applied-token',
   'deferred-post-dungeon',
+  'headless-completion',
 ])
 
 function logAiTurnScheduleSkip(reason, detail = {}) {
@@ -875,7 +896,9 @@ function logAiTurnPrimeSkip(reason, detail = {}) {
 }
 
 function scheduleAiTurnOnPresentationTick() {
-  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value) return
+  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value || headlessCompletionInFlight.value) {
+    return
+  }
   scheduleAiTurnIfReady()
 }
 const uiAssets = dungeonRunnerAssetPack
@@ -962,6 +985,7 @@ const showActionPane = computed(
 const biddingSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'))
 const biddingNonSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'))
 const gameplayInputLocked = ref(false)
+const headlessCompletionInFlight = ref(false)
 const visibleState = computed(() => {
   if (!match.value || !humanSeatId.value) return null
   return getPlayerView(match.value.state, { seatId: humanSeatId.value })
@@ -1043,9 +1067,6 @@ const selectedEquipmentModalView = computed(() => {
     legalActions: legalActions.value,
   })
 })
-const equipmentModalActionsDisabled = computed(
-  () => gameplayInputLocked.value || dungeonOutcomeDialogOpen.value || !isHumanTurn.value,
-)
 const vorpalPromptView = computed(() =>
   createVorpalDeclarationPromptView({
     isHumanTurn: isHumanTurn.value,
@@ -1157,6 +1178,7 @@ const dungeonOutcomeMessage = computed(() =>
 const dungeonOutcomeDialogOpen = computed({
   get() {
     return (
+      !headlessCompletionInFlight.value &&
       !gameplayInputLocked.value &&
       isDungeonOutcomeDialogOpen({
       lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
@@ -1169,31 +1191,27 @@ const dungeonOutcomeDialogOpen = computed({
     continueFromDungeonOutcome()
   },
 })
-const matchOverSummary = computed(() => {
-  const fallback = {
-    title: 'Match over',
-    message: 'The match has ended.',
-    winnerLabel: 'Unknown',
-  }
-  if (!match.value || match.value.state.phase !== MATCH_PHASES.MATCH_OVER) return fallback
-  const winnerSeatId = match.value.state.matchWinnerSeatId
-  const winnerSeat = match.value.state.seats.find((seat) => seat.id === winnerSeatId)
-  const winnerLabel = winnerSeat?.label ?? winnerSeatId ?? 'Unknown'
-  const isHumanWinner = winnerSeatId != null && winnerSeatId === humanSeatId.value
-  if (isHumanWinner) {
-    return {
-      title: 'Victory!',
-      message: 'You won the match. Great run.',
-      winnerLabel,
-    }
-  }
-  return {
-    title: 'Defeat',
-    message: `${winnerLabel} won this match.`,
-    winnerLabel,
-  }
-})
-const matchOverToneClass = computed(() => (matchOverSummary.value.title === 'Victory!' ? 'dr-outcome--success' : 'dr-outcome--failure'))
+const humanGameplayBlocked = computed(
+  () =>
+    gameplayInputLocked.value ||
+    dungeonOutcomeDialogOpen.value ||
+    headlessCompletionInFlight.value,
+)
+const equipmentModalActionsDisabled = computed(
+  () => humanGameplayBlocked.value || !isHumanTurn.value,
+)
+const matchOverSummary = computed(() =>
+  buildMatchOverSummary({
+    state: match.value?.state ?? null,
+    humanPlayerSeatId: humanSeatId.value,
+    seats: match.value?.state?.seats ?? [],
+  }),
+)
+const matchOverToneClass = computed(() =>
+  matchOverSummary.value.variant === MATCH_OVER_END_VARIANTS.VICTORY
+    ? 'dr-outcome--success'
+    : 'dr-outcome--failure',
+)
 const matchOverDialogOpen = computed({
   get() {
     return !!match.value && match.value.state.phase === MATCH_PHASES.MATCH_OVER
@@ -1224,6 +1242,7 @@ onMounted(() => {
     presentationSpeedProfile.value = pace
     presentationOrchestrator.setSpeedProfile(pace)
     syncPresentationLabel()
+    void maybeRunHeadlessMatchCompletion()
   }
   void loadModelCatalog()
   presentationTimerId = window.setInterval(() => {
@@ -1425,7 +1444,7 @@ function takeHumanAction(action) {
     return
   }
   resetAiTurnPrefetch()
-  if (gameplayInputLocked.value) {
+  if (humanGameplayBlocked.value) {
     return
   }
   if (autoResolveTimerId) {
@@ -1493,7 +1512,7 @@ function onConfirmationDialogCancel() {
 }
 
 function openEquipmentModal(token) {
-  if (!token?.hasModal || dungeonOutcomeDialogOpen.value) return
+  if (!token?.hasModal || humanGameplayBlocked.value) return
   selectedEquipmentTokenId.value = token.equipmentId
   equipmentModalOpen.value = true
 }
@@ -1522,7 +1541,7 @@ function continueFromEquipmentModal() {
   equipmentModalOpen.value = false
 }
 
-function continueFromDungeonOutcome() {
+async function continueFromDungeonOutcome() {
   const run = match.value?.state?.lastDungeonRun
   if (!run) return
   dismissedDungeonRun.value = run
@@ -1532,6 +1551,68 @@ function continueFromDungeonOutcome() {
   }
   presentationOrchestrator.flushPostDungeonOutcomeAnimations()
   syncPresentationLabel()
+  await maybeRunHeadlessMatchCompletion()
+}
+
+function teardownForHeadlessMatchCompletion() {
+  if (aiTurnTimerId) {
+    window.clearTimeout(aiTurnTimerId)
+    aiTurnTimerId = null
+  }
+  if (autoResolveTimerId) {
+    window.clearTimeout(autoResolveTimerId)
+    autoResolveTimerId = null
+  }
+  resetAiTurnPrefetch()
+  abandonScheduledInferenceQueue()
+  presentationOrchestrator.clear()
+  deferredPostDungeonState.value = null
+  lastAppliedAiTurnToken = null
+  const run = match.value?.state?.lastDungeonRun
+  if (run) dismissedDungeonRun.value = run
+}
+
+function createPageHeadlessCompletionFlightGate() {
+  return {
+    get inFlight() {
+      return headlessCompletionInFlight.value
+    },
+    tryStart() {
+      if (headlessCompletionInFlight.value) return false
+      headlessCompletionInFlight.value = true
+      return true
+    },
+    finish() {
+      headlessCompletionInFlight.value = false
+    },
+  }
+}
+
+async function maybeRunHeadlessMatchCompletion() {
+  if (!match.value) return
+  const humanId = humanSeatId.value
+  if (!humanId) return
+
+  const chooseAction = createLivePlayActionChooser({
+    nnFailureRecovery,
+    ensureNnModelsReady,
+    nnRuntimeOptions,
+  })
+  try {
+    const result = await runMaybeHeadlessMatchCompletionFromState(match.value.state, {
+      humanPlayerSeatId: humanId,
+      chooseAction,
+      gate: createPageHeadlessCompletionFlightGate(),
+      afterFlightStart: teardownForHeadlessMatchCompletion,
+    })
+    if (result.ran && !result.failed) {
+      match.value = { ...match.value, state: result.state }
+    } else if (result.ran && result.failed && debugMode.value) {
+      console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
+    }
+  } finally {
+    syncPresentationLabel()
+  }
 }
 
 function confirmVorpalDeclaration() {
@@ -1546,6 +1627,10 @@ async function runAiTurn() {
   const trace = aiTurnTrace()
   if (aiTurnInFlight) {
     trace('run.skip', { reason: 'in-flight' })
+    return
+  }
+  if (headlessCompletionInFlight.value) {
+    trace('run.skip', { reason: 'headless-completion' })
     return
   }
   if (gameplayInputLocked.value) {
@@ -1588,37 +1673,16 @@ async function runAiTurn() {
   })
   const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
   const roleType = seat?.role?.type
-  let action = null
-  if (roleType === 'nn') {
+  const chooseAction = createLivePlayActionChooser({
+    nnFailureRecovery,
+    ensureNnModelsReady,
+    nnRuntimeOptions,
+    tryConsumePrefetch: async () => consumeAiTurnPrefetch(runToken, (step, detail) => trace(step, detail)),
+  })
+  let action = await chooseAction({ state: match.value.state, seatId, runToken })
+  if (roleType === 'nn' && action?.meta?.fallbackReason === 'MODEL_LOAD_FAILED') {
     const modelId = seat.role.modelId ?? 'latest'
-    if (match.value.state.phase === 'pick-adventurer' && !isNnAdventurerPickEnabled()) {
-      trace('choose.random-adventurer', { seatId })
-      action = chooseRandombotAction(match.value.state, { seatId })
-    } else if (nnFailureRecovery.isCoolingDown(modelId)) {
-      trace('choose.randombot', { reason: 'model-cooldown', modelId })
-      action = chooseRandombotAction(match.value.state, { seatId })
-    } else {
-      await ensureNnModelsReady()
-      action = await consumeAiTurnPrefetch(runToken, (step, detail) => trace(step, detail))
-      if (action) {
-        trace('choose.prefetch-hit', { modelId, actionType: action.type })
-      } else {
-        trace('choose.nn.begin', { modelId })
-        action = await chooseNnActionWithFallback(match.value.state, { seatId }, nnRuntimeOptions(modelId))
-        trace('choose.nn.done', { modelId, actionType: action?.type ?? null, fallbackReason: action?.meta?.fallbackReason ?? null })
-      }
-      if (action?.meta?.fallbackReason === 'MODEL_LOAD_FAILED') {
-        // Use the safe fallback for this turn; recovery UI must not block the AI pipeline.
-        void handleNnModelFailure(seat, modelId, seatId, action)
-      }
-    }
-  } else {
-    trace('choose.randombot', { seatId })
-    action = chooseRandombotAction(match.value.state, { seatId })
-  }
-  if (!action) {
-    trace('choose.empty', { seatId, roleType })
-    action = chooseRandombotAction(match.value.state, { seatId })
+    void handleNnModelFailure(seat, modelId, seatId, action)
   }
   if (!action) {
     trace('run.abort', { reason: 'no-action' })
@@ -1675,6 +1739,10 @@ async function runAiTurn() {
 
 function primeAiTurnPrefetch() {
   const trace = aiTurnTrace()
+  if (headlessCompletionInFlight.value) {
+    logAiTurnPrimeSkip('headless-completion')
+    return
+  }
   if (!match.value || isHumanTurn.value) {
     logAiTurnPrimeSkip(!match.value ? 'no-match' : 'human-turn')
     return
@@ -1717,14 +1785,6 @@ function primeAiTurnPrefetch() {
       return chooseNnActionWithFallback(state, { seatId }, nnRuntimeOptions(modelId))
     },
   })
-}
-
-function shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState) {
-  return (
-    prevState.phase === MATCH_PHASES.DUNGEON &&
-    nextState.phase === MATCH_PHASES.PICK_ADVENTURER &&
-    nextState.lastDungeonRun != null
-  )
 }
 
 function enqueuePresentationTransition(prevState, nextState, action, actorSeatId, actorRoleType) {
@@ -1871,6 +1931,10 @@ function scheduleAiTurnIfReady() {
     logAiTurnScheduleSkip('in-flight')
     return
   }
+  if (headlessCompletionInFlight.value) {
+    logAiTurnScheduleSkip('headless-completion')
+    return
+  }
   if (deferredPostDungeonState.value) {
     logAiTurnScheduleSkip('deferred-post-dungeon')
     return
@@ -1926,7 +1990,7 @@ function scheduleHumanAutoResolveIfReady() {
   if (!match.value) {
     return
   }
-  if (gameplayInputLocked.value) {
+  if (humanGameplayBlocked.value) {
     return
   }
   if (!isHumanTurn.value) {


### PR DESCRIPTION
## Summary

- When the human seat is **eliminated** but the match is not yet **match over**, finish remaining opponent play headlessly (no presentation), then show **elimination end (human)** without a winner line.
- Adds pure policy/summary modules and a headless completion runner with the same bot/NN chooser parity as live play; wires the play page for Continue, resume-on-load, finishing-match overlay, and locked controls.
- Preserves **defeat (human, not eliminated)** and victory dialogs; **completed match replay** still uploads at **match over**.

Closes #147

## Test plan

- [ ] Eliminate the human mid-match with multiple opponents: lethal dungeon outcome dialog → Continue → finishing overlay → elimination end dialog (no winner), rematch/setup work.
- [ ] Lose match over without elimination: defeat dialog still names the winner.
- [ ] Win the match: victory dialog unchanged.
- [ ] Reload after elimination before match over: resumes headless completion, not spectator bot play.
- [ ] `npm test` — policy, summary builder, headless runner, integration, and release tests pass.