### PR TITLE
Movie Vote: Pinia bridge for P2P sync (parity with Game Timer)

### DIFF
--- a/src/features/movie-vote/components/MovieVoteTopBar.vue
+++ b/src/features/movie-vote/components/MovieVoteTopBar.vue
@@ -76,7 +76,6 @@ import MovieVoteSyncControl from './MovieVoteSyncControl.vue'
 import { useMovieVoteP2P } from '../composables/useMovieVoteP2P.js'
 import { getMovieVoteSettingsModel } from '../settingsModel.js'
 import { normalizeVotingMethod, VOTING_METHOD_OPTIONS } from '../votingMethod.js'
-import { movieVoteHostVotingMethodChanged } from '../p2p/session.js'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 
 const helpOpen = ref(false)
@@ -97,7 +96,6 @@ const votingMethodModel = computed({
     const next = normalizeVotingMethod(v)
     if (next === votingMethod.value) return
     store.setVotingMethod(next)
-    movieVoteHostVotingMethodChanged()
   },
 })
 </script>

--- a/src/features/movie-vote/movieVoteStore.submitVote.test.js
+++ b/src/features/movie-vote/movieVoteStore.submitVote.test.js
@@ -1,0 +1,92 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/movieVoteStore.submitVote.test.js
+ */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from './core.js'
+import { useMovieVoteStore } from '../../stores/movieVote.js'
+
+/** @param {string} publicId */
+function ballotMovie(publicId) {
+  return {
+    publicId,
+    source: /** @type {const} */ ('custom'),
+    tmdbId: null,
+    customKey: publicId,
+    title: publicId,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+test('submitVote returns false without mutating when phase is not voting', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.phase = 'suggest'
+  store.myRanking = ['a', 'b']
+
+  assert.equal(store.submitVote(['a', 'b']), false)
+  assert.equal(store.myVoteSubmitted, false)
+})
+
+test('submitVote returns false when already submitted', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID])
+  store.myVoteSubmitted = true
+
+  assert.equal(store.submitVote(['a', 'b']), false)
+  assert.deepEqual(store.votesByParticipant, {})
+})
+
+test('submitVote returns false for invalid ranking', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID])
+
+  assert.equal(store.submitVote(['a']), false)
+  assert.equal(store.submitVote(['a', 'a']), false)
+  assert.equal(store.myVoteSubmitted, false)
+})
+
+test('submitVote host path records vote and locks ballot', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID])
+
+  assert.equal(store.submitVote(['b', 'a']), true)
+  assert.equal(store.myVoteSubmitted, true)
+  assert.deepEqual(store.votesByParticipant[HOST_PARTICIPANT_ID], ['b', 'a'])
+  assert.deepEqual(store.myRanking, ['b', 'a'])
+  assert.deepEqual(store.voteProgress, { submitted: 1, total: 1 })
+})
+
+test('submitVote guest path locks ballot without merging vote locally', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+
+  assert.equal(store.submitVote(['b', 'a']), true)
+  assert.equal(store.myVoteSubmitted, true)
+  assert.deepEqual(store.votesByParticipant, {})
+})
+
+test('setMyRanking does not change ranking after submit', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID, 'guest-1'])
+  store.submitVote(['b', 'a'])
+
+  store.setMyRanking(['a', 'b'])
+  assert.deepEqual(store.myRanking, ['b', 'a'])
+})

--- a/src/features/movie-vote/p2p/movieVotePiniaBridge.hostReset.test.js
+++ b/src/features/movie-vote/p2p/movieVotePiniaBridge.hostReset.test.js
@@ -1,0 +1,94 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/movieVotePiniaBridge.hostReset.test.js
+ *
+ * Host-reset wire integration (dynamic session load after RTDB mocks).
+ */
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+import { createApp } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { installRtdbLifecycleMocks, withFirebaseEnv } from './sessionRtdbLifecycleHarness.js'
+
+/** @returns {import('../types.js').MoviePick} */
+function customPick(localId, title) {
+  return {
+    localId,
+    source: 'custom',
+    tmdbId: null,
+    customKey: title.toLowerCase(),
+    title,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+const hostResetWireTests = { skip: !mock.module }
+
+test(
+  'host resetToSuggest clears guest draft ready flags and broadcasts state',
+  hostResetWireTests,
+  async () => {
+    mock.reset()
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => 'MVHOSTRESET1',
+        deriveStableHostSuffix: () => 'RESET1',
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    try {
+      await withFirebaseEnv(async () => {
+        const sessionMod = await import('./session.js')
+        const bridgeMod = await import('./movieVotePiniaBridge.js')
+
+        sessionMod.resetHostStateBroadcastProbeForTests()
+
+        const pinia = createPinia()
+        pinia.use(bridgeMod.movieVoteP2PPlugin)
+        const app = createApp({ render: () => null })
+        app.use(pinia)
+        setActivePinia(pinia)
+        const store = useMovieVoteStore()
+
+        await sessionMod.startAsHost(3)
+        assert.equal(sessionMod.sessionPhase.value, 'hosting')
+
+        sessionMod.setGuestDraftForTests('guest-1', { picks: [], ready: true })
+        sessionMod.setGuestDraftForTests('guest-2', {
+          picks: [customPick('g2', 'Guest Two')],
+          ready: true,
+        })
+
+        store.phase = 'results'
+        sessionMod.drainHostStateBroadcastProbeForTests()
+        bridgeMod.resetMovieVoteHostResetToSuggestProbeForTests()
+
+        store.resetToSuggest()
+
+        assert.deepEqual(bridgeMod.drainMovieVoteHostResetToSuggestProbeForTests(), [
+          'resetToSuggest',
+        ])
+        assert.equal(sessionMod.getGuestDraftReadyForTests('guest-1'), false)
+        assert.equal(sessionMod.getGuestDraftReadyForTests('guest-2'), false)
+        assert.ok(sessionMod.drainHostStateBroadcastProbeForTests() >= 1)
+        assert.ok(
+          harness.sets.some((s) => s.path.endsWith('/state')),
+          'host reset should write sequenced hub state',
+        )
+
+        sessionMod.teardownSession()
+      })
+    } finally {
+      mock.reset()
+    }
+  },
+)

--- a/src/features/movie-vote/p2p/movieVotePiniaBridge.js
+++ b/src/features/movie-vote/p2p/movieVotePiniaBridge.js
@@ -1,0 +1,338 @@
+/**
+ * @import '../types.js'
+ * Pinia plugin: apply inbound Movie Vote public state over P2P without echoing outbound sync.
+ */
+
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import {
+  bindMovieVoteP2PHandlers,
+  isMovieVoteP2PSessionActive,
+  sessionPhase,
+} from './session.js'
+
+let applyingRemote = false
+
+/** @type {import('./session.js').MovieVoteP2POutboundSync | null} */
+let outboundSync = null
+
+/** @type {string[]} */
+let syncProbe = []
+
+/** @type {string[]} */
+let hostSuggestOutboundProbe = []
+
+/** @type {{ participantId: string, ranking: string[] }[]} */
+let guestVoteWireProbe = []
+
+/** @type {string[]} */
+let hostAfterSubmitProbe = []
+
+/** @type {string[]} */
+let hostResetToSuggestProbe = []
+
+const SYNC_ACTION_NAMES = new Set([
+  'addDraftPick',
+  'removeDraftPick',
+  'clearAllDraftPicks',
+  'reorderDraftPicks',
+  'setReadyToVote',
+  'setParticipants',
+  'setUniqueSuggestedMovieCount',
+  'setVotingMethod',
+  'setVotingState',
+  'submitMyVoteLocal',
+  'markVoteSubmitted',
+  'mergeGuestVote',
+  'removeParticipantFromVote',
+  'setResults',
+  'resetForRoomExit',
+  'resetSessionSoft',
+  'resetToSuggest',
+])
+
+const GUEST_DRAFT_DEBOUNCE_MS = 320
+
+const GUEST_DRAFT_DEBOUNCE_ACTIONS = new Set([
+  'addDraftPick',
+  'removeDraftPick',
+  'reorderDraftPicks',
+  'clearAllDraftPicks',
+  'setReadyToVote',
+])
+
+/** Host suggest-phase intents: compile-check + RTDB state (not host-derived participant rows). */
+const HOST_SUGGEST_OUTBOUND_ACTIONS = new Set([
+  'addDraftPick',
+  'removeDraftPick',
+  'clearAllDraftPicks',
+  'reorderDraftPicks',
+  'setReadyToVote',
+])
+
+let handlersBound = false
+
+/** @type {ReturnType<typeof setTimeout> | undefined} */
+let guestDraftTimer
+
+/** @type {number} */
+let guestDraftPushProbe = 0
+
+/** @type {boolean} */
+let guestDraftPushSuppress = false
+
+/** @type {WeakSet<object>} */
+const actionHookInstalled = new WeakSet()
+
+/** @type {WeakSet<object>} */
+const phaseSubscribeInstalled = new WeakSet()
+
+/** @returns {import('./session.js').MovieVoteP2POutboundSync} */
+function getOutboundSync() {
+  if (!outboundSync) {
+    throw new Error('movieVote P2P outbound sync not initialized')
+  }
+  return outboundSync
+}
+
+/** @returns {void} */
+function cancelGuestDraftDebounce() {
+  if (guestDraftTimer !== undefined) {
+    globalThis.clearTimeout(guestDraftTimer)
+    guestDraftTimer = undefined
+  }
+}
+
+/** @returns {void} */
+function pushGuestDraftPayload() {
+  guestDraftPushProbe += 1
+  if (!guestDraftPushSuppress) {
+    getOutboundSync().guestPushDraft()
+  }
+}
+
+/** @returns {void} */
+function scheduleGuestDraftDebounce() {
+  cancelGuestDraftDebounce()
+  guestDraftTimer = globalThis.setTimeout(() => {
+    guestDraftTimer = undefined
+    pushGuestDraftPayload()
+  }, GUEST_DRAFT_DEBOUNCE_MS)
+}
+
+/**
+ * @param {ReturnType<typeof useMovieVoteStore>} store
+ * @returns {boolean}
+ */
+function shouldGuestSyncDraft(store) {
+  return (
+    sessionPhase.value === 'guest_connected' &&
+    store.phase === 'suggest' &&
+    Boolean(store.myParticipantId)
+  )
+}
+
+/** @returns {void} */
+export function resetMovieVoteP2PSyncProbeForTests() {
+  syncProbe = []
+}
+
+/** @returns {void} */
+export function resetMovieVoteGuestDraftDebounceForTests() {
+  cancelGuestDraftDebounce()
+  guestDraftPushProbe = 0
+  guestDraftPushSuppress = false
+}
+
+/** @param {boolean} suppress */
+export function suppressGuestDraftPushForTests(suppress) {
+  guestDraftPushSuppress = suppress
+}
+
+/** @returns {number} */
+export function drainGuestDraftPushProbeForTests() {
+  const n = guestDraftPushProbe
+  guestDraftPushProbe = 0
+  return n
+}
+
+/** @returns {string[]} */
+export function drainMovieVoteP2PSyncProbeForTests() {
+  const copy = [...syncProbe]
+  syncProbe = []
+  return copy
+}
+
+/** @returns {void} */
+export function resetMovieVoteHostSuggestProbeForTests() {
+  hostSuggestOutboundProbe = []
+}
+
+/** @returns {string[]} */
+export function drainMovieVoteHostSuggestProbeForTests() {
+  const copy = [...hostSuggestOutboundProbe]
+  hostSuggestOutboundProbe = []
+  return copy
+}
+
+/** @returns {void} */
+export function resetMovieVoteGuestVoteWireForTests() {
+  guestVoteWireProbe = []
+}
+
+/** @returns {{ participantId: string, ranking: string[] }[]} */
+export function drainMovieVoteGuestVoteWireForTests() {
+  const copy = [...guestVoteWireProbe]
+  guestVoteWireProbe = []
+  return copy
+}
+
+/** @returns {void} */
+export function resetMovieVoteHostAfterSubmitProbeForTests() {
+  hostAfterSubmitProbe = []
+}
+
+/** @returns {string[]} */
+export function drainMovieVoteHostAfterSubmitProbeForTests() {
+  const copy = [...hostAfterSubmitProbe]
+  hostAfterSubmitProbe = []
+  return copy
+}
+
+/** @returns {void} */
+export function resetMovieVoteHostResetToSuggestProbeForTests() {
+  hostResetToSuggestProbe = []
+}
+
+/** @returns {string[]} */
+export function drainMovieVoteHostResetToSuggestProbeForTests() {
+  const copy = [...hostResetToSuggestProbe]
+  hostResetToSuggestProbe = []
+  return copy
+}
+
+/**
+ * @param {import('../types.js').MovieVotePublicPayload} payload
+ * @returns {void}
+ */
+function applyInboundPublicPayload(payload) {
+  const s = useMovieVoteStore()
+  applyingRemote = true
+  try {
+    s.applyPublicPayload(payload)
+  } finally {
+    applyingRemote = false
+  }
+}
+
+/**
+ * Applies host/guest inbound public state the same way the P2P session handlers do (tests only).
+ * @param {import('../types.js').MovieVotePublicPayload} payload
+ * @returns {void}
+ */
+export function applyInboundMovieVotePayloadForTests(payload) {
+  applyInboundPublicPayload(payload)
+}
+
+/**
+ * Registers P2P public-payload handlers once and hooks `movieVote` store actions for future outbound sync.
+ * @param {import('pinia').PiniaPluginContext} ctx
+ * @returns {void}
+ */
+export function movieVoteP2PPlugin(ctx) {
+  const { store } = ctx
+  if (store.$id !== 'movieVote') return
+
+  if (!handlersBound) {
+    handlersBound = true
+    outboundSync = bindMovieVoteP2PHandlers({
+      applyPublicPayload: applyInboundPublicPayload,
+      onWireTeardown: () => {
+        cancelGuestDraftDebounce()
+      },
+    })
+  }
+
+  if (!phaseSubscribeInstalled.has(store)) {
+    phaseSubscribeInstalled.add(store)
+    store.$subscribe((_mutation, state) => {
+      if (sessionPhase.value === 'guest_connected' && state.phase !== 'suggest') {
+        cancelGuestDraftDebounce()
+      }
+    })
+  }
+
+  if (actionHookInstalled.has(store)) return
+  actionHookInstalled.add(store)
+
+  store.$onAction(({ name, after, args }) => {
+    after(() => {
+      if (applyingRemote) return
+
+      const s = useMovieVoteStore()
+      const wire = getOutboundSync()
+
+      if (sessionPhase.value === 'guest_connected' && s.phase !== 'suggest') {
+        cancelGuestDraftDebounce()
+      }
+
+      if (name === 'submitVote') {
+        if (!s.myVoteSubmitted) return
+        cancelGuestDraftDebounce()
+        if (!isMovieVoteP2PSessionActive()) return
+        const ranking = args[0]
+        if (!Array.isArray(ranking)) return
+        if (sessionPhase.value === 'guest_connected') {
+          guestVoteWireProbe.push({
+            participantId: s.myParticipantId ?? '',
+            ranking: [...ranking],
+          })
+          wire.guestSubmitVote(ranking)
+        } else if (sessionPhase.value === 'hosting') {
+          hostAfterSubmitProbe.push('afterVoteSubmit')
+          wire.hostAfterVoteSubmit()
+        }
+        return
+      }
+
+      if (!isMovieVoteP2PSessionActive()) return
+
+      if (name === 'markVoteSubmitted') {
+        cancelGuestDraftDebounce()
+      }
+
+      if (name === 'setMyParticipantId') {
+        if (shouldGuestSyncDraft(s)) {
+          cancelGuestDraftDebounce()
+          pushGuestDraftPayload()
+        }
+        return
+      }
+
+      if (GUEST_DRAFT_DEBOUNCE_ACTIONS.has(name) && shouldGuestSyncDraft(s)) {
+        scheduleGuestDraftDebounce()
+      }
+
+      if (!SYNC_ACTION_NAMES.has(name)) return
+
+      if (sessionPhase.value === 'hosting') {
+        if (name === 'resetToSuggest') {
+          hostResetToSuggestProbe.push('resetToSuggest')
+          wire.hostResetToSuggest()
+          return
+        }
+        if (s.phase !== 'suggest') return
+        syncProbe.push(name)
+        if (name === 'setVotingMethod') {
+          hostSuggestOutboundProbe.push('votingMethodChanged')
+          wire.hostVotingMethodChanged()
+        } else if (HOST_SUGGEST_OUTBOUND_ACTIONS.has(name)) {
+          hostSuggestOutboundProbe.push('localChanged')
+          wire.hostLocalChanged()
+        }
+        return
+      }
+
+      syncProbe.push(name)
+    })
+  })
+}

--- a/src/features/movie-vote/p2p/movieVotePiniaBridge.submitVote.test.js
+++ b/src/features/movie-vote/p2p/movieVotePiniaBridge.submitVote.test.js
@@ -1,0 +1,119 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/movieVotePiniaBridge.submitVote.test.js
+ */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createApp } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import {
+  drainMovieVoteGuestVoteWireForTests,
+  drainMovieVoteHostAfterSubmitProbeForTests,
+  drainMovieVoteP2PSyncProbeForTests,
+  movieVoteP2PPlugin,
+  resetMovieVoteGuestVoteWireForTests,
+  resetMovieVoteHostAfterSubmitProbeForTests,
+  resetMovieVoteP2PSyncProbeForTests,
+} from './movieVotePiniaBridge.js'
+import { sessionPhase } from './session.js'
+
+/** @param {string} publicId */
+function ballotMovie(publicId) {
+  return {
+    publicId,
+    source: /** @type {const} */ ('custom'),
+    tmdbId: null,
+    customKey: publicId,
+    title: publicId,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+function installMovieVotePinia() {
+  const pinia = createPinia()
+  pinia.use(movieVoteP2PPlugin)
+  const app = createApp({ render: () => null })
+  app.use(pinia)
+  setActivePinia(pinia)
+  return useMovieVoteStore()
+}
+
+test('guest submitVote wires vote message when P2P session active', () => {
+  resetMovieVoteGuestVoteWireForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+
+  sessionPhase.value = 'guest_connected'
+  assert.equal(store.submitVote(['b', 'a']), true)
+
+  assert.deepEqual(drainMovieVoteGuestVoteWireForTests(), [
+    { participantId: 'guest-1', ranking: ['b', 'a'] },
+  ])
+})
+
+test('invalid submitVote does not wire when P2P session active', () => {
+  resetMovieVoteGuestVoteWireForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+
+  sessionPhase.value = 'guest_connected'
+  assert.equal(store.submitVote(['a']), false)
+  assert.equal(store.myVoteSubmitted, false)
+  assert.deepEqual(drainMovieVoteGuestVoteWireForTests(), [])
+})
+
+test('guest submitVote does not wire when session idle', () => {
+  resetMovieVoteGuestVoteWireForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+
+  sessionPhase.value = 'idle'
+  assert.equal(store.submitVote(['b', 'a']), true)
+  assert.deepEqual(drainMovieVoteGuestVoteWireForTests(), [])
+})
+
+test('host submitVote triggers broadcast finish path when P2P session active', () => {
+  resetMovieVoteHostAfterSubmitProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID])
+
+  sessionPhase.value = 'hosting'
+  assert.equal(store.submitVote(['a', 'b']), true)
+
+  assert.deepEqual(drainMovieVoteHostAfterSubmitProbeForTests(), ['afterVoteSubmit'])
+})
+
+test('setMyRanking does not emit P2P sync probe when session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+
+  sessionPhase.value = 'guest_connected'
+  resetMovieVoteP2PSyncProbeForTests()
+  store.setMyRanking(['b', 'a'])
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})

--- a/src/features/movie-vote/p2p/movieVotePiniaBridge.test.js
+++ b/src/features/movie-vote/p2p/movieVotePiniaBridge.test.js
@@ -1,0 +1,524 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/movieVotePiniaBridge.test.js
+ *
+ * ## Fake-handler / probe pattern (#118 PRD)
+ *
+ * Production wires the `movieVote` store through `movieVoteP2PPlugin`, which registers
+ * `bindMovieVoteP2PHandlers` once and routes store `$onAction` hooks to the session
+ * outbound sync object (`hostLocalChanged`, `hostResetToSuggest`, `guestPushDraft`, …).
+ *
+ * Tests avoid RTDB/Firebase by:
+ * - **Fake handlers** — `bindMovieVoteP2PHandlers({ applyPublicPayload, onWireTeardown })` with
+ *   in-memory apply/teardown stubs (same contract as the plugin).
+ * - **Probes** — module-level counters/queues in `movieVotePiniaBridge.js` and `session.js`
+ *   (`drainMovieVote*ProbeForTests`, `drainHostStateBroadcastProbeForTests`) recording which
+ *   wire methods ran without asserting UI copy.
+ * - **Suppressors** — `suppressGuestDraftPushForTests` skips real inbox writes while still
+ *   counting debounced push scheduling.
+ * - **Inbound helper** — `applyInboundMovieVotePayloadForTests` applies remote payloads with
+ *   `applyingRemote` set so outbound echo probes stay empty.
+ *
+ * RTDB host-reset integration (guest-ready map + state broadcast) lives in
+ * `movieVotePiniaBridge.hostReset.test.js` with dynamic session load after `mock.module`.
+ */
+import assert from 'node:assert/strict'
+import { mock, test } from 'node:test'
+import { createApp } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { applyHostStoreFromRtdbHydrate } from '../hostRtdbHydrate.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import {
+  applyInboundMovieVotePayloadForTests,
+  drainGuestDraftPushProbeForTests,
+  drainMovieVoteHostAfterSubmitProbeForTests,
+  drainMovieVoteHostResetToSuggestProbeForTests,
+  drainMovieVoteHostSuggestProbeForTests,
+  drainMovieVoteP2PSyncProbeForTests,
+  movieVoteP2PPlugin,
+  resetMovieVoteGuestDraftDebounceForTests,
+  resetMovieVoteHostAfterSubmitProbeForTests,
+  resetMovieVoteHostResetToSuggestProbeForTests,
+  resetMovieVoteHostSuggestProbeForTests,
+  resetMovieVoteP2PSyncProbeForTests,
+  suppressGuestDraftPushForTests,
+} from './movieVotePiniaBridge.js'
+import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import { bindMovieVoteP2PHandlers, leaveSession, sessionPhase } from './session.js'
+
+function installMovieVotePinia() {
+  const pinia = createPinia()
+  pinia.use(movieVoteP2PPlugin)
+  const app = createApp({ render: () => null })
+  app.use(pinia)
+  setActivePinia(pinia)
+  return useMovieVoteStore()
+}
+
+/** @returns {import('../types.js').MovieVotePublicPayload} */
+function suggestPhasePayload(overrides = {}) {
+  return {
+    phase: 'suggest',
+    participants: [{ id: HOST_PARTICIPANT_ID, ready: false, pickCount: 0 }],
+    ballotMovies: null,
+    ballotOrderIds: null,
+    voteProgress: null,
+    irvResult: null,
+    uniqueSuggestedMovieCount: 0,
+    votingMethod: 'irv',
+    ...overrides,
+  }
+}
+
+/** @returns {import('../types.js').MoviePick} */
+function customPick(localId, title) {
+  return {
+    localId,
+    source: 'custom',
+    tmdbId: null,
+    customKey: title.toLowerCase(),
+    title,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+test('guest inbound state applies phase ballot and ready via bridge', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+
+  sessionPhase.value = 'guest_connected'
+
+  const payload = {
+    phase: 'voting',
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+      { id: 'guest-1', ready: true, pickCount: 1 },
+    ],
+    ballotMovies: [
+      {
+        publicId: 'm-a',
+        source: 'custom',
+        tmdbId: null,
+        customKey: 'alpha',
+        title: 'Alpha',
+        posterPath: null,
+        overview: '',
+      },
+      {
+        publicId: 'm-b',
+        source: 'custom',
+        tmdbId: null,
+        customKey: 'beta',
+        title: 'Beta',
+        posterPath: null,
+        overview: '',
+      },
+    ],
+    ballotOrderIds: ['m-a', 'm-b'],
+    voteProgress: { submitted: 0, total: 2 },
+    irvResult: null,
+    uniqueSuggestedMovieCount: 0,
+    votingMethod: 'irv',
+  }
+
+  applyInboundMovieVotePayloadForTests(payload)
+
+  assert.equal(store.phase, 'voting')
+  assert.equal(store.readyToVote, true)
+  assert.deepEqual(store.ballotOrderIds, ['m-a', 'm-b'])
+  assert.equal(store.ballotMovies.length, 2)
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})
+
+test('host RTDB hydrate applies public payload through bound handlers', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+
+  const payload = suggestPhasePayload({
+    participants: [{ id: HOST_PARTICIPANT_ID, ready: true, pickCount: 1 }],
+    uniqueSuggestedMovieCount: 3,
+    votingMethod: 'borda',
+  })
+
+  applyHostStoreFromRtdbHydrate(
+    { payload },
+    {
+      applyPublicPayload: (p) => applyInboundMovieVotePayloadForTests(p),
+      votingMethod: store.votingMethod,
+    },
+  )
+
+  assert.equal(store.readyToVote, true)
+  assert.equal(store.uniqueSuggestedMovieCount, 3)
+  assert.equal(store.votingMethod, 'borda')
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})
+
+test('action hook records local sync actions when session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+
+  sessionPhase.value = 'hosting'
+  store.addDraftPick(customPick('p1', 'One'))
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), ['addDraftPick'])
+})
+
+test('action hook ignores local actions when session idle', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+
+  sessionPhase.value = 'idle'
+  store.addDraftPick(customPick('p1', 'One'))
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})
+
+test('room exit invokes onWireTeardown handler', () => {
+  installMovieVotePinia()
+
+  let teardownCalls = 0
+  bindMovieVoteP2PHandlers({
+    onWireTeardown: () => {
+      resetMovieVoteGuestDraftDebounceForTests()
+      teardownCalls += 1
+    },
+  })
+
+  leaveSession()
+
+  assert.equal(teardownCalls, 1)
+  bindMovieVoteP2PHandlers({
+    onWireTeardown: () => {
+      resetMovieVoteGuestDraftDebounceForTests()
+    },
+  })
+})
+
+test('guest draft edits debounce to one push after quiesce', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  resetMovieVoteGuestDraftDebounceForTests()
+  resetMovieVoteP2PSyncProbeForTests()
+
+  try {
+    suppressGuestDraftPushForTests(true)
+    const store = installMovieVotePinia()
+    sessionPhase.value = 'guest_connected'
+    store.setMyParticipantId('guest-1')
+    assert.equal(drainGuestDraftPushProbeForTests(), 1)
+
+    store.addDraftPick(customPick('p1', 'One'))
+    store.addDraftPick(customPick('p2', 'Two'))
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+
+    mock.timers.tick(320)
+    assert.equal(drainGuestDraftPushProbeForTests(), 1)
+  } finally {
+    resetMovieVoteGuestDraftDebounceForTests()
+    mock.timers.reset()
+  }
+})
+
+/** @param {string} publicId */
+function ballotMovie(publicId) {
+  return {
+    publicId,
+    source: /** @type {const} */ ('custom'),
+    tmdbId: null,
+    customKey: publicId,
+    title: publicId,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+test('setMyParticipantId does not push draft when session idle', () => {
+  resetMovieVoteGuestDraftDebounceForTests()
+  suppressGuestDraftPushForTests(true)
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'idle'
+  store.setMyParticipantId('guest-1')
+  assert.equal(drainGuestDraftPushProbeForTests(), 0)
+  resetMovieVoteGuestDraftDebounceForTests()
+})
+
+test('pending guest draft debounce cancelled on voting phase without flush', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  resetMovieVoteGuestDraftDebounceForTests()
+
+  try {
+    suppressGuestDraftPushForTests(true)
+    const store = installMovieVotePinia()
+    sessionPhase.value = 'guest_connected'
+    store.setMyParticipantId('guest-1')
+    drainGuestDraftPushProbeForTests()
+
+    store.addDraftPick(customPick('p1', 'One'))
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+
+    store.setVotingState(
+      [ballotMovie('a'), ballotMovie('b')],
+      ['a', 'b'],
+      [HOST_PARTICIPANT_ID, 'guest-1'],
+    )
+
+    mock.timers.tick(320)
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+  } finally {
+    resetMovieVoteGuestDraftDebounceForTests()
+    mock.timers.reset()
+  }
+})
+
+test('pending guest draft debounce cancelled on room exit without flush', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  resetMovieVoteGuestDraftDebounceForTests()
+
+  try {
+    suppressGuestDraftPushForTests(true)
+    const store = installMovieVotePinia()
+    sessionPhase.value = 'guest_connected'
+    store.setMyParticipantId('guest-1')
+    drainGuestDraftPushProbeForTests()
+
+    store.addDraftPick(customPick('p1', 'One'))
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+
+    leaveSession()
+
+    mock.timers.tick(320)
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+  } finally {
+    resetMovieVoteGuestDraftDebounceForTests()
+    mock.timers.reset()
+  }
+})
+
+test('pending guest draft debounce cancelled on submitVote without flush', () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  resetMovieVoteGuestDraftDebounceForTests()
+
+  try {
+    suppressGuestDraftPushForTests(true)
+    const store = installMovieVotePinia()
+    sessionPhase.value = 'guest_connected'
+    store.setMyParticipantId('guest-1')
+    drainGuestDraftPushProbeForTests()
+
+    store.addDraftPick(customPick('p1', 'One'))
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+
+    store.setVotingState(
+      [ballotMovie('a'), ballotMovie('b')],
+      ['a', 'b'],
+      [HOST_PARTICIPANT_ID, 'guest-1'],
+    )
+    assert.equal(store.submitVote(['b', 'a']), true)
+
+    mock.timers.tick(320)
+    assert.equal(drainGuestDraftPushProbeForTests(), 0)
+  } finally {
+    resetMovieVoteGuestDraftDebounceForTests()
+    mock.timers.reset()
+  }
+})
+
+test('host setVotingMethod records sync and voting method in broadcast payload', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.setVotingMethod('borda')
+  assert.equal(store.votingMethod, 'borda')
+  const payload = buildMovieVotePublicPayload(store, new Map())
+  assert.equal(payload.votingMethod, 'borda')
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), ['setVotingMethod'])
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), ['votingMethodChanged'])
+})
+
+test('host suggest draft action wires localChanged not votingMethodChanged', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.addDraftPick(customPick('p1', 'One'))
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), ['localChanged'])
+})
+
+test('host setVotingMethod in voting phase does not wire outbound sync', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.setVotingMethod('borda')
+  store.phase = 'voting'
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  store.setVotingMethod('condorcet')
+  assert.equal(store.votingMethod, 'borda')
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+test('inbound applyPublicPayload does not emit sync probe when session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+
+  applyInboundMovieVotePayloadForTests(
+    suggestPhasePayload({
+      participants: [{ id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 }],
+      uniqueSuggestedMovieCount: 2,
+    }),
+  )
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})
+
+test('host resetToSuggest wires reset broadcast when P2P session active', () => {
+  resetMovieVoteHostResetToSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.phase = 'results'
+  store.resetToSuggest()
+  assert.deepEqual(drainMovieVoteHostResetToSuggestProbeForTests(), ['resetToSuggest'])
+})
+
+test('host resetToSuggest does not wire when session idle', () => {
+  resetMovieVoteHostResetToSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'idle'
+  store.resetToSuggest()
+  assert.deepEqual(drainMovieVoteHostResetToSuggestProbeForTests(), [])
+})
+
+test('host setParticipants in suggest records probe without suggest wire', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.setParticipants([{ id: HOST_PARTICIPANT_ID, ready: false, pickCount: 0 }])
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), ['setParticipants'])
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+const HOST_SUGGEST_WIRE_ACTIONS = [
+  ['addDraftPick', (s) => s.addDraftPick(customPick('w1', 'Wire'))],
+  ['removeDraftPick', (s) => s.removeDraftPick('setup')],
+  ['clearAllDraftPicks', (s) => s.clearAllDraftPicks()],
+  ['reorderDraftPicks', (s) => s.reorderDraftPicks(s.myDraftPicks.map((p) => ({ ...p })))],
+  ['setReadyToVote', (s) => s.setReadyToVote(true)],
+]
+
+for (const [name, run] of HOST_SUGGEST_WIRE_ACTIONS) {
+  test(`host ${name} in suggest wires localChanged`, () => {
+    const store = installMovieVotePinia()
+    sessionPhase.value = 'hosting'
+    if (name !== 'addDraftPick') {
+      store.addDraftPick(customPick('setup', 'Setup'))
+      resetMovieVoteHostSuggestProbeForTests()
+    } else {
+      resetMovieVoteHostSuggestProbeForTests()
+    }
+    run(store)
+    assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), ['localChanged'])
+  })
+}
+
+test('host suggest wire actions do not fire in voting phase', () => {
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.phase = 'voting'
+  store.addDraftPick(customPick('p1', 'One'))
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+test('setMyRanking does not outbound-sync when hosting session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID],
+  )
+  sessionPhase.value = 'hosting'
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+
+  store.setMyRanking(['b', 'a'])
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+test('setMyRanking does not outbound-sync when guest session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId('guest-1')
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+  sessionPhase.value = 'guest_connected'
+  resetMovieVoteP2PSyncProbeForTests()
+
+  store.setMyRanking(['b', 'a'])
+
+  assert.deepEqual(drainMovieVoteP2PSyncProbeForTests(), [])
+})
+
+test('setUniqueSuggestedMovieCount does not host-suggest wire when session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.setUniqueSuggestedMovieCount(4)
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+test('mergeGuestVote does not host-suggest wire when session active', () => {
+  resetMovieVoteHostSuggestProbeForTests()
+  resetMovieVoteHostAfterSubmitProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState(
+    [ballotMovie('a'), ballotMovie('b')],
+    ['a', 'b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+  sessionPhase.value = 'hosting'
+  store.mergeGuestVote('guest-1', ['b', 'a'])
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+  assert.deepEqual(drainMovieVoteHostAfterSubmitProbeForTests(), [])
+})
+
+test('setResults does not host-suggest wire when session active', () => {
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  store.setMyParticipantId(HOST_PARTICIPANT_ID)
+  store.setVotingState([ballotMovie('a'), ballotMovie('b')], ['a', 'b'], [HOST_PARTICIPANT_ID])
+  sessionPhase.value = 'hosting'
+  store.setResults({
+    winnerId: 'a',
+    rounds: [],
+    declaredTie: false,
+  })
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})
+
+test('resetSessionSoft does not host-suggest wire when session active', () => {
+  resetMovieVoteP2PSyncProbeForTests()
+  resetMovieVoteHostSuggestProbeForTests()
+  const store = installMovieVotePinia()
+  sessionPhase.value = 'hosting'
+  store.resetSessionSoft()
+  assert.deepEqual(drainMovieVoteHostSuggestProbeForTests(), [])
+})

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -57,6 +57,18 @@ import {
 
 const STABLE_HOST_SUFFIX_APP = 'movievote'
 
+/**
+ * @typedef {object} MovieVoteP2PHandlers
+ * @property {(payload: import('../types.js').MovieVotePublicPayload) => void} applyPublicPayload
+ * @property {() => void} onWireTeardown
+ */
+
+/** @type {MovieVoteP2PHandlers} */
+let handlers = {
+  applyPublicPayload: () => {},
+  onWireTeardown: () => {},
+}
+
 let nextSeq = 0
 
 let lastSeenSeq = 0
@@ -304,8 +316,11 @@ function buildPublicPayload() {
   return buildMovieVotePublicPayload(store, guestDrafts)
 }
 
+let hostStateBroadcastProbe = 0
+
 function hostBroadcastState() {
   if (!core.isHostRole() || !sessionSuffix.value) return
+  hostStateBroadcastProbe += 1
   const payload = buildPublicPayload()
   try {
     const st = useMovieVoteStore()
@@ -470,18 +485,109 @@ function handleGuestWelcome(raw) {
   const welcome = parseWelcome(raw)
   if (!welcome) return
   useMovieVoteStore().setMyParticipantId(welcome.participantId)
-  movieVoteGuestPushDraft()
 }
 
 /**
+ * Dispatches inbound hub state on the guest (sequenced public payload).
  * @param {unknown} raw
+ * @returns {void}
  */
 function handleGuestState(raw) {
   const st = parseState(raw)
   if (!st) return
   if (st.seq <= lastSeenSeq) return
   lastSeenSeq = st.seq
-  useMovieVoteStore().applyPublicPayload(st.payload)
+  try {
+    handlers.applyPublicPayload(st.payload)
+  } catch {
+    return
+  }
+}
+
+/**
+ * @typedef {object} MovieVoteP2POutboundSync
+ * @property {() => void} hostLocalChanged
+ * @property {() => void} hostResetToSuggest
+ * @property {() => void} hostVotingMethodChanged
+ * @property {() => void} guestPushDraft
+ * @property {(ranking: string[]) => void} guestSubmitVote
+ * @property {() => void} hostAfterVoteSubmit
+ */
+
+/** @type {MovieVoteP2POutboundSync} */
+const movieVoteP2POutboundSync = {
+  hostLocalChanged() {
+    if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
+    tryCompileBallot()
+    hostBroadcastState()
+  },
+  hostResetToSuggest() {
+    if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
+    clearGuestDraftReadyFlags(guestDrafts)
+    hostBroadcastState()
+  },
+  hostVotingMethodChanged() {
+    if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
+    hostBroadcastState()
+  },
+  guestPushDraft() {
+    if (core.isHostRole()) return
+    const store = useMovieVoteStore()
+    const pid = store.myParticipantId
+    if (!pid) return
+    core.writeGuestInbox(encodeDraft(store.myDraftPicks, store.readyToVote, pid))
+  },
+  guestSubmitVote(ranking) {
+    if (core.isHostRole()) return
+    const store = useMovieVoteStore()
+    const pid = store.myParticipantId
+    if (!pid) return
+    core.writeGuestInbox(encodeVote(pid, ranking))
+  },
+  hostAfterVoteSubmit() {
+    if (sessionPhase.value !== 'hosting') return
+    hostBroadcastState()
+    tryFinishVoting()
+  },
+}
+
+/**
+ * Installed once by the Pinia bridge; supplies public payload apply and wire teardown for the session.
+ * @param {Partial<MovieVoteP2PHandlers>} h
+ * @returns {MovieVoteP2POutboundSync}
+ */
+export function bindMovieVoteP2PHandlers(h) {
+  handlers = { ...handlers, ...h }
+  return movieVoteP2POutboundSync
+}
+
+/** @returns {void} */
+export function resetHostStateBroadcastProbeForTests() {
+  hostStateBroadcastProbe = 0
+}
+
+/** @returns {number} */
+export function drainHostStateBroadcastProbeForTests() {
+  const n = hostStateBroadcastProbe
+  hostStateBroadcastProbe = 0
+  return n
+}
+
+/**
+ * @param {string} participantId
+ * @param {{ picks: import('../types.js').MoviePick[], ready: boolean }} entry
+ * @returns {void}
+ */
+export function setGuestDraftForTests(participantId, entry) {
+  guestDrafts.set(participantId, entry)
+}
+
+/**
+ * @param {string} participantId
+ * @returns {boolean | undefined}
+ */
+export function getGuestDraftReadyForTests(participantId) {
+  return guestDrafts.get(participantId)?.ready
 }
 
 /**
@@ -643,7 +749,10 @@ async function hydrateHostFromRtdb(suffix) {
   const parsed = parseState(stateSnap.val())
   if (parsed) nextSeq = parsed.seq
   try {
-    applyHostStoreFromRtdbHydrate(parsed, useMovieVoteStore())
+    applyHostStoreFromRtdbHydrate(parsed, {
+      applyPublicPayload: (p) => handlers.applyPublicPayload(p),
+      votingMethod: useMovieVoteStore().votingMethod,
+    })
   } catch {
     void 0
   }
@@ -843,6 +952,11 @@ export function teardownSession() {
 function resetLocalStateAfterRoomExit() {
   teardownSession()
   try {
+    handlers.onWireTeardown()
+  } catch {
+    void 0
+  }
+  try {
     useMovieVoteStore().resetForRoomExit()
   } catch {
     void 0
@@ -868,44 +982,4 @@ export function leaveSession() {
 
 export function isMovieVoteP2PSessionActive() {
   return sessionPhase.value === 'hosting' || sessionPhase.value === 'guest_connected'
-}
-
-export function movieVoteHostLocalChanged() {
-  if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
-  tryCompileBallot()
-  hostBroadcastState()
-}
-
-/** After results reset: everyone must toggle ready again before the next ballot. */
-export function movieVoteHostResetToSuggest() {
-  if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
-  clearGuestDraftReadyFlags(guestDrafts)
-  hostBroadcastState()
-}
-
-export function movieVoteHostVotingMethodChanged() {
-  if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
-  hostBroadcastState()
-}
-
-export function movieVoteGuestPushDraft() {
-  if (core.isHostRole()) return
-  const store = useMovieVoteStore()
-  const pid = store.myParticipantId
-  if (!pid) return
-  core.writeGuestInbox(encodeDraft(store.myDraftPicks, store.readyToVote, pid))
-}
-
-export function movieVoteGuestSubmitVote(ranking) {
-  if (core.isHostRole()) return
-  const store = useMovieVoteStore()
-  const pid = store.myParticipantId
-  if (!pid) return
-  core.writeGuestInbox(encodeVote(pid, ranking))
-}
-
-export function movieVoteHostAfterVoteSubmit() {
-  if (!core.isHostRole() || sessionPhase.value !== 'hosting') return
-  hostBroadcastState()
-  tryFinishVoting()
 }

--- a/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
@@ -1,3 +1,10 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
+ *
+ * Uses dynamic `importSession` so RTDB mocks apply before `session.js` loads; host
+ * participant reconciliation still calls `outbound.hostLocalChanged()` where session
+ * has no matching store action (guest hello / guestOnline), not removed sync exports.
+ */
 import assert from 'node:assert/strict'
 import { afterEach, mock, test } from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
@@ -7,31 +14,7 @@ import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSessi
 import { encodeHello, encodeState, MSG_MV_DRAFT } from './protocol.js'
 import { ROOM_CLAIM_RESET_PATHS } from './sessionRoomRtdb.js'
 import { buildMovieVotePublicPayload } from '../publicPayload.js'
-
-const REQUIRED_FIREBASE_ENV = {
-  VITE_FIREBASE_API_KEY: 'test-api-key',
-  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
-  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
-  VITE_FIREBASE_PROJECT_ID: 'test-project',
-  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
-}
-
-/** @param {() => void | Promise<void>} fn */
-async function withFirebaseEnv(fn) {
-  const saved = {}
-  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-    saved[key] = process.env[key]
-    process.env[key] = REQUIRED_FIREBASE_ENV[key]
-  }
-  try {
-    await fn()
-  } finally {
-    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-      if (saved[key] === undefined) delete process.env[key]
-      else process.env[key] = saved[key]
-    }
-  }
-}
+import { installRtdbLifecycleMocks, withFirebaseEnv } from './sessionRtdbLifecycleHarness.js'
 
 /**
  * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
@@ -45,136 +28,6 @@ function refPath(ref) {
     cur = cur.parent ?? null
   }
   return parts.join('/')
-}
-
-/**
- * @param {string} dotPath
- * @returns {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }}
- */
-function buildRef(dotPath) {
-  const parts = dotPath.split('/').filter(Boolean)
-  /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null} */
-  let node = null
-  for (const part of parts) {
-    node = { key: part, parent: node }
-  }
-  return /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} */ (
-    node ?? { key: null, parent: null }
-  )
-}
-
-/**
- * @param {{
- *   getHostPing?: () => unknown,
- *   getEnded?: () => unknown,
- *   getHostClientId?: () => unknown,
- *   getState?: () => unknown,
- *   getWelcome?: () => unknown,
- *   getGuestOnline?: () => unknown,
- * }} [opts]
- * @returns {Promise<{
- *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
- *   sets: Array<{ path: string, value: unknown }>,
- *   removes: Array<{ path: string }>,
- *   emitChildAdded: (parentPath: string, childKey: string) => void,
- *   emitValue: (path: string, value: unknown) => void,
- * }>}
- */
-async function installRtdbLifecycleMocks(opts = {}) {
-  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
-  const listeners = new Map()
-  /** @type {Map<string, Set<(snap: { key: string | null, ref: ReturnType<typeof buildRef> }) => void>>} */
-  const childAddedHandlers = new Map()
-  /** @type {Array<{ path: string, value: unknown }>} */
-  const sets = []
-  /** @type {Array<{ path: string }>} */
-  const removes = []
-
-  /**
-   * @param {string} parentPath
-   * @param {string} childKey
-   */
-  function emitChildAdded(parentPath, childKey) {
-    const handlers = childAddedHandlers.get(parentPath)
-    if (!handlers?.size) return
-    const childPath = `${parentPath}/${childKey}`
-    const snap = { key: childKey, ref: buildRef(childPath) }
-    for (const handler of handlers) handler(snap)
-  }
-
-  /**
-   * @param {string} path
-   * @param {unknown} value
-   */
-  function emitValue(path, value) {
-    const handler = listeners.get(path)
-    if (handler) handler({ val: () => value })
-  }
-
-  const actual = await import('firebase/database')
-
-  mock.module('firebase/database', {
-    namedExports: {
-      ...actual,
-      get: async (ref) => {
-        if (ref.key === 'hostPing') {
-          return {
-            val: () => (opts.getHostPing !== undefined ? opts.getHostPing() : Date.now()),
-          }
-        }
-        if (ref.key === 'ended') {
-          return { val: () => (opts.getEnded !== undefined ? opts.getEnded() : null) }
-        }
-        if (ref.key === 'hostClientId') {
-          return {
-            val: () => (opts.getHostClientId !== undefined ? opts.getHostClientId() : null),
-          }
-        }
-        if (ref.key === 'state') {
-          return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
-        }
-        if (ref.key === 'welcome') {
-          return { val: () => (opts.getWelcome !== undefined ? opts.getWelcome() : null) }
-        }
-        if (ref.key === 'guestOnline') {
-          return {
-            val: () => (opts.getGuestOnline !== undefined ? opts.getGuestOnline() : null),
-          }
-        }
-        return { val: () => null }
-      },
-      set: async (ref, value) => {
-        sets.push({ path: refPath(ref), value })
-      },
-      remove: async (ref) => {
-        removes.push({ path: refPath(ref) })
-      },
-      onDisconnect: () => ({
-        remove: () => Promise.resolve(),
-        set: () => Promise.resolve(),
-      }),
-      onChildAdded: (ref, cb) => {
-        const path = refPath(ref)
-        if (!childAddedHandlers.has(path)) childAddedHandlers.set(path, new Set())
-        childAddedHandlers.get(path)?.add(cb)
-        return () => childAddedHandlers.get(path)?.delete(cb)
-      },
-      onValue: (ref, cb) => {
-        const path = refPath(ref)
-        listeners.set(path, cb)
-        return () => listeners.delete(path)
-      },
-    },
-  })
-
-  return {
-    listeners,
-    sets,
-    removes,
-    childAddedParentPaths: () => [...childAddedHandlers.keys()],
-    emitChildAdded,
-    emitValue,
-  }
 }
 
 /**
@@ -211,6 +64,33 @@ function guestParticipantIds(store) {
   return store.participants
     .filter((p) => p.id !== HOST_PARTICIPANT_ID)
     .map((p) => p.id)
+}
+
+/**
+ * Store + same `bindMovieVoteP2PHandlers` contract as the Pinia plugin, on the
+ * session module instance loaded by `importSession` (must not import the bridge
+ * before mocks — it would bind a different session copy).
+ * @param {Awaited<ReturnType<typeof importSession>>} sessionMod
+ */
+async function installLifecyclePinia(sessionMod) {
+  const { createApp } = await import('vue')
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const store = useMovieVoteStore()
+  const outbound = sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: () => {},
+  })
+  const app = createApp({ render: () => null })
+  app.use(pinia)
+  return { store, outbound }
+}
+
+/** Host suggest sync via outbound wire (replaces removed host sync exports). */
+function hostSyncParticipantsFromRoom(outbound) {
+  outbound.hostLocalChanged()
 }
 
 /** @type {import('../types.js').MovieVotePublicPayload} */
@@ -568,11 +448,9 @@ test(
     })
 
     await withFirebaseEnv(async () => {
-      const { startAsHost, movieVoteHostLocalChanged, sessionPhase } = await importSession(
-        `quorum-offline-${Date.now()}`,
-      )
-      setActivePinia(createPinia())
-      const store = useMovieVoteStore()
+      const sessionMod = await importSession(`quorum-offline-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = await installLifecyclePinia(sessionMod)
 
       await startAsHost(3)
       assert.equal(sessionPhase.value, 'hosting')
@@ -582,14 +460,14 @@ test(
       simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       const guestIdsAfterJoin = guestParticipantIds(store)
       assert.equal(guestIdsAfterJoin.length, 1)
 
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, false)
       mock.timers.tick(45_000)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       assert.equal(guestParticipantIds(store).length, 0)
       assert.ok(!guestParticipantIds(store).includes(guestIdsAfterJoin[0]))
@@ -624,42 +502,38 @@ test(
     })
 
     await withFirebaseEnv(async () => {
-      const { startAsHost, movieVoteHostLocalChanged, sessionPhase } = await importSession(
-        `zero-picks-ready-${Date.now()}`,
-      )
-      setActivePinia(createPinia())
-      const store = useMovieVoteStore()
+      const sessionMod = await importSession(`zero-picks-ready-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = await installLifecyclePinia(sessionMod)
 
       await startAsHost(3)
       assert.equal(sessionPhase.value, 'hosting')
 
-      store.myDraftPicks = [
-        {
-          localId: 'h1',
-          source: 'custom',
-          tmdbId: null,
-          customKey: 'alpha',
-          title: 'Alpha',
-          posterPath: null,
-          overview: '',
-        },
-        {
-          localId: 'h2',
-          source: 'custom',
-          tmdbId: null,
-          customKey: 'beta',
-          title: 'Beta',
-          posterPath: null,
-          overview: '',
-        },
-      ]
+      store.addDraftPick({
+        localId: 'h1',
+        source: 'custom',
+        tmdbId: null,
+        customKey: 'alpha',
+        title: 'Alpha',
+        posterPath: null,
+        overview: '',
+      })
+      store.addDraftPick({
+        localId: 'h2',
+        source: 'custom',
+        tmdbId: null,
+        customKey: 'beta',
+        title: 'Beta',
+        posterPath: null,
+        overview: '',
+      })
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
       simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       const guestPid = guestParticipantIds(store)[0]
       assert.ok(guestPid)
@@ -672,7 +546,7 @@ test(
       })
 
       store.setReadyToVote(true)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       assert.equal(store.phase, 'voting')
       assert.ok(store.voterIds.includes(HOST_PARTICIPANT_ID))
@@ -709,11 +583,9 @@ test(
     })
 
     await withFirebaseEnv(async () => {
-      const { startAsHost, movieVoteHostLocalChanged, sessionPhase } = await importSession(
-        `quorum-grace-${Date.now()}`,
-      )
-      setActivePinia(createPinia())
-      const store = useMovieVoteStore()
+      const sessionMod = await importSession(`quorum-grace-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = await installLifecyclePinia(sessionMod)
 
       await startAsHost(3)
       assert.equal(sessionPhase.value, 'hosting')
@@ -723,7 +595,7 @@ test(
       simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       const guestPid = guestParticipantIds(store)[0]
       assert.ok(guestPid)
@@ -732,7 +604,7 @@ test(
       mock.timers.tick(20_000)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       mock.timers.tick(45_000)
-      movieVoteHostLocalChanged()
+      hostSyncParticipantsFromRoom(outbound)
 
       assert.deepEqual(guestParticipantIds(store), [guestPid])
     })

--- a/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.js
+++ b/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.js
@@ -1,0 +1,176 @@
+/**
+ * Shared RTDB mocks for Movie Vote P2P lifecycle / bridge integration tests.
+ * Requires `node --experimental-test-module-mocks`.
+ */
+
+import { mock } from 'node:test'
+
+const REQUIRED_FIREBASE_ENV = {
+  VITE_FIREBASE_API_KEY: 'test-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
+  VITE_FIREBASE_PROJECT_ID: 'test-project',
+  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
+}
+
+/** @param {() => void | Promise<void>} fn */
+export async function withFirebaseEnv(fn) {
+  const saved = {}
+  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+    saved[key] = process.env[key]
+    process.env[key] = REQUIRED_FIREBASE_ENV[key]
+  }
+  try {
+    await fn()
+  } finally {
+    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
+/**
+ * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
+ * @returns {string}
+ */
+function refPath(ref) {
+  const parts = []
+  let cur = ref
+  while (cur) {
+    if (cur.key) parts.unshift(cur.key)
+    cur = cur.parent ?? null
+  }
+  return parts.join('/')
+}
+
+/**
+ * @param {string} dotPath
+ * @returns {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }}
+ */
+function buildRef(dotPath) {
+  const parts = dotPath.split('/').filter(Boolean)
+  /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null} */
+  let node = null
+  for (const part of parts) {
+    node = { key: part, parent: node }
+  }
+  return /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} */ (
+    node ?? { key: null, parent: null }
+  )
+}
+
+/**
+ * @param {{
+ *   getHostPing?: () => unknown,
+ *   getEnded?: () => unknown,
+ *   getHostClientId?: () => unknown,
+ *   getState?: () => unknown,
+ *   getWelcome?: () => unknown,
+ *   getGuestOnline?: () => unknown,
+ * }} [opts]
+ * @returns {Promise<{
+ *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
+ *   sets: Array<{ path: string, value: unknown }>,
+ *   removes: Array<{ path: string }>,
+ *   childAddedParentPaths: () => string[],
+ *   emitChildAdded: (parentPath: string, childKey: string) => void,
+ *   emitValue: (path: string, value: unknown) => void,
+ * }>}
+ */
+export async function installRtdbLifecycleMocks(opts = {}) {
+  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
+  const listeners = new Map()
+  /** @type {Map<string, Set<(snap: { key: string | null, ref: ReturnType<typeof buildRef> }) => void>>} */
+  const childAddedHandlers = new Map()
+  /** @type {Array<{ path: string, value: unknown }>} */
+  const sets = []
+  /** @type {Array<{ path: string }>} */
+  const removes = []
+
+  /**
+   * @param {string} parentPath
+   * @param {string} childKey
+   */
+  function emitChildAdded(parentPath, childKey) {
+    const handlers = childAddedHandlers.get(parentPath)
+    if (!handlers?.size) return
+    const childPath = `${parentPath}/${childKey}`
+    const snap = { key: childKey, ref: buildRef(childPath) }
+    for (const handler of handlers) handler(snap)
+  }
+
+  /**
+   * @param {string} path
+   * @param {unknown} value
+   */
+  function emitValue(path, value) {
+    const handler = listeners.get(path)
+    if (handler) handler({ val: () => value })
+  }
+
+  const actual = await import('firebase/database')
+
+  mock.module('firebase/database', {
+    namedExports: {
+      ...actual,
+      get: async (ref) => {
+        if (ref.key === 'hostPing') {
+          return {
+            val: () => (opts.getHostPing !== undefined ? opts.getHostPing() : Date.now()),
+          }
+        }
+        if (ref.key === 'ended') {
+          return { val: () => (opts.getEnded !== undefined ? opts.getEnded() : null) }
+        }
+        if (ref.key === 'hostClientId') {
+          return {
+            val: () => (opts.getHostClientId !== undefined ? opts.getHostClientId() : null),
+          }
+        }
+        if (ref.key === 'state') {
+          return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
+        }
+        if (ref.key === 'welcome') {
+          return { val: () => (opts.getWelcome !== undefined ? opts.getWelcome() : null) }
+        }
+        if (ref.key === 'guestOnline') {
+          return {
+            val: () => (opts.getGuestOnline !== undefined ? opts.getGuestOnline() : null),
+          }
+        }
+        return { val: () => null }
+      },
+      set: async (ref, value) => {
+        sets.push({ path: refPath(ref), value })
+      },
+      remove: async (ref) => {
+        removes.push({ path: refPath(ref) })
+      },
+      onDisconnect: () => ({
+        remove: () => Promise.resolve(),
+        set: () => Promise.resolve(),
+      }),
+      onChildAdded: (ref, cb) => {
+        const path = refPath(ref)
+        if (!childAddedHandlers.has(path)) childAddedHandlers.set(path, new Set())
+        childAddedHandlers.get(path)?.add(cb)
+        return () => childAddedHandlers.get(path)?.delete(cb)
+      },
+      onValue: (ref, cb) => {
+        const path = refPath(ref)
+        listeners.set(path, cb)
+        return () => listeners.delete(path)
+      },
+    },
+  })
+
+  return {
+    listeners,
+    sets,
+    removes,
+    childAddedParentPaths: () => [...childAddedHandlers.keys()],
+    emitChildAdded,
+    emitValue,
+  }
+}

--- a/src/pages/projects/MovieVotePage.vue
+++ b/src/pages/projects/MovieVotePage.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useQuasar } from 'quasar'
 import { useRoute, useRouter } from 'vue-router'
@@ -101,14 +101,7 @@ import {
   isValidRoomSuffix,
   normalizeRoomSuffixInput,
 } from '../../features/movie-vote/p2p/roomId.js'
-import {
-  joinRoom,
-  movieVoteGuestPushDraft,
-  movieVoteGuestSubmitVote,
-  movieVoteHostAfterVoteSubmit,
-  movieVoteHostLocalChanged,
-  movieVoteHostResetToSuggest,
-} from '../../features/movie-vote/p2p/session.js'
+import { joinRoom } from '../../features/movie-vote/p2p/session.js'
 import { useMovieVoteStore } from '../../stores/movieVote.js'
 
 const $q = useQuasar()
@@ -125,7 +118,7 @@ const {
   uniqueSuggestedMovieCount,
 } = storeToRefs(store)
 
-const { isGuest, isHosting, isInSession } = useMovieVoteP2P()
+const { isGuest, isInSession } = useMovieVoteP2P()
 
 /** Distinct movies in the room (TMDB-deduped) meet the minimum to mark ready. */
 const roomCanMarkReadyForVote = computed(() => uniqueSuggestedMovieCount.value >= 2)
@@ -134,49 +127,6 @@ const roomCanMarkReadyForVote = computed(() => uniqueSuggestedMovieCount.value >
 const roomShowsOthersSuggestionHint = computed(
   () => isInSession.value && uniqueSuggestedMovieCount.value >= 1,
 )
-
-let guestDraftTimer = 0
-function scheduleGuestDraftPush() {
-  if (!isGuest.value) return
-  window.clearTimeout(guestDraftTimer)
-  guestDraftTimer = window.setTimeout(() => {
-    guestDraftTimer = 0
-    movieVoteGuestPushDraft()
-  }, 320)
-}
-
-watch(
-  [myDraftPicks, () => store.readyToVote, phase, isGuest, uniqueSuggestedMovieCount],
-  () => {
-    if (isGuest.value && phase.value === 'suggest') {
-      scheduleGuestDraftPush()
-    }
-  },
-  { deep: true },
-)
-
-watch(
-  [() => store.myParticipantId, isGuest, phase],
-  () => {
-    if (isGuest.value && phase.value === 'suggest' && store.myParticipantId) {
-      movieVoteGuestPushDraft()
-    }
-  },
-)
-
-watch(
-  [myDraftPicks, () => store.readyToVote, phase, isHosting],
-  () => {
-    if (isHosting.value) {
-      movieVoteHostLocalChanged()
-    }
-  },
-  { deep: true },
-)
-
-onUnmounted(() => {
-  window.clearTimeout(guestDraftTimer)
-})
 
 const readyModel = computed({
   get: () => store.readyToVote,
@@ -204,32 +154,13 @@ function confirmClearMovies() {
 
 function onDoneVoting() {
   const ranking = [...store.myRanking]
-  if (ranking.length !== store.ballotOrderIds.length) {
+  if (!store.submitVote(ranking)) {
     $q.notify({ type: 'warning', message: 'Rank every movie.', position: 'top' })
-    return
   }
-  if (isGuest.value) {
-    movieVoteGuestSubmitVote(ranking)
-    store.markVoteSubmitted()
-    return
-  }
-  if (isHosting.value) {
-    store.submitMyVoteLocal(ranking)
-    movieVoteHostAfterVoteSubmit()
-    return
-  }
-  $q.notify({
-    type: 'warning',
-    message: 'Host or join a room to vote with others.',
-    position: 'top',
-  })
 }
 
 function onResetResults() {
   store.resetToSuggest()
-  if (isHosting.value) {
-    movieVoteHostResetToSuggest()
-  }
 }
 
 onMounted(() => {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -5,12 +5,14 @@ import { defineStore } from '#q-app/wrappers'
 import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { gameTimerP2PPlugin } from '../features/game-timer/p2p/gameTimerPiniaBridge.js'
+import { movieVoteP2PPlugin } from '../features/movie-vote/p2p/movieVotePiniaBridge.js'
 
 export default defineStore((/* { ssrContext } */) => {
   const pinia = createPinia()
 
   pinia.use(piniaPluginPersistedstate)
   pinia.use(gameTimerP2PPlugin)
+  pinia.use(movieVoteP2PPlugin)
 
   return pinia
 })

--- a/src/stores/movieVote.js
+++ b/src/stores/movieVote.js
@@ -213,6 +213,26 @@ export const useMovieVoteStore = defineStore('movieVote', {
       this.myRanking = [...ranking]
     },
 
+    /**
+     * Submit a full ballot ranking. Returns false without mutating when invalid.
+     * Host merges locally; guest locks UI until host state confirms.
+     * @param {string[]} ranking
+     * @returns {boolean}
+     */
+    submitVote(ranking) {
+      if (this.phase !== 'voting' || this.myVoteSubmitted) return false
+      if (!isRankingForBallot(ranking, this.ballotOrderIds)) return false
+
+      const pid = this.myParticipantId ?? HOST_PARTICIPANT_ID
+      if (pid === HOST_PARTICIPANT_ID) {
+        this.submitMyVoteLocal(ranking)
+      } else {
+        this.myRanking = [...ranking]
+        this.markVoteSubmitted()
+      }
+      return true
+    },
+
     /** Host records own vote */
     submitMyVoteLocal(ranking) {
       const pid = this.myParticipantId ?? HOST_PARTICIPANT_ID


### PR DESCRIPTION
## Summary

- Adds a Movie Vote Pinia P2P plugin (same bootstrap pattern as Game Timer) so pages and components dispatch store intents only; wire work goes through `bindMovieVoteP2PHandlers` with `applyingRemote` on inbound **state** applies.
- Moves guest **draft payload** debounce (320ms), host suggest/**voting method** sync, `submitVote`, and `resetToSuggest` off the play page and top bar into the plugin; shrinks session public API by removing `movieVoteHost*` / `movieVoteGuest*` sync exports.
- Rewrites RTDB lifecycle and bridge unit tests to drive the store with the plugin contract (fake-handler probes, host reset integration, full action→wire table).

Closes #118. Sub-issues #152–#156.

## Test plan

- [x] `npm test` (896 tests)
- [ ] Manual smoke: host + guest on `/projects/movie-vote` through suggest → voting → results → **Start over**
- [ ] ESLint on touched paths before merge if not run in CI