### PR TITLE
Dungeon Runner: replace silent NN fallbacks with runtime recovery

### DIFF
--- a/src/features/dungeon-runner/CONTRACT.md
+++ b/src/features/dungeon-runner/CONTRACT.md
@@ -13,13 +13,15 @@
 
 - AI agents read only `getLegalActions` output and submit one canonical action object.
 - Engine remains authoritative on legality and rejects out-of-contract actions.
-- Initial runtime AI strategy can choose from legal actions only; fallback is `PASS`.
 - Seat role types are `human`, `nn`, and `randombot`.
 - Model selection default is `latest`, else highest available semver.
-- NN runtime returns legal canonical actions and falls back to `PASS` on model/runtime failures.
-- NN runtime retries once on illegal model output before falling back to `PASS`.
+- NN inference runtime (`chooseNnAction`) returns a typed outcome: success with one legal canonical action and `meta` (`modelId`, `backend`), or failure with kind `LOAD`, `INFER`, or `ILLEGAL_OUTPUT` — never a substituted legal action on failure.
+- Exactly one legal action is returned immediately without inference; an empty legal set yields `null` (existing handling).
+- **Neural runtime recovery** is coordinated per `modelId` (shared model cache): split load (N=3) and infer (M=3) attempt counters, `recovering` flag, backend escalation (WebGL on attempts 1–2, CPU on attempt 3+), and terminal outcomes `NONE`, `REFRESH` (infer exhausted — refresh page, **match** may stay persisted), or `SETUP` (load exhausted — return to **setup** with **setup** preserved). Live play blocks only the active **neural opponent** seat while recovering.
+- **Match neural load gate** runs before the first turn on new **match** start and on resume-from-storage: preload each **setup** NN `modelId` once; any load failure immediately yields terminal **SETUP** (clear persisted **match**, restore **setup** snapshot) without multi-strike recovery.
+- `resetRuntimeForModel(modelId)` disposes the cached model, abandons the scheduled inference queue, and may reset the TF backend or force CPU for repair.
 - Default NN sampling mode is stochastic with deterministic code-level override support.
-- At runtime, **pick-adventurer** may bypass NN and use uniform random choice unless `VITE_DUNGEON_RUNNER_NN_PICK_ADVENTURER` is a strict truthy value (`1`, `true`, `yes`); this dev toggle is not part of the replay envelope.
+- For **neural opponent** seats, the sole intentional non-NN action path at runtime is the env-gated **pick-adventurer** bypass (uniform random choice when `VITE_DUNGEON_RUNNER_NN_PICK_ADVENTURER` is not a strict truthy value: `1`, `true`, `yes`); this dev toggle is not part of the replay envelope.
 - `encodeActionIndex` in `nn/policyAdapter.js` is a public export for dungeon-runner replay verification (maps canonical actions to policy head indices).
 
 ## Determinism Contract (v1)
@@ -33,6 +35,7 @@
 - Current match is stored as one local blob at `dungeon-runner/current-match`.
 - Resume flow is `resume-or-start-new` when a valid current match exists.
 - Schema mismatch must hard-reset persisted data.
+- Optional `neuralRecoveryByModelId` on the current **match** blob records per-`modelId` recovery coordinator counters and terminal outcome when infer/load exhaustion occurs during **finishing match** / headless completion so resume can surface the same blocking refresh or **setup** UX as live play (**REFRESH** keeps the **match**; **SETUP** is handled by clearing the blob).
 - Completed **match over** replays uploaded to RTDB use the same envelope shape as [Replay envelope contract (v1)](#replay-envelope-contract-v1); path root `dungeonRunnerCompletedMatches/{matchId}` (see `firebase/rtdb.js`). Field definitions are not duplicated here.
 - Completed **match over** outcomes uploaded to Firestore use [Match outcome record (v1)](#match-outcome-record-v1); path `dungeonRunnerMatchOutcomes/{matchId}` (see `firebase/firestore.js`). Paired replay and outcome share the same caller-supplied `createdAt`.
 

--- a/src/features/dungeon-runner/RELEASE_NOTES.md
+++ b/src/features/dungeon-runner/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 - Route + portfolio integration: complete.
 - Deterministic engine setup, legal actions, and transition contracts: complete.
 - Current match persistence and resume/start-new flow: complete.
-- Randombot and NN action paths with legality/fallback safety: complete.
+- Randombot and NN action paths with legality checks and neural runtime recovery: complete.
 - Localhost-gated debug mode and replay envelope workflow: complete.
 
 ## Known Risks

--- a/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
+++ b/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { chooseRandombotAction } from '../bots/randombot.js'
 import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
+import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
 import {
+  createLivePlayActionChooser,
   DEFAULT_MAX_HEADLESS_ACTIONS,
   runHeadlessMatchCompletion,
 } from '../ui/headlessMatchCompletionRunner.js'
@@ -467,6 +469,53 @@ test('createCompletedMatchReplayUploadTracker exposes maybeUpload', () => {
   const tracker = createCompletedMatchReplayUploadTracker(createMemoryStorage())
   assert.equal(typeof tracker.maybeUpload, 'function')
   assert.doesNotThrow(() => tracker.maybeUpload(null))
+})
+
+const NN_FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'nn', modelId: 'latest' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+async function buildHeadlessCompletedNnMatch(seed) {
+  const initial = createInitialMatchState(NN_FOUR_PLAYER_SETUP, { seed })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  const chooseAction = createLivePlayActionChooser({
+    nnRecovery: recovery,
+    nnRuntimeOptions: () => ({}),
+    chooseNnActionWithRecovery: async (state, actor) =>
+      chooseRandombotAction(state, { seatId: actor.seatId }),
+  })
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction,
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
+  return { initial, human, result }
+}
+
+test('maybeUpload uploads headless-completed nn match replay envelope', async () => {
+  const { initial, result } = await buildHeadlessCompletedNnMatch(8802)
+  const { deps, setCalls } = createDeps()
+  const match = {
+    id: 'match-headless-nn-complete',
+    setup: NN_FOUR_PLAYER_SETUP,
+    state: result.state,
+    presentationSpeedProfile: 'cinematic',
+  }
+
+  assert.ok(match.state.history.length > initial.history.length)
+
+  maybeUploadCompletedMatchReplay(match, deps)
+
+  assert.equal(setCalls.length, 1)
+  assert.equal(setCalls[0].matchId, 'match-headless-nn-complete')
+  assert.deepEqual(setCalls[0].envelope.setup, NN_FOUR_PLAYER_SETUP)
+  assert.deepEqual(setCalls[0].envelope.history, match.state.history)
 })
 
 test('maybeUpload uploads headless-completed multi-seat match replay envelope', async () => {

--- a/src/features/dungeon-runner/nn/chooseWithRecovery.js
+++ b/src/features/dungeon-runner/nn/chooseWithRecovery.js
@@ -1,0 +1,107 @@
+import { chooseNnAction, resetRuntimeForModel, NN_FAILURE_KIND } from './runtime.js'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from './recovery.js'
+
+export class NeuralRecoveryTerminalError extends Error {
+  /**
+   * @param {string} terminal
+   * @param {string} modelId
+   * @param {{ failureKind?: string }} [options]
+   */
+  constructor(terminal, modelId, options = {}) {
+    super(`Neural recovery reached terminal state: ${terminal}`)
+    this.name = 'NeuralRecoveryTerminalError'
+    this.terminal = terminal
+    this.modelId = modelId
+    this.failureKind = options.failureKind
+  }
+}
+
+/**
+ * @param {{
+ *   recovery?: ReturnType<typeof createNeuralRuntimeRecoveryCoordinator>
+ *   chooseNnAction?: typeof chooseNnAction
+ *   resetRuntimeForModel?: typeof resetRuntimeForModel
+ *   onRecoveryBegin?: (modelId: string) => void
+ *   onRecoveryAttempt?: (detail: {
+ *     modelId: string
+ *     failureKind: string
+ *     loadAttempts: number
+ *     inferAttempts: number
+ *     backend: string
+ *   }) => void
+ *   onRecoverySettled?: (modelId: string) => void
+ * }} [deps]
+ */
+export function createChooseNnActionWithRecovery(deps = {}) {
+  const recovery = deps.recovery ?? createNeuralRuntimeRecoveryCoordinator()
+  const choose = deps.chooseNnAction ?? chooseNnAction
+  const resetRuntime = deps.resetRuntimeForModel ?? resetRuntimeForModel
+  const onRecoveryBegin = deps.onRecoveryBegin
+  const onRecoveryAttempt = deps.onRecoveryAttempt
+  const onRecoverySettled = deps.onRecoverySettled
+  /** @type {Map<string, Promise<object|null>>} */
+  const inFlightByModelId = new Map()
+
+  async function runRecoveryLoop(state, actor, options, modelId) {
+    const terminalBefore = recovery.getTerminalOutcome(modelId)
+    if (terminalBefore !== NEURAL_RECOVERY_TERMINAL.NONE) {
+      throw new NeuralRecoveryTerminalError(terminalBefore, modelId)
+    }
+
+    while (true) {
+      const result = await choose(state, actor, { ...options, modelId })
+      if (result == null) return null
+      if (result.ok) {
+        recovery.recordSuccess(modelId)
+        onRecoverySettled?.(modelId)
+        return result.action
+      }
+
+      if (!recovery.isRecovering(modelId)) {
+        recovery.beginRecovery(modelId)
+        onRecoveryBegin?.(modelId)
+      }
+
+      const failurePath = result.kind === NN_FAILURE_KIND.LOAD ? 'load' : 'infer'
+      if (result.kind === NN_FAILURE_KIND.LOAD) {
+        recovery.recordLoadFailure(modelId)
+      } else {
+        recovery.recordInferFailure(modelId)
+      }
+
+      const backend = recovery.getBackendPreference(modelId, failurePath)
+      onRecoveryAttempt?.({
+        modelId,
+        failureKind: result.kind,
+        loadAttempts: recovery.getLoadAttempts(modelId),
+        inferAttempts: recovery.getInferAttempts(modelId),
+        backend,
+      })
+      resetRuntime(modelId, {
+        forceCpu: backend === 'cpu',
+        resetBackend: true,
+      })
+
+      const terminal = recovery.getTerminalOutcome(modelId)
+      if (terminal !== NEURAL_RECOVERY_TERMINAL.NONE) {
+        onRecoverySettled?.(modelId)
+        throw new NeuralRecoveryTerminalError(terminal, modelId, { failureKind: result.kind })
+      }
+    }
+  }
+
+  return async function chooseNnActionWithRecovery(state, actor, options = {}) {
+    const modelId = options.modelId ?? 'latest'
+    const existing = inFlightByModelId.get(modelId)
+    if (existing) return existing
+
+    const run = runRecoveryLoop(state, actor, options, modelId).finally(() => {
+      inFlightByModelId.delete(modelId)
+    })
+    inFlightByModelId.set(modelId, run)
+    return run
+  }
+}

--- a/src/features/dungeon-runner/nn/chooseWithRecovery.test.js
+++ b/src/features/dungeon-runner/nn/chooseWithRecovery.test.js
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from './recovery.js'
+import {
+  NeuralRecoveryTerminalError,
+  createChooseNnActionWithRecovery,
+} from './chooseWithRecovery.js'
+import { NN_FAILURE_KIND } from './runtime.js'
+
+function makeRunner(overrides = {}) {
+  const recovery = overrides.recovery ?? createNeuralRuntimeRecoveryCoordinator({
+    loadMaxAttempts: 3,
+    inferMaxAttempts: 3,
+  })
+  const resetCalls = []
+  let chooseImpl = overrides.chooseImpl
+  const chooseNnAction = async (state, actor, options) => {
+    if (chooseImpl) return chooseImpl(state, actor, options)
+    return { ok: true, action: { type: 'DRAW', meta: { modelId: options.modelId } } }
+  }
+  const onRecoveryBegin = overrides.onRecoveryBegin ?? (() => {})
+  const onRecoveryAttempt = overrides.onRecoveryAttempt
+  const runner = createChooseNnActionWithRecovery({
+    recovery,
+    chooseNnAction,
+    resetRuntimeForModel: (modelId, options) => {
+      resetCalls.push({ modelId, options })
+    },
+    onRecoveryBegin,
+    onRecoveryAttempt,
+  })
+  return { runner, recovery, resetCalls, setChooseImpl: (fn) => { chooseImpl = fn } }
+}
+
+test('chooseWithRecovery returns action on first success without recovery', async () => {
+  const { runner } = makeRunner()
+  const action = await runner({}, { seatId: 'seat-1' }, { modelId: 'latest' })
+  assert.deepEqual(action, { type: 'DRAW', meta: { modelId: 'latest' } })
+})
+
+test('chooseWithRecovery retries after load failure until success', async () => {
+  const { runner, recovery, resetCalls, setChooseImpl } = makeRunner()
+  let attempts = 0
+  setChooseImpl(async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.LOAD, modelId: 'latest', errorMessage: 'MODEL_LOAD_TIMEOUT' }
+    }
+    return { ok: true, action: { type: 'PASS', meta: { modelId: 'latest' } } }
+  })
+  const action = await runner({}, { seatId: 'seat-1' }, { modelId: 'latest' })
+  assert.equal(action.type, 'PASS')
+  assert.equal(recovery.isRecovering('latest'), false)
+  assert.equal(resetCalls.length, 1)
+})
+
+test('chooseWithRecovery invokes onRecoveryAttempt with backend preference after failure', async () => {
+  const attempts = []
+  const { runner, setChooseImpl } = makeRunner({
+    onRecoveryAttempt: (detail) => attempts.push(detail),
+  })
+  let calls = 0
+  setChooseImpl(async () => {
+    calls += 1
+    if (calls === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest', errorMessage: 'INFER_FAILED' }
+    }
+    return { ok: true, action: { type: 'DRAW', meta: { modelId: 'latest' } } }
+  })
+  await runner({}, { seatId: 'seat-1' }, { modelId: 'latest' })
+  assert.equal(attempts.length, 1)
+  assert.equal(attempts[0].failureKind, NN_FAILURE_KIND.INFER)
+  assert.equal(attempts[0].loadAttempts, 0)
+  assert.equal(attempts[0].inferAttempts, 1)
+  assert.equal(attempts[0].backend, 'webgl')
+})
+
+test('chooseWithRecovery throws SETUP terminal after load exhaustion', async () => {
+  const { runner, setChooseImpl } = makeRunner()
+  setChooseImpl(async () => ({
+    ok: false,
+    kind: NN_FAILURE_KIND.LOAD,
+    modelId: 'latest',
+    errorMessage: 'MODEL_LOAD_TIMEOUT',
+  }))
+  await assert.rejects(
+    () => runner({}, { seatId: 'seat-1' }, { modelId: 'latest' }),
+    (error) => {
+      assert.ok(error instanceof NeuralRecoveryTerminalError)
+      assert.equal(error.terminal, NEURAL_RECOVERY_TERMINAL.SETUP)
+      assert.equal(error.modelId, 'latest')
+      return true
+    },
+  )
+})
+
+test('chooseWithRecovery throws REFRESH terminal after infer exhaustion', async () => {
+  const { runner, setChooseImpl } = makeRunner()
+  setChooseImpl(async () => ({
+    ok: false,
+    kind: NN_FAILURE_KIND.INFER,
+    modelId: 'latest',
+    errorMessage: 'INFER_FAILED',
+  }))
+  await assert.rejects(
+    () => runner({}, { seatId: 'seat-1' }, { modelId: 'latest' }),
+    (error) => {
+      assert.ok(error instanceof NeuralRecoveryTerminalError)
+      assert.equal(error.terminal, NEURAL_RECOVERY_TERMINAL.REFRESH)
+      return true
+    },
+  )
+})
+
+test('chooseWithRecovery blocks concurrent calls until recovery completes', async () => {
+  const { runner, setChooseImpl } = makeRunner()
+  let attempts = 0
+  let releaseFirstRetry
+  const firstRetryGate = new Promise((resolve) => {
+    releaseFirstRetry = resolve
+  })
+  setChooseImpl(async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }
+    }
+    if (attempts === 2) {
+      await firstRetryGate
+      return { ok: true, action: { type: 'ADD_TO_DUNGEON', meta: { modelId: 'latest' } } }
+    }
+    return { ok: true, action: { type: 'DRAW', meta: { modelId: 'latest' } } }
+  })
+  const first = runner({}, { seatId: 'seat-1' }, { modelId: 'latest' })
+  await Promise.resolve()
+  const second = runner({}, { seatId: 'seat-2' }, { modelId: 'latest' })
+  releaseFirstRetry()
+  const [a, b] = await Promise.all([first, second])
+  assert.equal(a.type, 'ADD_TO_DUNGEON')
+  assert.equal(b.type, 'ADD_TO_DUNGEON')
+  assert.equal(attempts, 2)
+})
+
+test('chooseWithRecovery calls onRecoveryBegin on first failure', async () => {
+  let began = false
+  const { runner, setChooseImpl } = makeRunner({
+    onRecoveryBegin: () => { began = true },
+  })
+  let attempts = 0
+  setChooseImpl(async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.LOAD, modelId: 'latest' }
+    }
+    return { ok: true, action: { type: 'PASS', meta: { modelId: 'latest' } } }
+  })
+  await runner({}, { seatId: 'seat-1' }, { modelId: 'latest' })
+  assert.equal(began, true)
+})
+
+test('chooseWithRecovery treats ILLEGAL_OUTPUT as infer failure', async () => {
+  const { runner, recovery, setChooseImpl } = makeRunner()
+  setChooseImpl(async () => ({
+    ok: false,
+    kind: NN_FAILURE_KIND.ILLEGAL_OUTPUT,
+    modelId: 'latest',
+  }))
+  await assert.rejects(
+    () => runner({}, { seatId: 'seat-1' }, { modelId: 'latest' }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
+  assert.equal(recovery.getInferAttempts('latest'), 3)
+})

--- a/src/features/dungeon-runner/nn/matchNeuralLoadGate.js
+++ b/src/features/dungeon-runner/nn/matchNeuralLoadGate.js
@@ -1,0 +1,41 @@
+import { NEURAL_RECOVERY_TERMINAL } from './recovery.js'
+
+export { NEURAL_RECOVERY_TERMINAL }
+
+export function collectNeuralModelIdsFromSetup(setup) {
+  return [
+    ...new Set(
+      (setup?.opponents ?? [])
+        .filter((opponent) => opponent.type === 'nn')
+        .map((opponent) => opponent.modelId ?? 'latest'),
+    ),
+  ]
+}
+
+export async function runMatchNeuralLoadGate(setup, options = {}) {
+  const loadModel = options.loadModel
+  if (typeof loadModel !== 'function') {
+    throw new Error('loadModel required')
+  }
+  const modelIds = collectNeuralModelIdsFromSetup(setup)
+  for (const modelId of modelIds) {
+    try {
+      await loadModel(modelId, options.loadOptions)
+    } catch (error) {
+      return {
+        ok: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.SETUP,
+        failedModelId: modelId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+  return { ok: true, terminal: NEURAL_RECOVERY_TERMINAL.NONE }
+}
+
+export function resolveNeuralLoadGateSetupTerminal(options) {
+  const { storage, setupSnapshot, clearCurrentMatch, applySetupSnapshot, setupTarget } = options
+  applySetupSnapshot(setupTarget, setupSnapshot)
+  clearCurrentMatch(storage)
+  return { terminal: NEURAL_RECOVERY_TERMINAL.SETUP }
+}

--- a/src/features/dungeon-runner/nn/matchNeuralLoadGate.test.js
+++ b/src/features/dungeon-runner/nn/matchNeuralLoadGate.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  collectNeuralModelIdsFromSetup,
+  resolveNeuralLoadGateSetupTerminal,
+  runMatchNeuralLoadGate,
+} from './matchNeuralLoadGate.js'
+
+test('collectNeuralModelIdsFromSetup dedupes nn model ids with latest default', () => {
+  assert.deepEqual(
+    collectNeuralModelIdsFromSetup({
+      totalSeats: 4,
+      opponents: [
+        { type: 'nn', modelId: 'v1.0.0' },
+        { type: 'randombot' },
+        { type: 'nn' },
+      ],
+    }),
+    ['v1.0.0', 'latest'],
+  )
+})
+
+test('runMatchNeuralLoadGate succeeds when every nn model loads once', async () => {
+  const loads = []
+  const result = await runMatchNeuralLoadGate(
+    {
+      totalSeats: 3,
+      opponents: [{ type: 'nn', modelId: 'v1.0.0' }, { type: 'nn', modelId: 'v0.9.0' }],
+    },
+    {
+      loadModel(modelId) {
+        loads.push(modelId)
+        return Promise.resolve()
+      },
+    },
+  )
+  assert.equal(result.ok, true)
+  assert.equal(result.terminal, NEURAL_RECOVERY_TERMINAL.NONE)
+  assert.deepEqual(loads, ['v1.0.0', 'v0.9.0'])
+})
+
+test('runMatchNeuralLoadGate stops on first failed load with SETUP terminal', async () => {
+  const loads = []
+  const result = await runMatchNeuralLoadGate(
+    {
+      totalSeats: 3,
+      opponents: [{ type: 'nn', modelId: 'missing-model' }, { type: 'nn', modelId: 'v0.9.0' }],
+    },
+    {
+      loadModel(modelId) {
+        loads.push(modelId)
+        if (modelId === 'missing-model') {
+          return Promise.reject(new Error('missing model'))
+        }
+        return Promise.resolve()
+      },
+    },
+  )
+  assert.equal(result.ok, false)
+  assert.equal(result.terminal, NEURAL_RECOVERY_TERMINAL.SETUP)
+  assert.equal(result.failedModelId, 'missing-model')
+  assert.deepEqual(loads, ['missing-model'])
+})
+
+test('runMatchNeuralLoadGate skips load attempts when setup has no nn seats', async () => {
+  let loadCalls = 0
+  const result = await runMatchNeuralLoadGate(
+    {
+      totalSeats: 2,
+      opponents: [{ type: 'randombot' }],
+    },
+    {
+      loadModel() {
+        loadCalls += 1
+        return Promise.resolve()
+      },
+    },
+  )
+  assert.equal(result.ok, true)
+  assert.equal(loadCalls, 0)
+})
+
+test('resolveNeuralLoadGateSetupTerminal clears match and restores setup snapshot', () => {
+  const storage = { removed: false }
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  const snapshot = {
+    totalSeats: 3,
+    opponents: [{ type: 'nn', modelId: 'v1.0.0' }, { type: 'randombot' }],
+  }
+  const result = resolveNeuralLoadGateSetupTerminal({
+    storage,
+    setupSnapshot: snapshot,
+    clearCurrentMatch: (targetStorage) => {
+      assert.equal(targetStorage, storage)
+      targetStorage.removed = true
+    },
+    applySetupSnapshot: (target, nextSnapshot) => {
+      assert.equal(target, setupTarget)
+      assert.deepEqual(nextSnapshot, snapshot)
+      target.totalSeats = nextSnapshot.totalSeats
+      target.opponents.splice(0, target.opponents.length, ...nextSnapshot.opponents.map((opponent) => ({ ...opponent })))
+    },
+    setupTarget,
+  })
+  assert.equal(result.terminal, NEURAL_RECOVERY_TERMINAL.SETUP)
+  assert.equal(storage.removed, true)
+  assert.deepEqual(setupTarget, snapshot)
+})

--- a/src/features/dungeon-runner/nn/recovery.js
+++ b/src/features/dungeon-runner/nn/recovery.js
@@ -1,27 +1,141 @@
-export function createModelFailureRecovery(options = {}) {
-  const threshold = options.threshold ?? 2
-  const cooldownMs = options.cooldownMs ?? 30_000
-  const now = options.now ?? Date.now
+export const NEURAL_RECOVERY_TERMINAL = Object.freeze({
+  NONE: 'NONE',
+  REFRESH: 'REFRESH',
+  SETUP: 'SETUP',
+})
+
+/**
+ * @param {object} [options]
+ * @param {number} [options.loadMaxAttempts]
+ * @param {number} [options.inferMaxAttempts]
+ */
+export function createNeuralRuntimeRecoveryCoordinator(options = {}) {
+  const loadMaxAttempts = options.loadMaxAttempts ?? 3
+  const inferMaxAttempts = options.inferMaxAttempts ?? 3
   const stateByModelId = new Map()
 
+  function createEmptyState() {
+    return {
+      loadAttempts: 0,
+      inferAttempts: 0,
+      recovering: false,
+      terminal: NEURAL_RECOVERY_TERMINAL.NONE,
+    }
+  }
+
   function getState(modelId) {
-    const current = stateByModelId.get(modelId) ?? { failures: 0, cooldownUntil: 0 }
-    stateByModelId.set(modelId, current)
-    return current
+    if (!stateByModelId.has(modelId)) {
+      stateByModelId.set(modelId, createEmptyState())
+    }
+    return stateByModelId.get(modelId)
+  }
+
+  function backendForAttempt(attemptNumber) {
+    return attemptNumber >= 3 ? 'cpu' : 'webgl'
   }
 
   return {
-    recordFailure(modelId) {
+    beginRecovery(modelId) {
       const state = getState(modelId)
-      state.failures += 1
-      if (state.failures >= threshold) {
-        state.cooldownUntil = now() + cooldownMs
-        state.failures = 0
+      state.recovering = true
+    },
+    recordLoadFailure(modelId) {
+      const state = getState(modelId)
+      state.recovering = true
+      state.loadAttempts += 1
+      if (state.loadAttempts >= loadMaxAttempts) {
+        state.terminal = NEURAL_RECOVERY_TERMINAL.SETUP
+        state.recovering = false
       }
     },
-    isCoolingDown(modelId) {
+    recordInferFailure(modelId) {
       const state = getState(modelId)
-      return now() < state.cooldownUntil
+      state.recovering = true
+      state.inferAttempts += 1
+      if (state.inferAttempts >= inferMaxAttempts) {
+        state.terminal = NEURAL_RECOVERY_TERMINAL.REFRESH
+        state.recovering = false
+      }
+    },
+    recordSuccess(modelId) {
+      stateByModelId.set(modelId, createEmptyState())
+    },
+    isRecovering(modelId) {
+      const state = getState(modelId)
+      return state.recovering && state.terminal === NEURAL_RECOVERY_TERMINAL.NONE
+    },
+    shouldBlockTurn(modelId) {
+      return this.isRecovering(modelId)
+    },
+    getTerminalOutcome(modelId) {
+      return getState(modelId).terminal
+    },
+    getLoadAttempts(modelId) {
+      return getState(modelId).loadAttempts
+    },
+    getInferAttempts(modelId) {
+      return getState(modelId).inferAttempts
+    },
+    getBackendPreference(modelId, failureKind) {
+      const state = getState(modelId)
+      const attempts = failureKind === 'load' ? state.loadAttempts : state.inferAttempts
+      return backendForAttempt(attempts + 1)
+    },
+    reset(modelId) {
+      stateByModelId.delete(modelId)
+    },
+    exportSnapshot() {
+      /** @type {Record<string, { loadAttempts: number, inferAttempts: number, recovering: boolean, terminal: string }>} */
+      const snapshot = {}
+      for (const [modelId, state] of stateByModelId) {
+        snapshot[modelId] = {
+          loadAttempts: state.loadAttempts,
+          inferAttempts: state.inferAttempts,
+          recovering: state.recovering,
+          terminal: state.terminal,
+        }
+      }
+      return snapshot
+    },
+    importSnapshot(snapshot) {
+      if (!snapshot || typeof snapshot !== 'object') return
+      for (const [modelId, state] of Object.entries(snapshot)) {
+        if (!state || typeof state !== 'object') continue
+        stateByModelId.set(modelId, {
+          loadAttempts: Number(state.loadAttempts) || 0,
+          inferAttempts: Number(state.inferAttempts) || 0,
+          recovering: state.recovering === true,
+          terminal: Object.values(NEURAL_RECOVERY_TERMINAL).includes(state.terminal)
+            ? state.terminal
+            : NEURAL_RECOVERY_TERMINAL.NONE,
+        })
+      }
     },
   }
+}
+
+const TERMINAL_VALUES = new Set(Object.values(NEURAL_RECOVERY_TERMINAL))
+
+/**
+ * @param {unknown} snapshot
+ */
+export function isValidNeuralRecoveryByModelId(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return false
+  for (const state of Object.values(snapshot)) {
+    if (!state || typeof state !== 'object') return false
+    if (typeof state.loadAttempts !== 'number' || !Number.isFinite(state.loadAttempts)) return false
+    if (typeof state.inferAttempts !== 'number' || !Number.isFinite(state.inferAttempts)) return false
+    if (typeof state.recovering !== 'boolean') return false
+    if (!TERMINAL_VALUES.has(state.terminal)) return false
+  }
+  return true
+}
+
+/**
+ * @param {Record<string, { terminal?: string }>} snapshot
+ */
+export function neuralRecoverySnapshotHasTerminal(snapshot) {
+  return Object.values(snapshot).some(
+    (state) => state?.terminal && state.terminal !== NEURAL_RECOVERY_TERMINAL.NONE,
+  )
 }

--- a/src/features/dungeon-runner/nn/recovery.test.js
+++ b/src/features/dungeon-runner/nn/recovery.test.js
@@ -1,20 +1,108 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { createModelFailureRecovery } from './recovery.js'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from './recovery.js'
 
-test('marks model as cooling down after threshold failures', () => {
-  const recovery = createModelFailureRecovery({ threshold: 2, cooldownMs: 1000, now: () => 100 })
-  recovery.recordFailure('latest')
-  assert.equal(recovery.isCoolingDown('latest'), false)
-  recovery.recordFailure('latest')
-  assert.equal(recovery.isCoolingDown('latest'), true)
+test('recovery coordinator isolates state per modelId', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.isRecovering('v1.0.0'), false)
+  assert.equal(recovery.getTerminalOutcome('v1.0.0'), NEURAL_RECOVERY_TERMINAL.NONE)
 })
 
-test('cooldown expires and allows model again', () => {
-  let time = 100
-  const recovery = createModelFailureRecovery({ threshold: 1, cooldownMs: 1000, now: () => time })
-  recovery.recordFailure('latest')
-  assert.equal(recovery.isCoolingDown('latest'), true)
-  time = 1200
-  assert.equal(recovery.isCoolingDown('latest'), false)
+test('load failures increment load counter only', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ loadMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  recovery.recordLoadFailure('latest')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.getLoadAttempts('latest'), 2)
+  assert.equal(recovery.getInferAttempts('latest'), 0)
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.NONE)
+})
+
+test('infer failures increment infer counter only', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  recovery.recordInferFailure('latest')
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.getInferAttempts('latest'), 2)
+  assert.equal(recovery.getLoadAttempts('latest'), 0)
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.NONE)
+})
+
+test('third load failure reaches SETUP terminal', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ loadMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  recovery.recordLoadFailure('latest')
+  recovery.recordLoadFailure('latest')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.SETUP)
+  assert.equal(recovery.shouldBlockTurn('latest'), false)
+})
+
+test('third infer failure reaches REFRESH terminal', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  recovery.recordInferFailure('latest')
+  recovery.recordInferFailure('latest')
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.REFRESH)
+  assert.equal(recovery.shouldBlockTurn('latest'), false)
+})
+
+test('load backend escalation uses webgl for attempts 1-2 and cpu on attempt 3+', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ loadMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'load'), 'webgl')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'load'), 'webgl')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'load'), 'cpu')
+  recovery.recordLoadFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'load'), 'cpu')
+})
+
+test('infer backend escalation uses webgl for attempts 1-2 and cpu on attempt 3+', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 3 })
+  recovery.beginRecovery('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'infer'), 'webgl')
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'infer'), 'webgl')
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'infer'), 'cpu')
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.getBackendPreference('latest', 'infer'), 'cpu')
+})
+
+test('exportSnapshot and importSnapshot round-trip terminal state', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  recovery.beginRecovery('latest')
+  recovery.recordInferFailure('latest')
+  const snapshot = recovery.exportSnapshot()
+  const restored = createNeuralRuntimeRecoveryCoordinator()
+  restored.importSnapshot(snapshot)
+  assert.equal(restored.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.REFRESH)
+  assert.equal(restored.getInferAttempts('latest'), 1)
+})
+
+test('recordSuccess clears recovering state and counters', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  recovery.recordLoadFailure('latest')
+  recovery.recordSuccess('latest')
+  assert.equal(recovery.isRecovering('latest'), false)
+  assert.equal(recovery.getLoadAttempts('latest'), 0)
+  assert.equal(recovery.getInferAttempts('latest'), 0)
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.NONE)
+})
+
+test('shouldBlockTurn while recovering before terminal', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  assert.equal(recovery.shouldBlockTurn('latest'), true)
+  recovery.recordInferFailure('latest')
+  assert.equal(recovery.shouldBlockTurn('latest'), true)
 })

--- a/src/features/dungeon-runner/nn/runtime.js
+++ b/src/features/dungeon-runner/nn/runtime.js
@@ -14,6 +14,12 @@ let scheduledInferenceQueue = Promise.resolve()
  */
 let workerPathDisabled = true
 
+export const NN_FAILURE_KIND = Object.freeze({
+  LOAD: 'LOAD',
+  INFER: 'INFER',
+  ILLEGAL_OUTPUT: 'ILLEGAL_OUTPUT',
+})
+
 export const DEFAULT_NN_WORKER_TIMEOUT_MS = 8_000
 export const DEFAULT_NN_MODEL_LOAD_TIMEOUT_MS = 12_000
 /** Cap time spent in the scheduled inference queue for one sample (0 = no cap). */
@@ -43,7 +49,12 @@ function promiseWithTimeout(promise, timeoutMs, createError) {
   })
 }
 
-export async function chooseNnActionWithFallback(state, actor, options) {
+/**
+ * @typedef {{ ok: true, action: object }} NnChooseSuccess
+ * @typedef {{ ok: false, kind: keyof typeof NN_FAILURE_KIND, errorMessage?: string, modelId: string }} NnChooseFailure
+ */
+
+export async function chooseNnAction(state, actor, options) {
   const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), {
     modelId: options?.modelId ?? 'latest',
     seatId: actor.seatId,
@@ -64,57 +75,54 @@ export async function chooseNnActionWithFallback(state, actor, options) {
       selectedAction: legal[0],
       seatId: actor.seatId,
     })
-    return legal[0]
+    return { ok: true, action: legal[0] }
   }
   const modelId = options?.modelId ?? 'latest'
-  const backend = tf.getBackend() || 'cpu'
   trace('choose.sample.begin', { legalCount: legal.length })
   const sample = await attemptSample(modelId, state, legal, options)
   if (sample.ok && sample.action) {
-    if (sample.action.meta?.fallbackReason === 'INFER_BUDGET_EXCEEDED') {
-      trace('choose.fallback-budget', { actionType: sample.action.type })
-    } else {
-      trace('choose.sample.ok', { actionType: sample.action.type, backend: sample.action.meta?.backend })
-    }
-    return sample.action
+    trace('choose.sample.ok', { actionType: sample.action.type, backend: sample.action.meta?.backend })
+    return { ok: true, action: sample.action }
   }
   if (!sample.ok) {
-    trace('choose.sample.failed', { errorMessage: sample.errorMessage })
-    const fallback = createFallbackAction(legal, state, {
-      backend,
-      fallbackReason: 'MODEL_LOAD_FAILED',
-      modelId,
-    })
+    trace('choose.sample.failed', { kind: sample.kind, errorMessage: sample.errorMessage })
     options?.debugLogger?.({
-      kind: 'fallback',
-      fallbackReason: 'MODEL_LOAD_FAILED',
+      kind: 'failure',
+      failureKind: sample.kind,
       firstError: sample.errorMessage,
       legalActions: legal,
-      selectedAction: fallback,
       seatId: actor.seatId,
     })
-    return fallback
+    return {
+      ok: false,
+      kind: sample.kind,
+      errorMessage: sample.errorMessage,
+      modelId,
+    }
   }
-  const fallback = createFallbackAction(legal, state, {
-    backend,
-    fallbackReason: 'ILLEGAL_OUTPUT',
-    modelId,
-  })
+  trace('choose.illegal-output')
   options?.debugLogger?.({
-    kind: 'fallback',
-    fallbackReason: 'ILLEGAL_OUTPUT',
+    kind: 'failure',
+    failureKind: NN_FAILURE_KIND.ILLEGAL_OUTPUT,
     legalActions: legal,
-    selectedAction: fallback,
     seatId: actor.seatId,
   })
-  trace('choose.fallback', { fallbackReason: 'ILLEGAL_OUTPUT', actionType: fallback.type })
-  return fallback
+  return {
+    ok: false,
+    kind: NN_FAILURE_KIND.ILLEGAL_OUTPUT,
+    modelId,
+  }
 }
 
 /** Preload TF.js models so the first AI turn does not pay fetch/parse cost. */
 export async function warmNnModelCache(modelIds, options = {}) {
   const unique = [...new Set((modelIds ?? []).filter(Boolean))]
   await Promise.all(unique.map((modelId) => loadModel(modelId, options).catch(() => {})))
+}
+
+/** Load one NN model for match-start gating; throws on failure. */
+export async function loadNnModel(modelId, options = {}) {
+  return loadModel(modelId, options)
 }
 
 /** Preload models on the main thread and in the inference worker. */
@@ -146,23 +154,35 @@ async function attemptSample(modelId, state, legal, options) {
     const sample = await sampleAction(modelId, state, legal, options)
     if (sample.inferBudgetExceeded) {
       return {
-        ok: true,
-        action: createFallbackAction(legal, state, {
-          backend: tf.getBackend() || 'cpu',
-          fallbackReason: 'INFER_BUDGET_EXCEEDED',
-          modelId,
-        }),
-        errorMessage: null,
+        ok: false,
+        kind: NN_FAILURE_KIND.INFER,
+        errorMessage: 'INFER_BUDGET_EXCEEDED',
       }
     }
-    return { ok: true, action: sample.action, errorMessage: null }
+    if (sample.action) {
+      return { ok: true, action: sample.action }
+    }
+    return { ok: false, kind: NN_FAILURE_KIND.ILLEGAL_OUTPUT }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
     return {
       ok: false,
-      action: null,
-      errorMessage: error instanceof Error ? error.message : String(error),
+      kind: classifyNnFailureKind(message),
+      errorMessage: message,
     }
   }
+}
+
+function classifyNnFailureKind(message) {
+  if (
+    message === 'MODEL_LOAD_TIMEOUT' ||
+    message === 'missing model' ||
+    message === 'MODEL_LOAD_FAILED' ||
+    message === 'NN_WORKER_WARM_TIMEOUT'
+  ) {
+    return NN_FAILURE_KIND.LOAD
+  }
+  return NN_FAILURE_KIND.INFER
 }
 
 async function sampleAction(modelId, state, legal, options) {
@@ -208,6 +228,29 @@ export function abandonScheduledInferenceQueue() {
   scheduledInferenceQueue = Promise.resolve()
 }
 
+/**
+ * @param {string} modelId
+ * @param {{ forceCpu?: boolean, resetBackend?: boolean }} [options]
+ */
+export function resetRuntimeForModel(modelId, options = {}) {
+  const cached = modelCache.get(modelId)
+  if (cached) {
+    cached.dispose()
+    modelCache.delete(modelId)
+  }
+  abandonScheduledInferenceQueue()
+  if (options.resetBackend) {
+    try {
+      tf.disposeVariables()
+    } catch {
+      // Backend may not be initialized in tests.
+    }
+  }
+  if (options.forceCpu) {
+    void tf.setBackend('cpu')
+  }
+}
+
 async function runScheduledInference(task, options) {
   const trace = createPipelineStepLogger('NN', Boolean(options?.pipelineTrace), {
     modelId: options?.modelId ?? 'latest',
@@ -232,7 +275,7 @@ async function loadModel(modelId, options = {}) {
     trace('model.cache-hit')
     return modelCache.get(modelId)
   }
-  const baseUrl = import.meta.env?.BASE_URL ?? '/'
+  const baseUrl = options.publicBaseUrl ?? import.meta.env?.BASE_URL ?? '/'
   const prefix = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
   const modelUrl = `${prefix}models/dungeon-runner/${modelId}/model.json?ts=${Date.now()}`
   const timeoutMs = options.loadTimeoutMs ?? DEFAULT_NN_MODEL_LOAD_TIMEOUT_MS
@@ -255,8 +298,9 @@ async function inferActionWithBestRuntime(modelId, state, legal, options) {
   })
   const backendHint = tf.getBackend() || 'cpu'
   const randomSeed = createSamplingSeed(state, modelId, backendHint)
-  trace('infer.begin', { backend: backendHint, workerPathDisabled, legalCount: legal.length })
-  if (typeof Worker === 'function' && !workerPathDisabled) {
+  const useWorkerPath = options?.disableWorkerPath !== true && typeof Worker === 'function' && !workerPathDisabled
+  trace('infer.begin', { backend: backendHint, workerPathDisabled: !useWorkerPath, legalCount: legal.length })
+  if (useWorkerPath) {
     try {
       trace('infer.worker.begin')
       const workerStart = performance.now()
@@ -271,6 +315,12 @@ async function inferActionWithBestRuntime(modelId, state, legal, options) {
       trace('infer.worker.error', { message })
       if (message === 'NN_WORKER_TIMEOUT') {
         terminateSharedWorker()
+      }
+      if (classifyNnFailureKind(message) === NN_FAILURE_KIND.LOAD) {
+        throw error
+      }
+      if (options?.allowMainThreadInfer === false) {
+        throw error
       }
     }
   }
@@ -476,14 +526,6 @@ function disposePrediction(prediction) {
   prediction.dispose()
 }
 
-function createFallbackAction(legalActions, state, meta) {
-  const seed = state?.rng?.state ?? 1
-  const next = (Math.imul(seed >>> 0, 1664525) + 1013904223) >>> 0
-  const index = legalActions.length > 0 ? next % legalActions.length : 0
-  const sample = legalActions[index] ?? legalActions[0]
-  return { ...sample, meta }
-}
-
 function applyPolicyMask(values, legalMask) {
   const masked = [...values]
   for (let i = 0; i < masked.length; i += 1) {
@@ -527,10 +569,23 @@ function seededRandomFactory(seed) {
   }
 }
 
+/** @internal Test-only cache inspection. */
+export function isNnModelCachedForTests(modelId) {
+  return modelCache.has(modelId)
+}
+
+/** @internal Test-only cache seeding. */
+export function cacheNnModelForTests(modelId, model) {
+  modelCache.set(modelId, model)
+}
+
 export function resetNnRuntimeForTests() {
   terminateSharedWorker()
   workerRequestId = 1
   scheduledInferenceQueue = Promise.resolve()
+  for (const model of modelCache.values()) {
+    model.dispose()
+  }
   modelCache.clear()
   workerPathDisabled = false
 }

--- a/src/features/dungeon-runner/nn/runtime.test.js
+++ b/src/features/dungeon-runner/nn/runtime.test.js
@@ -1,61 +1,118 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import * as tf from '@tensorflow/tfjs'
 import { createInitialMatchState, getLegalActions } from '../engine/kernel.js'
-import { chooseNnActionWithFallback, resetNnRuntimeForTests } from './runtime.js'
+import {
+  NN_FAILURE_KIND,
+  cacheNnModelForTests,
+  chooseNnAction,
+  isNnModelCachedForTests,
+  resetNnRuntimeForTests,
+  resetRuntimeForModel,
+} from './runtime.js'
+
+function assertSuccess(result) {
+  assert.equal(result?.ok, true)
+  return result.action
+}
+
+function installPassWorker() {
+  const originalWorker = globalThis.Worker
+  class FakeWorker {
+    constructor() {
+      this.onmessage = null
+      this.onerror = null
+    }
+
+    postMessage(payload) {
+      queueMicrotask(() => {
+        this.onmessage?.({
+          data: {
+            requestId: payload.requestId,
+            action: { type: 'PASS' },
+            backend: 'webgl',
+            modelId: payload.modelId,
+          },
+        })
+      })
+    }
+
+    terminate() {}
+  }
+  globalThis.Worker = FakeWorker
+  resetNnRuntimeForTests()
+  return () => {
+    globalThis.Worker = originalWorker
+    resetNnRuntimeForTests()
+  }
+}
 
 test('nn runtime returns legal action and records backend metadata', async () => {
-  const state = createInitialMatchState(
-    { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
-    { seed: 88 },
-  )
-  const seatId = state.turn.activeSeatId
-  const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
-  const legal = getLegalActions(state, { seatId })
-  assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+  const restore = installPassWorker()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 88 },
+    )
+    const seatId = state.turn.activeSeatId
+    const action = assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' }))
+    const legal = getLegalActions(state, { seatId })
+    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+    assert.equal(typeof action.meta?.backend, 'string')
+  } finally {
+    restore()
+  }
 })
 
-test('nn runtime falls back to pass when model unavailable', async () => {
+test('nn runtime returns typed LOAD failure when model unavailable', async () => {
   const state = createInitialMatchState(
     { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'missing-model' }] },
     { seed: 89 },
   )
   const seatId = state.turn.activeSeatId
-  const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'missing-model' })
-  const legal = getLegalActions(state, { seatId })
-  assert.equal(legal.some((candidate) => candidate.type === action.type), true)
-  assert.equal(action.meta.fallbackReason, 'MODEL_LOAD_FAILED')
+  const result = await chooseNnAction(state, { seatId }, { modelId: 'missing-model' })
+  assert.equal(result.ok, false)
+  assert.equal(result.kind, NN_FAILURE_KIND.LOAD)
+  assert.equal(result.modelId, 'missing-model')
+  assert.equal(result.action?.meta?.fallbackReason, undefined)
 })
 
 test('nn runtime scheduling preserves deterministic action order', async () => {
-  const state = createInitialMatchState(
-    { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
-    { seed: 92 },
-  )
-  const seatId = state.turn.activeSeatId
-  const [a, b] = await Promise.all([
-    chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' }),
-    chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' }),
-  ])
-  assert.equal(a.type, b.type)
+  const restore = installPassWorker()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 92 },
+    )
+    const seatId = state.turn.activeSeatId
+    const [a, b] = await Promise.all([
+      assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' })),
+      assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' })),
+    ])
+    assert.equal(a.type, b.type)
+  } finally {
+    restore()
+  }
 })
 
 test('nn runtime supports deterministic sampling override', async () => {
-  const state = createInitialMatchState(
-    { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
-    { seed: 77 },
-  )
-  const seatId = state.turn.activeSeatId
-  const actionA = await chooseNnActionWithFallback(
-    state,
-    { seatId },
-    { modelId: 'latest', samplingMode: 'deterministic' },
-  )
-  const actionB = await chooseNnActionWithFallback(
-    state,
-    { seatId },
-    { modelId: 'latest', samplingMode: 'deterministic' },
-  )
-  assert.equal(actionA.type, actionB.type)
+  const restore = installPassWorker()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 77 },
+    )
+    const seatId = state.turn.activeSeatId
+    const actionA = assertSuccess(
+      await chooseNnAction(state, { seatId }, { modelId: 'latest', samplingMode: 'deterministic' }),
+    )
+    const actionB = assertSuccess(
+      await chooseNnAction(state, { seatId }, { modelId: 'latest', samplingMode: 'deterministic' }),
+    )
+    assert.equal(actionA.type, actionB.type)
+  } finally {
+    restore()
+  }
 })
 
 test('nn runtime serializes cross-model requests deterministically', async () => {
@@ -95,8 +152,8 @@ test('nn runtime serializes cross-model requests deterministically', async () =>
     )
     const seatId = state.turn.activeSeatId
     await Promise.all([
-      chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' }),
-      chooseNnActionWithFallback(state, { seatId }, { modelId: 'v1.0.0' }),
+      chooseNnAction(state, { seatId }, { modelId: 'latest' }),
+      chooseNnAction(state, { seatId }, { modelId: 'v1.0.0' }),
     ])
     assert.equal(maxInFlight, 1)
   } finally {
@@ -144,7 +201,7 @@ test('nn runtime uses worker path when available', async () => {
       { seed: 101 },
     )
     const seatId = state.turn.activeSeatId
-    const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
+    const action = assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' }))
     assert.equal(workerUsed, true)
     const legal = getLegalActions(state, { seatId })
     assert.equal(legal.some((candidate) => candidate.type === action.type), true)
@@ -156,7 +213,7 @@ test('nn runtime uses worker path when available', async () => {
   }
 })
 
-test('nn runtime falls back on illegal worker output without retrying', async () => {
+test('nn runtime returns ILLEGAL_OUTPUT without retrying worker', async () => {
   const originalWorker = globalThis.Worker
   let calls = 0
   class FakeWorker {
@@ -189,18 +246,17 @@ test('nn runtime falls back on illegal worker output without retrying', async ()
       { seed: 104 },
     )
     const seatId = state.turn.activeSeatId
-    const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
+    const result = await chooseNnAction(state, { seatId }, { modelId: 'latest' })
     assert.equal(calls, 1)
-    const legal = getLegalActions(state, { seatId })
-    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
-    assert.equal(action.meta.fallbackReason, 'ILLEGAL_OUTPUT')
+    assert.equal(result.ok, false)
+    assert.equal(result.kind, NN_FAILURE_KIND.ILLEGAL_OUTPUT)
   } finally {
     globalThis.Worker = originalWorker
     resetNnRuntimeForTests()
   }
 })
 
-test('nn runtime falls back on model-load failure without retrying', async () => {
+test('nn runtime returns INFER failure on worker runtime error without retrying', async () => {
   const originalWorker = globalThis.Worker
   let calls = 0
   class FakeWorker {
@@ -226,13 +282,11 @@ test('nn runtime falls back on model-load failure without retrying', async () =>
       { seed: 106 },
     )
     const seatId = state.turn.activeSeatId
-    const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
+    const result = await chooseNnAction(state, { seatId }, { modelId: 'latest', allowMainThreadInfer: false })
     assert.equal(calls, 1)
-    const legal = getLegalActions(state, { seatId })
-    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
-    assert.equal(action.meta.fallbackReason, 'MODEL_LOAD_FAILED')
-    assert.equal(typeof action.meta.backend, 'string')
-    assert.equal(action.meta.modelId, 'latest')
+    assert.equal(result.ok, false)
+    assert.equal(result.kind, NN_FAILURE_KIND.INFER)
+    assert.equal(result.modelId, 'latest')
   } finally {
     globalThis.Worker = originalWorker
     resetNnRuntimeForTests()
@@ -240,14 +294,23 @@ test('nn runtime falls back on model-load failure without retrying', async () =>
 })
 
 test('nn stochastic sampling is reproducible for same state and backend', async () => {
-  const state = createInitialMatchState(
-    { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
-    { seed: 105 },
-  )
-  const seatId = state.turn.activeSeatId
-  const a = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest', samplingMode: 'stochastic' })
-  const b = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest', samplingMode: 'stochastic' })
-  assert.equal(a.type, b.type)
+  const restore = installPassWorker()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 105 },
+    )
+    const seatId = state.turn.activeSeatId
+    const a = assertSuccess(
+      await chooseNnAction(state, { seatId }, { modelId: 'latest', samplingMode: 'stochastic' }),
+    )
+    const b = assertSuccess(
+      await chooseNnAction(state, { seatId }, { modelId: 'latest', samplingMode: 'stochastic' }),
+    )
+    assert.equal(a.type, b.type)
+  } finally {
+    restore()
+  }
 })
 
 test('nn runtime uses policy logits head and keeps dungeon reveal legal', async () => {
@@ -268,7 +331,7 @@ test('nn runtime uses policy logits head and keeps dungeon reveal legal', async 
       hp: 5,
     },
   }
-  const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest' })
+  const action = assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' }))
   assert.equal(action.type, 'REVEAL_OR_CONTINUE')
 })
 
@@ -311,7 +374,7 @@ test('nn runtime emits debug trace payload when requested', async () => {
       { seed: 150 },
     )
     const seatId = state.turn.activeSeatId
-    await chooseNnActionWithFallback(state, { seatId }, {
+    await chooseNnAction(state, { seatId }, {
       modelId: 'latest',
       debugTrace: true,
       debugLogger: (trace) => traces.push(trace),
@@ -326,26 +389,25 @@ test('nn runtime emits debug trace payload when requested', async () => {
   }
 })
 
-test('nn runtime emits debug trace on model-load fallback path', async () => {
+test('nn runtime emits debug trace on model-load failure path', async () => {
   const traces = []
   const state = createInitialMatchState(
     { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'missing-model' }] },
     { seed: 151 },
   )
   const seatId = state.turn.activeSeatId
-  const action = await chooseNnActionWithFallback(state, { seatId }, {
+  const result = await chooseNnAction(state, { seatId }, {
     modelId: 'missing-model',
     debugTrace: true,
     debugLogger: (trace) => traces.push(trace),
   })
-  const legal = getLegalActions(state, { seatId })
-  assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+  assert.equal(result.ok, false)
   assert.equal(traces.length >= 1, true)
-  assert.equal(traces.at(-1).kind, 'fallback')
-  assert.equal(traces.at(-1).fallbackReason, 'MODEL_LOAD_FAILED')
+  assert.equal(traces.at(-1).kind, 'failure')
+  assert.equal(traces.at(-1).failureKind, NN_FAILURE_KIND.LOAD)
 })
 
-test('hanging worker times out and falls back without blocking the inference queue', async () => {
+test('hanging worker times out and returns INFER failure without blocking the inference queue', async () => {
   const originalWorker = globalThis.Worker
   class HangingWorker {
     constructor() {
@@ -368,14 +430,14 @@ test('hanging worker times out and falls back without blocking the inference que
     )
     const seatId = state.turn.activeSeatId
     const started = Date.now()
-    const action = await chooseNnActionWithFallback(state, { seatId }, {
+    const result = await chooseNnAction(state, { seatId }, {
       modelId: 'latest',
       workerTimeoutMs: 40,
       loadTimeoutMs: 40,
     })
     const elapsed = Date.now() - started
-    const legal = getLegalActions(state, { seatId })
-    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
+    assert.equal(result.ok, false)
+    assert.equal(result.kind, NN_FAILURE_KIND.INFER)
     assert.ok(elapsed < 500, `expected bounded inference time, got ${elapsed}ms`)
   } finally {
     globalThis.Worker = originalWorker
@@ -383,7 +445,7 @@ test('hanging worker times out and falls back without blocking the inference que
   }
 })
 
-test('worker-side model load errors do not masquerade as pass actions', async () => {
+test('worker-side model load errors return LOAD failure not pass actions', async () => {
   const originalWorker = globalThis.Worker
   class FakeWorker {
     constructor() {
@@ -412,17 +474,16 @@ test('worker-side model load errors do not masquerade as pass actions', async ()
       { seed: 152 },
     )
     const seatId = state.turn.activeSeatId
-    const action = await chooseNnActionWithFallback(state, { seatId }, { modelId: 'latest', debugTrace: true })
-    const legal = getLegalActions(state, { seatId })
-    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
-    assert.equal(action.meta?.fallbackReason, 'MODEL_LOAD_FAILED')
+    const result = await chooseNnAction(state, { seatId }, { modelId: 'latest', debugTrace: true })
+    assert.equal(result.ok, false)
+    assert.equal(result.kind, NN_FAILURE_KIND.LOAD)
   } finally {
     globalThis.Worker = originalWorker
     resetNnRuntimeForTests()
   }
 })
 
-test('inferBudgetMs falls back without waiting for slow inference', async () => {
+test('inferBudgetMs returns INFER failure without waiting for slow inference', async () => {
   const originalWorker = globalThis.Worker
   class SlowWorker {
     constructor() {
@@ -454,17 +515,52 @@ test('inferBudgetMs falls back without waiting for slow inference', async () => 
     )
     const seatId = state.turn.activeSeatId
     const start = performance.now()
-    const action = await chooseNnActionWithFallback(state, { seatId }, {
+    const result = await chooseNnAction(state, { seatId }, {
       modelId: 'latest',
       inferBudgetMs: 40,
     })
     const elapsed = performance.now() - start
     assert.ok(elapsed < 250, `expected budget cap, got ${elapsed}ms`)
-    const legal = getLegalActions(state, { seatId })
-    assert.equal(legal.some((candidate) => candidate.type === action.type), true)
-    assert.equal(action.meta.fallbackReason, 'INFER_BUDGET_EXCEEDED')
+    assert.equal(result.ok, false)
+    assert.equal(result.kind, NN_FAILURE_KIND.INFER)
+    assert.equal(result.errorMessage, 'INFER_BUDGET_EXCEEDED')
   } finally {
     globalThis.Worker = originalWorker
     resetNnRuntimeForTests()
   }
+})
+
+test('resetRuntimeForModel evicts cached model for subsequent loads', () => {
+  resetNnRuntimeForTests()
+  let disposed = false
+  cacheNnModelForTests('latest', { dispose() { disposed = true } })
+  assert.equal(isNnModelCachedForTests('latest'), true)
+  resetRuntimeForModel('latest')
+  assert.equal(disposed, true)
+  assert.equal(isNnModelCachedForTests('latest'), false)
+})
+
+test('resetRuntimeForModel abandons scheduled inference queue', async () => {
+  const restore = installPassWorker()
+  try {
+    const state = createInitialMatchState(
+      { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+      { seed: 202 },
+    )
+    const seatId = state.turn.activeSeatId
+    const pending = chooseNnAction(state, { seatId }, { modelId: 'latest' })
+    resetRuntimeForModel('latest')
+    const result = assertSuccess(await chooseNnAction(state, { seatId }, { modelId: 'latest' }))
+    await pending.catch(() => {})
+    assert.equal(result.type, 'PASS')
+  } finally {
+    restore()
+  }
+})
+
+test('resetRuntimeForModel can force cpu backend', async () => {
+  resetNnRuntimeForTests()
+  await tf.setBackend('cpu')
+  resetRuntimeForModel('latest', { forceCpu: true })
+  assert.equal(tf.getBackend(), 'cpu')
 })

--- a/src/features/dungeon-runner/persistence/currentMatch.js
+++ b/src/features/dungeon-runner/persistence/currentMatch.js
@@ -1,3 +1,5 @@
+import { isValidNeuralRecoveryByModelId } from '../nn/recovery.js'
+
 export const CURRENT_MATCH_SCHEMA_VERSION = 1
 
 const STORAGE_KEY = 'dungeon-runner/current-match'
@@ -47,6 +49,13 @@ function isValidMatchShape(match) {
     match.presentationSpeedProfile != null &&
     match.presentationSpeedProfile !== 'cinematic' &&
     match.presentationSpeedProfile !== 'brisk'
+  ) {
+    return false
+  }
+  if (
+    'neuralRecoveryByModelId' in match &&
+    match.neuralRecoveryByModelId != null &&
+    !isValidNeuralRecoveryByModelId(match.neuralRecoveryByModelId)
   ) {
     return false
   }

--- a/src/features/dungeon-runner/persistence/currentMatch.test.js
+++ b/src/features/dungeon-runner/persistence/currentMatch.test.js
@@ -8,17 +8,32 @@ import {
   applyAction,
   createInitialMatchState,
 } from '../engine/kernel.js'
+import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { NN_FAILURE_KIND } from '../nn/runtime.js'
 import {
   buildDeferredDungeonOutcomeDisplayState,
+  createLivePlayActionChooser,
   DEFAULT_MAX_HEADLESS_ACTIONS,
   resolveHeadlessCompletionStartState,
   runMaybeHeadlessMatchCompletionFromState,
 } from '../ui/headlessMatchCompletionRunner.js'
 import {
+  shouldDeferHeadlessForPersistedNeuralTerminal,
+  shouldRunHeadlessMatchCompletion,
+} from '../ui/headlessNeuralRecoveryPersistence.js'
+import {
   getMatchOverEndDialogVariant,
   MATCH_OVER_END_VARIANTS,
   needsHeadlessCompletion,
 } from '../ui/humanEliminationCompletionPolicy.js'
+import { applySetupSnapshot } from '../setup/state.js'
+import { resolveNeuralLoadGateSetupTerminal } from '../nn/matchNeuralLoadGate.js'
+import { NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
+import {
+  attachNeuralRecoverySnapshotToMatch,
+  surfacePersistedNeuralRecoveryTerminal,
+} from '../ui/headlessNeuralRecoveryPersistence.js'
+import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
 import {
   CURRENT_MATCH_SCHEMA_VERSION,
   clearCurrentMatch,
@@ -235,4 +250,174 @@ test('invalid presentationSpeedProfile rejects persisted match', () => {
   const loaded = loadCurrentMatch(storage)
   assert.equal(loaded.ok, false)
   assert.equal(loaded.errorCode, 'INVALID_SHAPE')
+})
+
+const NN_TWO_PLAYER_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
+
+function humanEliminatedPickState(state, humanSeatId) {
+  const opponent = state.seats.find(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  )
+  assert.ok(opponent)
+  return {
+    ...state,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    scoreboard: {
+      ...state.scoreboard,
+      [humanSeatId]: {
+        ...state.scoreboard[humanSeatId],
+        lives: 0,
+        eliminated: true,
+        successes: 0,
+      },
+    },
+    turn: { ...state.turn, activeSeatId: opponent.id, turnNumber: state.turn.turnNumber + 1 },
+    pickAdventurer: {
+      ...state.pickAdventurer,
+      activeSeatId: opponent.id,
+    },
+  }
+}
+
+test('headless infer terminal persists refresh snapshot and defers completion on reload', async () => {
+  const storage = createMemoryStorage()
+  const initial = createInitialMatchState(NN_TWO_PLAYER_SETUP, { seed: 9200 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+
+  const baseMatch = {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: 'm-headless-nn-refresh',
+    setup: NN_TWO_PLAYER_SETUP,
+    state: start,
+    history: start.history,
+  }
+  persistCurrentMatch(storage, baseMatch)
+
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  const chooseAction = createLivePlayActionChooser({
+    nnRecovery: recovery,
+    nnRuntimeOptions: () => ({}),
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction: async () => ({ ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }),
+      resetRuntimeForModel: () => {},
+    }),
+  })
+
+  await assert.rejects(
+    () => runMaybeHeadlessMatchCompletionFromState(start, {
+      humanPlayerSeatId: human.id,
+      chooseAction,
+      maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+    }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
+
+  const withTerminal = attachNeuralRecoverySnapshotToMatch(baseMatch, recovery)
+  persistCurrentMatch(storage, withTerminal)
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(
+    loaded.match.neuralRecoveryByModelId.latest.terminal,
+    NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+  assert.equal(shouldDeferHeadlessForPersistedNeuralTerminal(loaded.match.neuralRecoveryByModelId), true)
+
+  let refreshOpen = false
+  const resumedRecovery = createNeuralRuntimeRecoveryCoordinator()
+  assert.equal(
+    surfacePersistedNeuralRecoveryTerminal({
+      recovery: resumedRecovery,
+      neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
+      hasMatchSetup: true,
+      openRefreshTerminal: () => {
+        refreshOpen = true
+      },
+    }),
+    true,
+  )
+  assert.equal(refreshOpen, true)
+  assert.equal(shouldRunHeadlessMatchCompletion(loaded.match, human.id), false)
+})
+
+test('persisted neural recovery terminal round-trips and surfaces refresh on resume', () => {
+  const storage = createMemoryStorage()
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  recovery.beginRecovery('latest')
+  recovery.recordInferFailure('latest')
+  const base = {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: 'm-nn-refresh',
+    setup: { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+    state: { turn: { activeSeatId: 'seat-2' } },
+    history: [],
+  }
+  persistCurrentMatch(storage, attachNeuralRecoverySnapshotToMatch(base, recovery))
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(
+    loaded.match.neuralRecoveryByModelId.latest.terminal,
+    NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+
+  const resumedRecovery = createNeuralRuntimeRecoveryCoordinator()
+  let refreshOpen = false
+  assert.equal(
+    surfacePersistedNeuralRecoveryTerminal({
+      recovery: resumedRecovery,
+      neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
+      hasMatchSetup: true,
+      openRefreshTerminal: () => {
+        refreshOpen = true
+      },
+    }),
+    true,
+  )
+  assert.equal(refreshOpen, true)
+})
+
+test('invalid neuralRecoveryByModelId rejects persisted match', () => {
+  const storage = createMemoryStorage()
+  persistCurrentMatch(storage, {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: 'm-bad-recovery',
+    setup: { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+    state: {},
+    history: [],
+    neuralRecoveryByModelId: { latest: { terminal: 'UNKNOWN' } },
+  })
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, false)
+  assert.equal(loaded.errorCode, 'INVALID_SHAPE')
+})
+
+test('neural load gate setup terminal clears persisted match while preserving setup snapshot', () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = {
+    totalSeats: 3,
+    opponents: [{ type: 'nn', modelId: 'v1.0.0' }, { type: 'randombot' }],
+  }
+  persistCurrentMatch(storage, {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: 'm-gate-fail',
+    setup: setupSnapshot,
+    state: { turn: { activeSeatId: 'seat-2' } },
+    history: [],
+  })
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  resolveNeuralLoadGateSetupTerminal({
+    storage,
+    setupSnapshot,
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget,
+  })
+  assert.equal(loadCurrentMatch(storage).ok, false)
+  assert.deepEqual(setupTarget, setupSnapshot)
 })

--- a/src/features/dungeon-runner/release.integration.test.js
+++ b/src/features/dungeon-runner/release.integration.test.js
@@ -341,6 +341,21 @@ test('dungeon runner page wires headless match completion after human eliminatio
   assert.equal(page.includes('abandonScheduledInferenceQueue'), true)
   assert.equal(page.includes('data-testid="finishing-match-overlay"'), true)
   assert.equal(page.includes('headlessCompletionInFlight'), true)
+  assert.equal(page.includes('attachNeuralRecoverySnapshotToMatch'), true)
+  assert.equal(page.includes('surfacePersistedNeuralRecoveryTerminal'), true)
+  assert.equal(page.includes('shouldRunHeadlessMatchCompletion'), true)
+})
+
+test('headless nn terminal failure persists refresh snapshot for resume', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const fnIdx = page.indexOf('async function maybeRunHeadlessMatchCompletion()')
+  assert.ok(fnIdx >= 0)
+  const fnBlock = page.slice(fnIdx, fnIdx + 2000)
+  assert.equal(fnBlock.includes('shouldRunHeadlessMatchCompletion'), true)
+  assert.equal(fnBlock.includes("ux.action === 'refresh-dialog'"), true)
+  assert.equal(fnBlock.includes('attachNeuralRecoverySnapshotToMatch'), true)
+  assert.equal(fnBlock.includes('persistCurrentMatch'), true)
+  assert.equal(fnBlock.includes('chooseRandombotAction'), false)
 })
 
 test('continueFromDungeonOutcome triggers headless completion when policy requires it', () => {
@@ -353,11 +368,89 @@ test('continueFromDungeonOutcome triggers headless completion when policy requir
 
 test('resume on mount may run headless completion without spectator scheduling', () => {
   const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
-  const mountedIdx = page.indexOf('onMounted(() => {')
-  assert.ok(mountedIdx >= 0)
-  const mountedBlock = page.slice(mountedIdx, mountedIdx + 1200)
-  assert.equal(mountedBlock.includes('void maybeRunHeadlessMatchCompletion()'), true)
-  assert.equal(mountedBlock.includes('scheduleAiTurnIfReady'), false)
+  const bootstrapIdx = page.indexOf('async function bootstrapDungeonRunnerPage()')
+  assert.ok(bootstrapIdx >= 0)
+  const bootstrapBlock = page.slice(bootstrapIdx, bootstrapIdx + 1600)
+  assert.equal(bootstrapBlock.includes('runMatchNeuralLoadGate'), true)
+  assert.equal(bootstrapBlock.includes('void maybeRunHeadlessMatchCompletion()'), true)
+  assert.equal(bootstrapBlock.includes('scheduleAiTurnIfReady'), false)
+})
+
+test('match neural load gate blocks match entry and clears persisted match on hard load failure', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes('runMatchNeuralLoadGate'), true)
+  assert.equal(page.includes('applyNeuralLoadGateSetupTerminal'), true)
+  assert.equal(page.includes('handleNeuralRecoveryTerminalError'), true)
+  assert.equal(page.includes('data-testid="neural-load-gate-terminal"'), true)
+  assert.equal(page.includes('handleNnModelFailure'), false)
+  assert.equal(page.includes('getDowngradeModelId'), false)
+  assert.equal(page.includes("logAiTurnScheduleSkip('neural-load-gate')"), true)
+})
+
+test('live neural recovery surfaces seat spinner and refresh terminal without clearing match', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes('buildSeatRecoveryIndicators'), true)
+  assert.equal(page.includes('recoveryTestId'), true)
+  assert.equal(page.includes('data-testid="neural-refresh-terminal"'), true)
+  assert.equal(page.includes('neuralRefreshTerminalOpen'), true)
+  assert.equal(page.includes('reloadPageForNeuralRefreshTerminal'), true)
+  assert.equal(page.includes('resolveNeuralRecoveryTerminalUx'), true)
+  assert.equal(page.includes("logAiTurnScheduleSkip('model-recovering'"), true)
+  assert.equal(page.includes('chooseNnActionWithFallback'), false)
+  const refreshHandlerIdx = page.indexOf('function handleNeuralRecoveryTerminalError(error)')
+  assert.ok(refreshHandlerIdx >= 0)
+  const refreshHandlerBlock = page.slice(refreshHandlerIdx, refreshHandlerIdx + 520)
+  assert.equal(refreshHandlerBlock.includes("'refresh-dialog'"), true)
+  assert.equal(refreshHandlerBlock.includes('neuralRefreshTerminalOpen.value = true'), true)
+  assert.equal(refreshHandlerBlock.includes('clearCurrentMatch'), false)
+})
+
+test('human gameplay is not blocked by nn recovery coordinator state', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const blockIdx = page.indexOf('const humanGameplayBlocked = computed(')
+  assert.ok(blockIdx >= 0)
+  const block = page.slice(blockIdx, blockIdx + 320)
+  assert.equal(block.includes('headlessCompletionInFlight.value'), true)
+  assert.equal(block.includes('neuralRefreshTerminalOpen.value'), true)
+  assert.equal(block.includes('nnRecovery'), false)
+  assert.equal(block.includes('shouldBlockAiTurnScheduleForRecovery'), false)
+})
+
+test('mid-match neural load exhaustion restores setup through recovery handler', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const handlerIdx = page.indexOf('function handleNeuralRecoveryTerminalError(error)')
+  assert.ok(handlerIdx >= 0)
+  const handlerBlock = page.slice(handlerIdx, handlerIdx + 520)
+  assert.equal(handlerBlock.includes("'setup-restore'"), true)
+  assert.equal(handlerBlock.includes('applyNeuralLoadGateSetupTerminal'), true)
+})
+
+test('live play prefetch primes nn actions through recovery-aware chooser', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  const fnIdx = page.indexOf('function primeAiTurnPrefetch()')
+  assert.ok(fnIdx >= 0)
+  const fnBlock = page.slice(fnIdx, fnIdx + 2000)
+  assert.equal(fnBlock.includes('chooseNnActionWithRecovery'), true)
+  assert.equal(fnBlock.includes('chooseNnActionWithFallback'), false)
+  assert.equal(fnBlock.includes("logAiTurnPrimeSkip('model-recovering'"), true)
+})
+
+test('refresh terminal blocks live ai scheduling while open', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes("logAiTurnScheduleSkip('neural-refresh-terminal'"), true)
+  const scheduleIdx = page.indexOf('function scheduleAiTurnIfReady()')
+  assert.ok(scheduleIdx >= 0)
+  const scheduleBlock = page.slice(scheduleIdx, scheduleIdx + 400)
+  assert.equal(scheduleBlock.includes('neuralRefreshTerminalOpen.value'), true)
+})
+
+test('active nn recovery watch resumes ai scheduling after recovery settles', () => {
+  const page = readFileSync(new URL('../../pages/projects/DungeonRunnerPage.vue', import.meta.url), 'utf8')
+  assert.equal(page.includes('const activeNnRecoveryBlocking = computed('), true)
+  const watchIdx = page.indexOf('watch(activeNnRecoveryBlocking')
+  assert.ok(watchIdx >= 0)
+  const watchBlock = page.slice(watchIdx, watchIdx + 200)
+  assert.equal(watchBlock.includes('scheduleAiTurnIfReady()'), true)
 })
 
 test('live AI scheduling is gated while headless completion runs', () => {

--- a/src/features/dungeon-runner/setup/state.js
+++ b/src/features/dungeon-runner/setup/state.js
@@ -23,3 +23,13 @@ export function canStartMatchFromSetup(setup) {
   if (!Array.isArray(setup?.opponents) || setup.opponents.length === 0) return false
   return validateSetupConfig(normalizeSetupState(setup)).ok
 }
+
+export function applySetupSnapshot(target, snapshot) {
+  const normalized = normalizeSetupState(snapshot)
+  target.totalSeats = normalized.totalSeats
+  target.opponents.splice(
+    0,
+    target.opponents.length,
+    ...normalized.opponents.map((opponent) => ({ ...opponent })),
+  )
+}

--- a/src/features/dungeon-runner/setup/state.test.js
+++ b/src/features/dungeon-runner/setup/state.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { canStartMatchFromSetup, normalizeSetupState } from './state.js'
+import { applySetupSnapshot, canStartMatchFromSetup, normalizeSetupState } from './state.js'
 
 test('normalizeSetupState keeps opponents aligned with total seats', () => {
   const setup = normalizeSetupState({
@@ -44,4 +44,18 @@ test('canStartMatchFromSetup allows valid NN and randombot mix', () => {
     }),
     true,
   )
+})
+
+test('applySetupSnapshot restores opponents and table size from persisted setup', () => {
+  const target = {
+    totalSeats: 2,
+    opponents: [{ type: 'randombot' }],
+  }
+  applySetupSnapshot(target, {
+    totalSeats: 4,
+    opponents: [{ type: 'nn', modelId: 'v1.0.0' }, { type: 'nn', modelId: 'v0.9.0' }, { type: 'randombot' }],
+  })
+  assert.equal(target.totalSeats, 4)
+  assert.equal(target.opponents.length, 3)
+  assert.equal(target.opponents[0].modelId, 'v1.0.0')
 })

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js
@@ -2,10 +2,23 @@
 let prefetchEntry = null
 /** @type {string | null} */
 let lastPrefetchSkipLogKey = null
+/** @type {{ isRecovering: (modelId: string) => boolean } | null} */
+let prefetchRecoveryGate = null
 
 export function resetAiTurnPrefetch() {
   prefetchEntry = null
   lastPrefetchSkipLogKey = null
+}
+
+/**
+ * @param {{ isRecovering: (modelId: string) => boolean } | null} gate
+ */
+export function setAiTurnPrefetchRecoveryGate(gate) {
+  prefetchRecoveryGate = gate
+}
+
+export function cancelAiTurnPrefetch() {
+  prefetchEntry = null
 }
 
 /**
@@ -15,8 +28,12 @@ export function resetAiTurnPrefetch() {
  *   trace?: (step: string, detail?: Record<string, unknown>) => void
  * }} params
  */
-export function startAiTurnPrefetch({ runToken, compute, trace }) {
+export function startAiTurnPrefetch({ runToken, compute, trace, modelId }) {
   if (!runToken) return
+  if (modelId && prefetchRecoveryGate?.isRecovering(modelId)) {
+    trace?.('prefetch.skip', { reason: 'model-recovering', runToken, modelId })
+    return
+  }
   if (prefetchEntry?.runToken === runToken) {
     const skipKey = `already-in-flight:${runToken}`
     if (lastPrefetchSkipLogKey !== skipKey) {
@@ -59,7 +76,11 @@ export function startAiTurnPrefetch({ runToken, compute, trace }) {
  * @param {(step: string, detail?: Record<string, unknown>) => void} [trace]
  * @returns {Promise<object|null>}
  */
-export async function consumeAiTurnPrefetch(runToken, trace) {
+export async function consumeAiTurnPrefetch(runToken, trace, modelId) {
+  if (modelId && prefetchRecoveryGate?.isRecovering(modelId)) {
+    trace?.('prefetch.consume.blocked', { runToken, modelId, reason: 'model-recovering' })
+    return null
+  }
   if (!prefetchEntry || prefetchEntry.runToken !== runToken) {
     trace?.('prefetch.consume.miss', {
       runToken,

--- a/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.test.js
+++ b/src/features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.test.js
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
 import {
+  cancelAiTurnPrefetch,
   consumeAiTurnPrefetch,
   resetAiTurnPrefetch,
+  setAiTurnPrefetchRecoveryGate,
   startAiTurnPrefetch,
 } from './dungeonRunnerAiTurnPrefetch.js'
 
@@ -92,4 +95,50 @@ test('consume awaits in-flight prefetch to completion', async () => {
   assert.deepEqual(action, { type: 'DRAW' })
   assert.ok(steps.includes('prefetch.consume.hit'))
   assert.equal(steps.includes('prefetch.consume.timeout'), false)
+})
+
+test('prefetch start is skipped while modelId is recovering', async () => {
+  resetAiTurnPrefetch()
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  setAiTurnPrefetchRecoveryGate(recovery)
+  const steps = []
+  startAiTurnPrefetch({
+    runToken: 'a',
+    modelId: 'latest',
+    trace: (step) => steps.push(step),
+    compute: async () => ({ type: 'PASS' }),
+  })
+  assert.ok(steps.includes('prefetch.skip'))
+  assert.equal(await consumeAiTurnPrefetch('a', () => {}, 'latest'), null)
+  setAiTurnPrefetchRecoveryGate(null)
+})
+
+test('prefetch consume is blocked while modelId is recovering', async () => {
+  resetAiTurnPrefetch()
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  setAiTurnPrefetchRecoveryGate(recovery)
+  startAiTurnPrefetch({
+    runToken: 'a',
+    compute: async () => ({ type: 'DRAW' }),
+  })
+  recovery.beginRecovery('latest')
+  const steps = []
+  assert.equal(await consumeAiTurnPrefetch('a', (step) => steps.push(step), 'latest'), null)
+  assert.ok(steps.includes('prefetch.consume.blocked'))
+  setAiTurnPrefetchRecoveryGate(null)
+})
+
+test('cancelAiTurnPrefetch clears in-flight entry', async () => {
+  resetAiTurnPrefetch()
+  let resolveCompute
+  startAiTurnPrefetch({
+    runToken: 'a',
+    compute: () => new Promise((resolve) => {
+      resolveCompute = resolve
+    }),
+  })
+  cancelAiTurnPrefetch()
+  assert.equal(await consumeAiTurnPrefetch('a', () => {}), null)
+  resolveCompute({ type: 'DRAW' })
 })

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
@@ -1,5 +1,6 @@
 import { chooseRandombotAction } from '../bots/randombot.js'
-import { chooseNnActionWithFallback } from '../nn/runtime.js'
+import { createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { chooseNnAction } from '../nn/runtime.js'
 import { isNnAdventurerPickEnabled } from '../setup/nnAdventurerPick.js'
 import { MATCH_PHASES, applyAction } from '../engine/kernel.js'
 import { isHumanEliminated, needsHeadlessCompletion } from './humanEliminationCompletionPolicy.js'
@@ -239,44 +240,45 @@ export async function runHeadlessMatchCompletion(state, options) {
 }
 
 /**
- * Mirrors live AI turn chooser semantics (Randombot, NN with cooldown/fallback, adventurer pick flag).
+ * Mirrors live AI turn chooser semantics (Randombot, NN with recovery coordinator, adventurer pick flag).
  * @param {{
- *   nnFailureRecovery: { isCoolingDown: (modelId: string) => boolean }
+ *   nnRecovery: {
+ *     isRecovering: (modelId: string) => boolean
+ *     getTerminalOutcome: (modelId: string) => string
+ *   }
  *   ensureNnModelsReady?: () => Promise<void>
  *   nnRuntimeOptions: (modelId: string) => object
  *   isNnAdventurerPickEnabled?: () => boolean
- *   chooseNnAction?: typeof chooseNnActionWithFallback
- *   tryConsumePrefetch?: (ctx: { state: object, seatId: string, runToken?: string }) => Promise<{ type: string } | null> | { type: string } | null
+ *   chooseNnActionWithRecovery?: ReturnType<typeof createChooseNnActionWithRecovery>
+ *   tryConsumePrefetch?: (ctx: { state: object, seatId: string, runToken?: string, modelId: string }) => Promise<{ type: string } | null> | { type: string } | null
+ *   onRecoveryBegin?: (modelId: string) => void
  * }} deps
  */
 export function createLivePlayActionChooser(deps) {
   const adventurerPickEnabled = deps.isNnAdventurerPickEnabled ?? isNnAdventurerPickEnabled
-  const chooseNn = deps.chooseNnAction ?? chooseNnActionWithFallback
+  const chooseNnWithRecovery = deps.chooseNnActionWithRecovery ?? createChooseNnActionWithRecovery({
+    recovery: deps.nnRecovery,
+    chooseNnAction,
+    onRecoveryBegin: deps.onRecoveryBegin,
+  })
   return async function chooseAction({ state, seatId, runToken }) {
     const seat = state.seats.find((candidate) => candidate.id === seatId)
     const roleType = seat?.role?.type
-    let action = null
     if (roleType === 'nn') {
       const modelId = seat.role.modelId ?? 'latest'
       if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !adventurerPickEnabled()) {
-        action = chooseRandombotAction(state, { seatId })
-      } else if (deps.nnFailureRecovery.isCoolingDown(modelId)) {
-        action = chooseRandombotAction(state, { seatId })
-      } else {
-        await deps.ensureNnModelsReady?.()
-        if (deps.tryConsumePrefetch) {
-          action = await deps.tryConsumePrefetch({ state, seatId, runToken })
-        }
-        if (!action) {
-          action = await chooseNn(state, { seatId }, deps.nnRuntimeOptions(modelId))
-        }
+        return chooseRandombotAction(state, { seatId })
       }
-    } else {
-      action = chooseRandombotAction(state, { seatId })
+      await deps.ensureNnModelsReady?.()
+      let action = null
+      if (!deps.nnRecovery.isRecovering(modelId) && deps.tryConsumePrefetch) {
+        action = await deps.tryConsumePrefetch({ state, seatId, runToken, modelId })
+      }
+      if (!action) {
+        action = await chooseNnWithRecovery(state, { seatId }, deps.nnRuntimeOptions(modelId))
+      }
+      return action
     }
-    if (!action) {
-      action = chooseRandombotAction(state, { seatId })
-    }
-    return action
+    return chooseRandombotAction(state, { seatId })
   }
 }

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
@@ -28,6 +28,12 @@ import {
   shouldBlockLiveAiPipelineWhileHeadless,
   shouldShowFinishingMatchOverlay,
 } from './headlessMatchCompletionRunner.js'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from '../nn/recovery.js'
+import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { NN_FAILURE_KIND } from '../nn/runtime.js'
 
 const FOUR_PLAYER_SETUP = {
   totalSeats: 4,
@@ -182,33 +188,100 @@ test('runHeadlessMatchCompletion reaches match over from reloaded deferred dunge
   assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
 })
 
+const NN_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
+
+function liveChooserDeps(overrides = {}) {
+  return {
+    nnRecovery: overrides.nnRecovery ?? createNeuralRuntimeRecoveryCoordinator(),
+    nnRuntimeOptions: overrides.nnRuntimeOptions ?? (() => ({})),
+    isNnAdventurerPickEnabled: overrides.isNnAdventurerPickEnabled ?? (() => true),
+    chooseNnActionWithRecovery: overrides.chooseNnActionWithRecovery,
+    tryConsumePrefetch: overrides.tryConsumePrefetch,
+    onRecoveryBegin: overrides.onRecoveryBegin,
+  }
+}
+
 test('createLivePlayActionChooser matches randombot for randombot seats', async () => {
   const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 11 })
   const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
   assert.ok(bot)
-  const chooser = createLivePlayActionChooser({
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
-  })
+  const chooser = createLivePlayActionChooser(liveChooserDeps())
   const action = await chooser({ state: initial, seatId: bot.id })
   assert.deepEqual(action, chooseRandombotAction(initial, { seatId: bot.id }))
 })
 
-test('createLivePlayActionChooser uses randombot when nn model is cooling down', async () => {
-  const setup = {
-    totalSeats: 2,
-    opponents: [{ type: 'nn', modelId: 'latest' }],
-  }
-  const initial = createInitialMatchState(setup, { seed: 12 })
+test('createLivePlayActionChooser propagates terminal error instead of randombot on nn failure', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 12 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
-  const chooser = createLivePlayActionChooser({
-    nnFailureRecovery: { isCoolingDown: () => true },
-    nnRuntimeOptions: () => ({}),
-    isNnAdventurerPickEnabled: () => true,
-  })
-  const action = await chooser({ state: initial, seatId: nnSeat.id })
-  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: nnSeat.id }))
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
+      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest')
+    },
+  }))
+  await assert.rejects(
+    () => chooser({ state: initial, seatId: nnSeat.id }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
+})
+
+test('createLivePlayActionChooser blocks concurrent nn calls while recovery is in flight', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 120 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  let attempts = 0
+  let releaseRetry
+  const retryGate = new Promise((resolve) => { releaseRetry = resolve })
+  const chooseNnAction = async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }
+    }
+    await retryGate
+    return { ok: true, action: { type: 'DRAW', meta: { modelId: 'latest' } } }
+  }
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction,
+      resetRuntimeForModel: () => {},
+    }),
+  }))
+  const first = chooser({ state: initial, seatId: nnSeat.id })
+  await Promise.resolve()
+  const second = chooser({ state: initial, seatId: nnSeat.id })
+  releaseRetry()
+  const [a, b] = await Promise.all([first, second])
+  assert.equal(a.type, 'DRAW')
+  assert.equal(b.type, 'DRAW')
+  assert.equal(attempts, 2)
+})
+
+test('createLivePlayActionChooser never returns randombot on nn infer failure', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 121 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const randombotAction = chooseRandombotAction(initial, { seatId: nnSeat.id })
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
+      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest', {
+        failureKind: NN_FAILURE_KIND.INFER,
+      })
+    },
+  }))
+  await assert.rejects(
+    () => chooser({ state: initial, seatId: nnSeat.id }),
+    (error) => {
+      assert.ok(error instanceof NeuralRecoveryTerminalError)
+      assert.notDeepEqual(error, randombotAction)
+      return true
+    },
+  )
 })
 
 test('buildDeferredDungeonOutcomeDisplayState defers pick-adventurer behind dungeon phase', () => {
@@ -230,11 +303,7 @@ test('buildDeferredDungeonOutcomeDisplayState defers pick-adventurer behind dung
 })
 
 test('createLivePlayActionChooser uses randombot on pick-adventurer when nn pick flag is off', async () => {
-  const setup = {
-    totalSeats: 2,
-    opponents: [{ type: 'nn', modelId: 'latest' }],
-  }
-  const initial = createInitialMatchState(setup, { seed: 13 })
+  const initial = createInitialMatchState(NN_SETUP, { seed: 13 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
   const pickState = {
@@ -243,21 +312,21 @@ test('createLivePlayActionChooser uses randombot on pick-adventurer when nn pick
     turn: { ...initial.turn, activeSeatId: nnSeat.id },
     pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
   }
-  const chooser = createLivePlayActionChooser({
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
+  let nnCalled = false
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
     isNnAdventurerPickEnabled: () => false,
-  })
+    chooseNnActionWithRecovery: async () => {
+      nnCalled = true
+      return { type: 'PASS' }
+    },
+  }))
   const action = await chooser({ state: pickState, seatId: nnSeat.id })
   assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
+  assert.equal(nnCalled, false)
 })
 
 test('createLivePlayActionChooser uses nn path when model ready and pick enabled', async () => {
-  const setup = {
-    totalSeats: 2,
-    opponents: [{ type: 'nn', modelId: 'latest' }],
-  }
-  const initial = createInitialMatchState(setup, { seed: 14 })
+  const initial = createInitialMatchState(NN_SETUP, { seed: 14 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
   const pickState = {
@@ -268,20 +337,19 @@ test('createLivePlayActionChooser uses nn path when model ready and pick enabled
   }
   let nnCallCount = 0
   let lastNnOptions = null
-  const chooser = createLivePlayActionChooser({
-    nnFailureRecovery: { isCoolingDown: () => false },
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
     nnRuntimeOptions: () => ({ modelId: 'latest', samplingMode: 'greedy' }),
     isNnAdventurerPickEnabled: () => true,
-    chooseNnAction: async (state, actor, options) => {
+    chooseNnActionWithRecovery: async (state, actor, options) => {
       nnCallCount += 1
       lastNnOptions = options
-      return chooseRandombotAction(state, { seatId: actor.seatId })
+      return { type: 'PASS' }
     },
-  })
+  }))
   const action = await chooser({ state: pickState, seatId: nnSeat.id })
   assert.equal(nnCallCount, 1)
   assert.deepEqual(lastNnOptions, { modelId: 'latest', samplingMode: 'greedy' })
-  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
+  assert.equal(action.type, 'PASS')
 })
 
 test('headless completion appends actions to state history through match over', async () => {
@@ -385,27 +453,115 @@ test('headless orchestration skips duplicate start while in flight', async () =>
 })
 
 test('createLivePlayActionChooser consumes prefetch before nn inference', async () => {
-  const setup = {
-    totalSeats: 2,
-    opponents: [{ type: 'nn', modelId: 'latest' }],
-  }
-  const initial = createInitialMatchState(setup, { seed: 99 })
+  const initial = createInitialMatchState(NN_SETUP, { seed: 99 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
   let nnCalled = false
-  const chooser = createLivePlayActionChooser({
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
-    isNnAdventurerPickEnabled: () => true,
-    chooseNnAction: async () => {
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
       nnCalled = true
       return { type: 'PASS' }
     },
     tryConsumePrefetch: async () => ({ type: 'DRAW' }),
-  })
+  }))
   const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
   assert.equal(action.type, 'DRAW')
   assert.equal(nnCalled, false)
+})
+
+test('createLivePlayActionChooser skips prefetch while model is recovering', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 100 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  let prefetchConsumed = false
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    tryConsumePrefetch: async () => {
+      prefetchConsumed = true
+      return { type: 'DRAW' }
+    },
+    chooseNnActionWithRecovery: async () => ({ type: 'PASS' }),
+  }))
+  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
+  assert.equal(prefetchConsumed, false)
+  assert.equal(action.type, 'PASS')
+})
+
+test('runHeadlessMatchCompletion propagates nn load terminal without randombot fallback', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 500 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ loadMaxAttempts: 1 })
+  const chooseAction = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction: async () => ({ ok: false, kind: NN_FAILURE_KIND.LOAD, modelId: 'latest' }),
+      resetRuntimeForModel: () => {},
+    }),
+  }))
+  await assert.rejects(
+    () => runHeadlessMatchCompletion(start, {
+      chooseAction,
+      humanPlayerSeatId: human.id,
+      maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+    }),
+    (error) => error instanceof NeuralRecoveryTerminalError && error.terminal === NEURAL_RECOVERY_TERMINAL.SETUP,
+  )
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.SETUP)
+})
+
+test('runHeadlessMatchCompletion propagates nn infer terminal without randombot fallback', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 501 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  const chooseAction = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction: async () => ({ ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }),
+      resetRuntimeForModel: () => {},
+    }),
+  }))
+  await assert.rejects(
+    () => runHeadlessMatchCompletion(start, {
+      chooseAction,
+      humanPlayerSeatId: human.id,
+      maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+    }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.REFRESH)
+})
+
+const NN_FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'nn', modelId: 'latest' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+test('runHeadlessMatchCompletion reaches match over with nn recovery chooser on success', async () => {
+  const initial = createInitialMatchState(NN_FOUR_PLAYER_SETUP, { seed: 502 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedBeforeMatchOver(initial, human.id)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  const chooseAction = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    chooseNnActionWithRecovery: async (state, actor) =>
+      chooseRandombotAction(state, { seatId: actor.seatId }),
+  }))
+  const result = await runHeadlessMatchCompletion(start, {
+    chooseAction,
+    humanPlayerSeatId: human.id,
+    maxActions: DEFAULT_MAX_HEADLESS_ACTIONS,
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
 })
 
 test('runHeadlessMatchCompletion fails closed when safety cap exceeded', async () => {

--- a/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js
+++ b/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js
@@ -1,0 +1,72 @@
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  neuralRecoverySnapshotHasTerminal,
+} from '../nn/recovery.js'
+import { needsHeadlessCompletion } from './humanEliminationCompletionPolicy.js'
+import { resolveNeuralRecoveryTerminalUx } from './neuralSeatRecoveryView.js'
+
+/**
+ * @param {object} match
+ * @param {ReturnType<import('../nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>} recovery
+ */
+export function attachNeuralRecoverySnapshotToMatch(match, recovery) {
+  const neuralRecoveryByModelId = recovery.exportSnapshot()
+  if (!neuralRecoverySnapshotHasTerminal(neuralRecoveryByModelId)) {
+    return match
+  }
+  return { ...match, neuralRecoveryByModelId }
+}
+
+/**
+ * @param {{
+ *   recovery: ReturnType<import('../nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
+ *   neuralRecoveryByModelId?: Record<string, { terminal?: string }>
+ *   hasMatchSetup?: boolean
+ *   applySetupTerminal?: () => void
+ *   openRefreshTerminal?: () => void
+ * }} options
+ * @returns {boolean} whether a blocking terminal UX was surfaced
+ */
+export function surfacePersistedNeuralRecoveryTerminal(options) {
+  const snapshot = options.neuralRecoveryByModelId
+  if (!snapshot || !neuralRecoverySnapshotHasTerminal(snapshot)) {
+    return false
+  }
+  options.recovery.importSnapshot(snapshot)
+  for (const state of Object.values(snapshot)) {
+    const terminal = state?.terminal ?? NEURAL_RECOVERY_TERMINAL.NONE
+    const ux = resolveNeuralRecoveryTerminalUx({
+      terminal,
+      hasMatchSetup: options.hasMatchSetup === true,
+    })
+    if (ux.action === 'setup-restore') {
+      options.applySetupTerminal?.()
+      return true
+    }
+    if (ux.action === 'refresh-dialog') {
+      options.openRefreshTerminal?.()
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * @param {Record<string, { terminal?: string }> | undefined} neuralRecoveryByModelId
+ */
+export function shouldDeferHeadlessForPersistedNeuralTerminal(neuralRecoveryByModelId) {
+  if (!neuralRecoveryByModelId) return false
+  return Object.values(neuralRecoveryByModelId).some(
+    (state) => state?.terminal === NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+}
+
+/**
+ * @param {{ state?: object, neuralRecoveryByModelId?: Record<string, { terminal?: string }> } | null | undefined} match
+ * @param {string | null | undefined} humanPlayerSeatId
+ */
+export function shouldRunHeadlessMatchCompletion(match, humanPlayerSeatId) {
+  if (!match?.state || !humanPlayerSeatId) return false
+  if (shouldDeferHeadlessForPersistedNeuralTerminal(match.neuralRecoveryByModelId)) return false
+  return needsHeadlessCompletion(match.state, humanPlayerSeatId)
+}

--- a/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.test.js
+++ b/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from '../nn/recovery.js'
+import {
+  attachNeuralRecoverySnapshotToMatch,
+  shouldDeferHeadlessForPersistedNeuralTerminal,
+  shouldRunHeadlessMatchCompletion,
+  surfacePersistedNeuralRecoveryTerminal,
+} from './headlessNeuralRecoveryPersistence.js'
+
+test('attachNeuralRecoverySnapshotToMatch omits field when no terminal is recorded', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  const match = { id: 'm-1', setup: {}, state: {}, history: [] }
+  assert.deepEqual(attachNeuralRecoverySnapshotToMatch(match, recovery), match)
+})
+
+test('attachNeuralRecoverySnapshotToMatch records terminal snapshot for persistence', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  recovery.beginRecovery('latest')
+  recovery.recordInferFailure('latest')
+  const match = { id: 'm-1', setup: {}, state: {}, history: [] }
+  const next = attachNeuralRecoverySnapshotToMatch(match, recovery)
+  assert.equal(next.neuralRecoveryByModelId.latest.terminal, NEURAL_RECOVERY_TERMINAL.REFRESH)
+})
+
+test('surfacePersistedNeuralRecoveryTerminal opens refresh dialog for REFRESH snapshot', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  let refreshOpen = false
+  const surfaced = surfacePersistedNeuralRecoveryTerminal({
+    recovery,
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 0,
+        inferAttempts: 3,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.REFRESH,
+      },
+    },
+    hasMatchSetup: true,
+    openRefreshTerminal: () => {
+      refreshOpen = true
+    },
+  })
+  assert.equal(surfaced, true)
+  assert.equal(refreshOpen, true)
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.REFRESH)
+})
+
+test('surfacePersistedNeuralRecoveryTerminal restores setup for SETUP snapshot', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  let setupRestored = false
+  const surfaced = surfacePersistedNeuralRecoveryTerminal({
+    recovery,
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 3,
+        inferAttempts: 0,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.SETUP,
+      },
+    },
+    hasMatchSetup: true,
+    applySetupTerminal: () => {
+      setupRestored = true
+    },
+  })
+  assert.equal(surfaced, true)
+  assert.equal(setupRestored, true)
+  assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.SETUP)
+})
+
+test('shouldRunHeadlessMatchCompletion is false when refresh terminal is persisted', () => {
+  const match = {
+    state: { phase: 'pick-adventurer', turn: { activeSeatId: 'seat-2' }, scoreboard: {}, seats: [] },
+    neuralRecoveryByModelId: { latest: { terminal: NEURAL_RECOVERY_TERMINAL.REFRESH } },
+  }
+  assert.equal(shouldRunHeadlessMatchCompletion(match, 'seat-1'), false)
+})
+
+test('shouldDeferHeadlessForPersistedNeuralTerminal is true only for REFRESH snapshots', () => {
+  assert.equal(
+    shouldDeferHeadlessForPersistedNeuralTerminal({
+      latest: { terminal: NEURAL_RECOVERY_TERMINAL.REFRESH },
+    }),
+    true,
+  )
+  assert.equal(
+    shouldDeferHeadlessForPersistedNeuralTerminal({
+      latest: { terminal: NEURAL_RECOVERY_TERMINAL.SETUP },
+    }),
+    false,
+  )
+})

--- a/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
+++ b/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { chooseRandombotAction } from '../bots/randombot.js'
 import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
+import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
+import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
 import { createLivePlayActionChooser } from './headlessMatchCompletionRunner.js'
 
 const RANDOMBOT_SETUP = {
@@ -14,50 +17,45 @@ const NN_SETUP = {
   opponents: [{ type: 'nn', modelId: 'latest' }],
 }
 
-function expectedActionType(state, seatId, deps) {
-  const seat = state.seats.find((candidate) => candidate.id === seatId)
-  const roleType = seat?.role?.type
-  if (roleType === 'nn') {
-    const modelId = seat.role.modelId ?? 'latest'
-    if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !deps.isNnAdventurerPickEnabled()) {
-      return chooseRandombotAction(state, { seatId })?.type ?? null
-    }
-    if (deps.nnFailureRecovery.isCoolingDown(modelId)) {
-      return chooseRandombotAction(state, { seatId })?.type ?? null
-    }
-    return deps.fallbackActionType
+function parityDeps(overrides = {}) {
+  const nnRecovery = overrides.nnRecovery ?? createNeuralRuntimeRecoveryCoordinator()
+  return {
+    nnRecovery,
+    nnRuntimeOptions: overrides.nnRuntimeOptions ?? (() => ({})),
+    isNnAdventurerPickEnabled: overrides.isNnAdventurerPickEnabled ?? (() => true),
+    chooseNnActionWithRecovery: overrides.chooseNnActionWithRecovery ?? createChooseNnActionWithRecovery({
+      recovery: nnRecovery,
+      chooseNnAction: overrides.chooseNnAction ?? (async () => ({
+        ok: true,
+        action: { type: overrides.fallbackActionType ?? 'PASS', meta: { modelId: 'latest' } },
+      })),
+      resetRuntimeForModel: () => {},
+    }),
   }
-  return chooseRandombotAction(state, { seatId })?.type ?? null
 }
 
 test('createLivePlayActionChooser matches inline live AI action types for randombot seats', async () => {
   const initial = createInitialMatchState(RANDOMBOT_SETUP, { seed: 21 })
   const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
   assert.ok(bot)
-  const deps = {
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
-    isNnAdventurerPickEnabled: () => true,
-    fallbackActionType: 'PASS',
-  }
-  const chooser = createLivePlayActionChooser(deps)
+  const chooser = createLivePlayActionChooser(parityDeps())
   const action = await chooser({ state: initial, seatId: bot.id })
-  assert.equal(action?.type ?? null, expectedActionType(initial, bot.id, deps))
+  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: bot.id }))
 })
 
-test('createLivePlayActionChooser matches inline live AI action types when nn is cooling down', async () => {
+test('createLivePlayActionChooser propagates terminal error when nn recovery exhausts', async () => {
   const initial = createInitialMatchState(NN_SETUP, { seed: 22 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
-  const deps = {
-    nnFailureRecovery: { isCoolingDown: () => true },
-    nnRuntimeOptions: () => ({}),
-    isNnAdventurerPickEnabled: () => true,
-    fallbackActionType: 'PASS',
-  }
-  const chooser = createLivePlayActionChooser(deps)
-  const action = await chooser({ state: initial, seatId: nnSeat.id })
-  assert.equal(action?.type ?? null, expectedActionType(initial, nnSeat.id, deps))
+  const chooser = createLivePlayActionChooser(parityDeps({
+    chooseNnActionWithRecovery: async () => {
+      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest')
+    },
+  }))
+  await assert.rejects(
+    () => chooser({ state: initial, seatId: nnSeat.id }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
 })
 
 test('createLivePlayActionChooser matches inline live AI action types on nn pick-adventurer when pick disabled', async () => {
@@ -70,31 +68,19 @@ test('createLivePlayActionChooser matches inline live AI action types on nn pick
     turn: { ...initial.turn, activeSeatId: nnSeat.id },
     pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
   }
-  const deps = {
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
+  const chooser = createLivePlayActionChooser(parityDeps({
     isNnAdventurerPickEnabled: () => false,
-    fallbackActionType: 'PASS',
-  }
-  const chooser = createLivePlayActionChooser(deps)
+  }))
   const action = await chooser({ state: pickState, seatId: nnSeat.id })
-  assert.equal(action?.type ?? null, expectedActionType(pickState, nnSeat.id, deps))
+  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
 })
 
 test('createLivePlayActionChooser matches inline live AI action types on nn inference path', async () => {
   const initial = createInitialMatchState(NN_SETUP, { seed: 24 })
   const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
   assert.ok(nnSeat)
-  const deps = {
-    nnFailureRecovery: { isCoolingDown: () => false },
-    nnRuntimeOptions: () => ({}),
-    isNnAdventurerPickEnabled: () => true,
-    fallbackActionType: 'DRAW',
-  }
-  const chooser = createLivePlayActionChooser({
-    ...deps,
-    chooseNnAction: async () => ({ type: deps.fallbackActionType }),
-  })
+  const deps = parityDeps({ fallbackActionType: 'DRAW' })
+  const chooser = createLivePlayActionChooser(deps)
   const action = await chooser({ state: initial, seatId: nnSeat.id })
-  assert.equal(action?.type ?? null, expectedActionType(initial, nnSeat.id, deps))
+  assert.equal(action?.type, 'DRAW')
 })

--- a/src/features/dungeon-runner/ui/neuralSeatRecoveryView.js
+++ b/src/features/dungeon-runner/ui/neuralSeatRecoveryView.js
@@ -1,0 +1,58 @@
+import { NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
+
+/**
+ * @param {{ role?: { type?: string, modelId?: string } }} seat
+ * @returns {string | null}
+ */
+export function nnSeatModelId(seat) {
+  if (seat?.role?.type !== 'nn') return null
+  return seat.role.modelId ?? 'latest'
+}
+
+/**
+ * @param {{ seats: object[], recovery: { isRecovering: (modelId: string) => boolean } }} params
+ */
+export function buildSeatRecoveryIndicators({ seats, recovery }) {
+  return seats.map((seat) => {
+    const modelId = nnSeatModelId(seat)
+    const recovering = modelId ? recovery.isRecovering(modelId) : false
+    return {
+      seatId: seat.id,
+      recovering,
+      testId: recovering ? `neural-seat-recovery-${seat.id}` : null,
+    }
+  })
+}
+
+/**
+ * @param {{ state: { turn?: { activeSeatId?: string }, seats?: object[] }, recovery: { shouldBlockTurn: (modelId: string) => boolean } }} params
+ */
+export function isActiveNnSeatRecovering({ state, recovery }) {
+  const activeSeatId = state?.turn?.activeSeatId
+  if (!activeSeatId) return false
+  const seat = state.seats?.find((candidate) => candidate.id === activeSeatId)
+  const modelId = nnSeatModelId(seat)
+  if (!modelId) return false
+  return recovery.shouldBlockTurn(modelId)
+}
+
+/**
+ * @param {{ state: { turn?: { activeSeatId?: string }, seats?: object[] }, recovery: { shouldBlockTurn: (modelId: string) => boolean } }} params
+ */
+export function shouldBlockAiTurnScheduleForRecovery({ state, recovery }) {
+  return isActiveNnSeatRecovering({ state, recovery })
+}
+
+/**
+ * @param {{ terminal: string, hasMatchSetup?: boolean }} params
+ * @returns {{ action: 'setup-restore' | 'refresh-dialog' } | { action: null }}
+ */
+export function resolveNeuralRecoveryTerminalUx({ terminal, hasMatchSetup = false }) {
+  if (terminal === NEURAL_RECOVERY_TERMINAL.SETUP && hasMatchSetup) {
+    return { action: 'setup-restore' }
+  }
+  if (terminal === NEURAL_RECOVERY_TERMINAL.REFRESH) {
+    return { action: 'refresh-dialog' }
+  }
+  return { action: null }
+}

--- a/src/features/dungeon-runner/ui/neuralSeatRecoveryView.test.js
+++ b/src/features/dungeon-runner/ui/neuralSeatRecoveryView.test.js
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
+import { NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
+import {
+  buildSeatRecoveryIndicators,
+  isActiveNnSeatRecovering,
+  resolveNeuralRecoveryTerminalUx,
+  shouldBlockAiTurnScheduleForRecovery,
+} from './neuralSeatRecoveryView.js'
+
+test('buildSeatRecoveryIndicators marks only nn seats whose model is recovering', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('model-a')
+  const seats = [
+    { id: 'human', role: { type: 'human' } },
+    { id: 'nn-a', role: { type: 'nn', modelId: 'model-a' } },
+    { id: 'nn-b', role: { type: 'nn', modelId: 'model-b' } },
+  ]
+  const rows = buildSeatRecoveryIndicators({ seats, recovery })
+  assert.deepEqual(rows, [
+    { seatId: 'human', recovering: false, testId: null },
+    { seatId: 'nn-a', recovering: true, testId: 'neural-seat-recovery-nn-a' },
+    { seatId: 'nn-b', recovering: false, testId: null },
+  ])
+})
+
+test('isActiveNnSeatRecovering is true only for active nn seat in recovery', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  const state = {
+    turn: { activeSeatId: 'nn-1' },
+    seats: [{ id: 'nn-1', role: { type: 'nn', modelId: 'latest' } }],
+  }
+  assert.equal(isActiveNnSeatRecovering({ state, recovery }), true)
+  assert.equal(
+    isActiveNnSeatRecovering({
+      state: { ...state, turn: { activeSeatId: 'human' } },
+      recovery,
+    }),
+    false,
+  )
+})
+
+test('shouldBlockAiTurnScheduleForRecovery when active nn model is recovering', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  const state = {
+    turn: { activeSeatId: 'nn-1' },
+    seats: [{ id: 'nn-1', role: { type: 'nn', modelId: 'latest' } }],
+  }
+  assert.equal(shouldBlockAiTurnScheduleForRecovery({ state, recovery }), true)
+  assert.equal(
+    shouldBlockAiTurnScheduleForRecovery({
+      state: { ...state, turn: { activeSeatId: 'human' } },
+      recovery,
+    }),
+    false,
+  )
+})
+
+test('shouldBlockAiTurnScheduleForRecovery is false when only inactive nn seat recovers', () => {
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('model-b')
+  const state = {
+    turn: { activeSeatId: 'human' },
+    seats: [
+      { id: 'human', role: { type: 'human' } },
+      { id: 'nn-a', role: { type: 'nn', modelId: 'model-a' } },
+      { id: 'nn-b', role: { type: 'nn', modelId: 'model-b' } },
+    ],
+  }
+  assert.equal(shouldBlockAiTurnScheduleForRecovery({ state, recovery }), false)
+})
+
+test('resolveNeuralRecoveryTerminalUx maps coordinator terminals to play-page actions', () => {
+  assert.deepEqual(
+    resolveNeuralRecoveryTerminalUx({ terminal: NEURAL_RECOVERY_TERMINAL.SETUP, hasMatchSetup: true }),
+    { action: 'setup-restore' },
+  )
+  assert.deepEqual(
+    resolveNeuralRecoveryTerminalUx({ terminal: NEURAL_RECOVERY_TERMINAL.SETUP, hasMatchSetup: false }),
+    { action: null },
+  )
+  assert.deepEqual(
+    resolveNeuralRecoveryTerminalUx({ terminal: NEURAL_RECOVERY_TERMINAL.REFRESH }),
+    { action: 'refresh-dialog' },
+  )
+  assert.deepEqual(
+    resolveNeuralRecoveryTerminalUx({ terminal: NEURAL_RECOVERY_TERMINAL.NONE }),
+    { action: null },
+  )
+})

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -158,6 +158,13 @@
                 >
                   <span class="text-caption">{{ row.label }}</span>
                 </q-badge>
+                <div
+                  v-if="row.recovering"
+                  class="row items-center justify-center q-mt-xs"
+                  :data-testid="row.recoveryTestId"
+                >
+                  <q-spinner size="16px" color="primary" />
+                </div>
                 <div class="dr-seat-progress-cell text-caption" :aria-label="row.ariaLabel">
                   <span
                     v-for="index in row.successes"
@@ -516,6 +523,42 @@
       </q-card>
     </q-dialog>
 
+    <q-dialog v-model="neuralLoadGateTerminalOpen" persistent data-testid="neural-load-gate-terminal">
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
+        <div class="text-body2 q-mb-md">
+          A selected neural model could not load. Adjust setup and start a new match.
+        </div>
+        <div class="row justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Back to setup"
+            data-testid="neural-load-gate-terminal-dismiss"
+            @click="dismissNeuralLoadGateTerminal"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+
+    <q-dialog v-model="neuralRefreshTerminalOpen" persistent data-testid="neural-refresh-terminal">
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
+        <div class="text-body2 q-mb-md">
+          Inference could not recover. Refresh the page to reload the neural runtime; your match stays saved.
+        </div>
+        <div class="row justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Refresh page"
+            data-testid="neural-refresh-terminal-reload"
+            @click="reloadPageForNeuralRefreshTerminal"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+
     <q-dialog v-model="vorpalDialogOpen" persistent>
       <q-card class="q-pa-md" style="min-width: 320px">
         <div class="text-subtitle1 q-mb-xs">Vorpal target</div>
@@ -604,7 +647,11 @@ import {
   persistCurrentMatch,
 } from '../../features/dungeon-runner/persistence/currentMatch.js'
 import { createDefaultSetupConfig, validateSetupConfig } from '../../features/dungeon-runner/setup/config.js'
-import { canStartMatchFromSetup, normalizeSetupState } from '../../features/dungeon-runner/setup/state.js'
+import {
+  applySetupSnapshot,
+  canStartMatchFromSetup,
+  normalizeSetupState,
+} from '../../features/dungeon-runner/setup/state.js'
 import { createMatchSeed } from '../../features/dungeon-runner/setup/seed.js'
 import { isNnAdventurerPickEnabled } from '../../features/dungeon-runner/setup/nnAdventurerPick.js'
 import { shouldEnableDebugOnBoot } from '../../features/dungeon-runner/debug/mode.js'
@@ -612,10 +659,14 @@ import { buildStateFromReplayEnvelope } from '../../features/dungeon-runner/debu
 import { exportReplayEnvelope, importReplayEnvelope } from '../../features/dungeon-runner/debug/replay.js'
 import {
   abandonScheduledInferenceQueue,
-  chooseNnActionWithFallback,
-  warmNnModelCache,
+  loadNnModel,
 } from '../../features/dungeon-runner/nn/runtime.js'
-import { createModelFailureRecovery } from '../../features/dungeon-runner/nn/recovery.js'
+import { createNeuralRuntimeRecoveryCoordinator } from '../../features/dungeon-runner/nn/recovery.js'
+import { createChooseNnActionWithRecovery, NeuralRecoveryTerminalError } from '../../features/dungeon-runner/nn/chooseWithRecovery.js'
+import {
+  resolveNeuralLoadGateSetupTerminal,
+  runMatchNeuralLoadGate,
+} from '../../features/dungeon-runner/nn/matchNeuralLoadGate.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
 import { pickDefaultModelId, validateSelectedModels } from '../../features/dungeon-runner/models/discovery.js'
 import {
@@ -628,8 +679,10 @@ import {
 } from '../../features/dungeon-runner/ui/dungeonRunnerPresentationInterval.js'
 import { buildAiTurnRunToken } from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnToken.js'
 import {
+  cancelAiTurnPrefetch,
   consumeAiTurnPrefetch,
   resetAiTurnPrefetch,
+  setAiTurnPrefetchRecoveryGate,
   startAiTurnPrefetch,
 } from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js'
 import { createPipelineStepLogger } from '../../features/dungeon-runner/nn/nnPipelineTrace.js'
@@ -680,6 +733,16 @@ import { isDungeonPresentationTraceEnabled } from '../../features/dungeon-runner
 import { isDungeonOrchestratorPresentationKind } from '../../features/dungeon-runner/ui/orchestratorPresentationKinds.js'
 import { usePresentationMotion } from '../../features/dungeon-runner/ui/usePresentationMotion.js'
 import { createCompletedMatchReplayUploadTracker } from '../../features/dungeon-runner/firebase/completedMatchReplayUpload.js'
+import {
+  buildSeatRecoveryIndicators,
+  resolveNeuralRecoveryTerminalUx,
+  shouldBlockAiTurnScheduleForRecovery,
+} from '../../features/dungeon-runner/ui/neuralSeatRecoveryView.js'
+import {
+  attachNeuralRecoverySnapshotToMatch,
+  shouldRunHeadlessMatchCompletion,
+  surfacePersistedNeuralRecoveryTerminal,
+} from '../../features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js'
 
 const completedMatchReplayUpload = createCompletedMatchReplayUploadTracker(window.sessionStorage)
 
@@ -697,7 +760,48 @@ function presentationTraceEnabled() {
   return isDungeonPresentationTraceEnabled()
 }
 const modelOptions = ref([])
-const nnFailureRecovery = createModelFailureRecovery()
+const nnRecovery = createNeuralRuntimeRecoveryCoordinator()
+const nnRecoveryRevision = ref(0)
+function notifyNnRecoveryStateChanged() {
+  nnRecoveryRevision.value += 1
+}
+setAiTurnPrefetchRecoveryGate(nnRecovery)
+
+function logNnRecoveryTrace(modelId, step, detail = {}) {
+  if (!debugMode.value) return
+  aiTurnTrace({ modelId })(`recovery.${step}`, {
+    loadAttempts: nnRecovery.getLoadAttempts(modelId),
+    inferAttempts: nnRecovery.getInferAttempts(modelId),
+    loadBackend: nnRecovery.getBackendPreference(modelId, 'load'),
+    inferBackend: nnRecovery.getBackendPreference(modelId, 'infer'),
+    ...detail,
+  })
+}
+
+const chooseNnActionWithRecovery = createChooseNnActionWithRecovery({
+  recovery: nnRecovery,
+  onRecoveryBegin: (modelId) => {
+    cancelAiTurnPrefetch()
+    notifyNnRecoveryStateChanged()
+    logNnRecoveryTrace(modelId, 'begin')
+  },
+  onRecoveryAttempt: (detail) => {
+    notifyNnRecoveryStateChanged()
+    logNnRecoveryTrace(detail.modelId, 'attempt', detail)
+  },
+  onRecoverySettled: () => notifyNnRecoveryStateChanged(),
+})
+
+function buildLivePlayChooserDeps(extra = {}) {
+  return {
+    nnRecovery,
+    ensureNnModelsReady,
+    nnRuntimeOptions,
+    chooseNnActionWithRecovery,
+    onRecoveryBegin: () => cancelAiTurnPrefetch(),
+    ...extra,
+  }
+}
 const replayImportText = ref('')
 const replayExportText = ref('')
 const nnDebugTraceText = ref('')
@@ -836,6 +940,9 @@ usePresentationMotion({
 const activePresentationLabel = ref('')
 const equipmentModalOpen = ref(false)
 const selectedEquipmentTokenId = ref(null)
+const neuralLoadGateTerminalOpen = ref(false)
+const neuralRefreshTerminalOpen = ref(false)
+const matchNeuralLoadGateInFlight = ref(false)
 const confirmationDialogOpen = ref(false)
 const confirmationDialogTitle = ref('Confirm')
 const confirmationDialogMessage = ref('')
@@ -1099,11 +1206,17 @@ const biddingBoard = computed(() =>
   }),
 )
 const seatRunTrackerRows = computed(() => {
+  void nnRecoveryRevision.value
   const scoreboard = match.value?.state?.scoreboard ?? {}
+  const seats = match.value?.state?.seats ?? []
+  const recoveryBySeatId = new Map(
+    buildSeatRecoveryIndicators({ seats, recovery: nnRecovery }).map((entry) => [entry.seatId, entry]),
+  )
   return biddingBoard.value.secondary.seats.map((row) => {
     const score = scoreboard[row.seatId] ?? {}
     const successes = Math.max(0, Number(score.successes ?? 0))
     const failures = Math.max(0, 2 - Number(score.lives ?? 2))
+    const recovery = recoveryBySeatId.get(row.seatId)
     return {
       seatId: row.seatId,
       label: row.label,
@@ -1111,6 +1224,8 @@ const seatRunTrackerRows = computed(() => {
       isActive: row.isActive,
       successes,
       failures,
+      recovering: recovery?.recovering ?? false,
+      recoveryTestId: recovery?.testId ?? null,
       ariaLabel: `${row.label}: ${successes} successful run${successes === 1 ? '' : 's'}, ${failures} failed run${failures === 1 ? '' : 's'}`,
     }
   })
@@ -1195,7 +1310,8 @@ const humanGameplayBlocked = computed(
   () =>
     gameplayInputLocked.value ||
     dungeonOutcomeDialogOpen.value ||
-    headlessCompletionInFlight.value,
+    headlessCompletionInFlight.value ||
+    neuralRefreshTerminalOpen.value,
 )
 const equipmentModalActionsDisabled = computed(
   () => humanGameplayBlocked.value || !isHumanTurn.value,
@@ -1229,21 +1345,7 @@ onMounted(() => {
       '[DungeonRunner][presentation] trace on — localStorage.setItem("dungeonPresentationTrace","1") — also logs [card-flight] for pile/deck → card motion',
     )
   }
-  const loaded = loadCurrentMatch(window.localStorage)
-  if (loaded.ok) {
-    const pace =
-      loaded.match.presentationSpeedProfile === 'brisk' || loaded.match.presentationSpeedProfile === 'cinematic'
-        ? loaded.match.presentationSpeedProfile
-        : 'cinematic'
-    dungeonRunnerSettingsStore.setAnimationPace(pace)
-    match.value = { ...loaded.match, presentationSpeedProfile: pace }
-    deferredPostDungeonState.value = null
-    presentationOrchestrator.clear()
-    presentationSpeedProfile.value = pace
-    presentationOrchestrator.setSpeedProfile(pace)
-    syncPresentationLabel()
-    void maybeRunHeadlessMatchCompletion()
-  }
+  void bootstrapDungeonRunnerPage()
   void loadModelCatalog()
   presentationTimerId = window.setInterval(() => {
     runPresentationIntervalTick(presentationOrchestrator, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS, {
@@ -1253,6 +1355,49 @@ onMounted(() => {
     })
   }, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS)
 })
+
+async function bootstrapDungeonRunnerPage() {
+  const loaded = loadCurrentMatch(window.localStorage)
+  if (!loaded.ok) return
+  const setupSnapshot = cloneSetup(loaded.match.setup)
+  matchNeuralLoadGateInFlight.value = true
+  try {
+    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
+    if (!gate.ok) {
+      applyNeuralLoadGateSetupTerminal(setupSnapshot)
+      return
+    }
+    const pace =
+      loaded.match.presentationSpeedProfile === 'brisk' || loaded.match.presentationSpeedProfile === 'cinematic'
+        ? loaded.match.presentationSpeedProfile
+        : 'cinematic'
+    dungeonRunnerSettingsStore.setAnimationPace(pace)
+    matchNeuralLoadGateInFlight.value = false
+    match.value = { ...loaded.match, presentationSpeedProfile: pace }
+    deferredPostDungeonState.value = null
+    presentationOrchestrator.clear()
+    presentationSpeedProfile.value = pace
+    presentationOrchestrator.setSpeedProfile(pace)
+    nnModelsWarmPromise = Promise.resolve()
+    syncPresentationLabel()
+    const surfacedTerminal = surfacePersistedNeuralRecoveryTerminal({
+      recovery: nnRecovery,
+      neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
+      hasMatchSetup: Boolean(loaded.match.setup),
+      applySetupTerminal: () => applyNeuralLoadGateSetupTerminal(cloneSetup(loaded.match.setup)),
+      openRefreshTerminal: () => {
+        neuralRefreshTerminalOpen.value = true
+      },
+    })
+    if (surfacedTerminal) {
+      notifyNnRecoveryStateChanged()
+      return
+    }
+    void maybeRunHeadlessMatchCompletion()
+  } finally {
+    matchNeuralLoadGateInFlight.value = false
+  }
+}
 
 onBeforeUnmount(() => {
   if (presentationTimerId) window.clearInterval(presentationTimerId)
@@ -1282,6 +1427,18 @@ watch(
   },
   { deep: true },
 )
+
+const activeNnRecoveryBlocking = computed(() => {
+  void nnRecoveryRevision.value
+  if (!match.value?.state) return false
+  return shouldBlockAiTurnScheduleForRecovery({ state: match.value.state, recovery: nnRecovery })
+})
+
+watch(activeNnRecoveryBlocking, (blocking, wasBlocking) => {
+  if (wasBlocking && !blocking) {
+    scheduleAiTurnIfReady()
+  }
+})
 
 watch(
   () => match.value?.state?.lastDungeonRun ?? null,
@@ -1313,7 +1470,7 @@ watch(
   },
 )
 
-function startNewMatch() {
+async function startNewMatch() {
   const modelValidation = validateSelectedModels(setup.opponents, modelOptions.value)
   if (!modelValidation.ok) {
     $q.notify({
@@ -1325,104 +1482,163 @@ function startNewMatch() {
     })
     return
   }
-  clearCurrentMatch(window.localStorage)
-  const seed = createMatchSeed()
-  const id = `match-${Date.now()}`
   const setupSnapshot = cloneSetup()
-  const baseState = createInitialMatchState(setupSnapshot, { seed })
-  const shuffledState = shuffleMatchDeck(shuffleMatchSeats(baseState, { seed: seed ^ 0x5f3759df }), {
-    seed: seed ^ 0x9e3779b9,
-  })
-  const firstSeatId = shuffledState.turn.activeSeatId
-  const initialPickState = {
-    ...shuffledState,
-    phase: MATCH_PHASES.PICK_ADVENTURER,
-    hero: null,
-    pickAdventurer: {
-      ...shuffledState.pickAdventurer,
-      activeSeatId: firstSeatId,
-    },
-  }
-  match.value = {
-    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-    id,
-    setup: setupSnapshot,
-    state: initialPickState,
-    history: [],
-    presentationSpeedProfile: presentationSpeedProfile.value,
-  }
-  deferredPostDungeonState.value = null
-  nnDebugTraceText.value = ''
-  nnDebugTraceHistory.value = []
-  presentationOrchestrator.clear()
-  lastAppliedAiTurnToken = null
-  resetAiTurnPrefetch()
-  presentationInputWasLocked = false
-  nnModelsWarmPromise = preloadNnModelsForSetup(setupSnapshot)
-  syncPresentationLabel()
-}
-
-function rematch() {
-  if (!match.value) return
-  const seed = createMatchSeed()
-  const id = `match-${Date.now()}`
-  const setupSnapshot = cloneSetup(match.value.setup)
-  const baseState = createInitialMatchState(setupSnapshot, { seed })
-  const preservedBotLabels = match.value.state.seats
-    .filter((seat) => seat.role?.type !== 'human' && seat.label)
-    .map((seat) => seat.label)
-  const shuffledState = shuffleMatchDeck(
-    shuffleMatchSeats(baseState, {
-      seed: seed ^ 0x5f3759df,
-      preservedBotLabels,
-    }),
-    {
+  matchNeuralLoadGateInFlight.value = true
+  try {
+    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
+    if (!gate.ok) {
+      applyNeuralLoadGateSetupTerminal(setupSnapshot)
+      return
+    }
+    clearCurrentMatch(window.localStorage)
+    const seed = createMatchSeed()
+    const id = `match-${Date.now()}`
+    const baseState = createInitialMatchState(setupSnapshot, { seed })
+    const shuffledState = shuffleMatchDeck(shuffleMatchSeats(baseState, { seed: seed ^ 0x5f3759df }), {
       seed: seed ^ 0x9e3779b9,
-    },
-  )
-  const firstSeatId = shuffledState.turn.activeSeatId
-  const initialPickState = {
-    ...shuffledState,
-    phase: MATCH_PHASES.PICK_ADVENTURER,
-    hero: null,
-    pickAdventurer: {
-      ...shuffledState.pickAdventurer,
-      activeSeatId: firstSeatId,
-    },
+    })
+    const firstSeatId = shuffledState.turn.activeSeatId
+    const initialPickState = {
+      ...shuffledState,
+      phase: MATCH_PHASES.PICK_ADVENTURER,
+      hero: null,
+      pickAdventurer: {
+        ...shuffledState.pickAdventurer,
+        activeSeatId: firstSeatId,
+      },
+    }
+    match.value = {
+      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+      id,
+      setup: setupSnapshot,
+      state: initialPickState,
+      history: [],
+      presentationSpeedProfile: presentationSpeedProfile.value,
+    }
+    deferredPostDungeonState.value = null
+    nnDebugTraceText.value = ''
+    nnDebugTraceHistory.value = []
+    presentationOrchestrator.clear()
+    lastAppliedAiTurnToken = null
+    resetAiTurnPrefetch()
+    presentationInputWasLocked = false
+    nnModelsWarmPromise = Promise.resolve()
+    syncPresentationLabel()
+  } finally {
+    matchNeuralLoadGateInFlight.value = false
+    scheduleAiTurnIfReady()
+    scheduleHumanAutoResolveIfReady()
   }
-  match.value = {
-    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-    id,
-    setup: setupSnapshot,
-    state: initialPickState,
-    history: [],
-    presentationSpeedProfile: presentationSpeedProfile.value,
-  }
-  deferredPostDungeonState.value = null
-  nnDebugTraceText.value = ''
-  nnDebugTraceHistory.value = []
-  presentationOrchestrator.clear()
-  lastAppliedAiTurnToken = null
-  resetAiTurnPrefetch()
-  presentationInputWasLocked = false
-  nnModelsWarmPromise = preloadNnModelsForSetup(setupSnapshot)
-  syncPresentationLabel()
 }
 
-function preloadNnModelsForSetup(setupSnapshot) {
-  const modelIds = [
-    ...new Set(
-      (setupSnapshot?.opponents ?? [])
-        .filter((opponent) => opponent.type === 'nn')
-        .map((opponent) => opponent.modelId ?? 'latest'),
-    ),
-  ]
-  if (!modelIds.length) return Promise.resolve()
-  return warmNnModelCache(modelIds)
+async function rematch() {
+  if (!match.value) return
+  const setupSnapshot = cloneSetup(match.value.setup)
+  matchNeuralLoadGateInFlight.value = true
+  try {
+    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
+    if (!gate.ok) {
+      applyNeuralLoadGateSetupTerminal(setupSnapshot)
+      return
+    }
+    const seed = createMatchSeed()
+    const id = `match-${Date.now()}`
+    const baseState = createInitialMatchState(setupSnapshot, { seed })
+    const preservedBotLabels = match.value.state.seats
+      .filter((seat) => seat.role?.type !== 'human' && seat.label)
+      .map((seat) => seat.label)
+    const shuffledState = shuffleMatchDeck(
+      shuffleMatchSeats(baseState, {
+        seed: seed ^ 0x5f3759df,
+        preservedBotLabels,
+      }),
+      {
+        seed: seed ^ 0x9e3779b9,
+      },
+    )
+    const firstSeatId = shuffledState.turn.activeSeatId
+    const initialPickState = {
+      ...shuffledState,
+      phase: MATCH_PHASES.PICK_ADVENTURER,
+      hero: null,
+      pickAdventurer: {
+        ...shuffledState.pickAdventurer,
+        activeSeatId: firstSeatId,
+      },
+    }
+    match.value = {
+      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+      id,
+      setup: setupSnapshot,
+      state: initialPickState,
+      history: [],
+      presentationSpeedProfile: presentationSpeedProfile.value,
+    }
+    deferredPostDungeonState.value = null
+    nnDebugTraceText.value = ''
+    nnDebugTraceHistory.value = []
+    presentationOrchestrator.clear()
+    lastAppliedAiTurnToken = null
+    resetAiTurnPrefetch()
+    presentationInputWasLocked = false
+    nnModelsWarmPromise = Promise.resolve()
+    syncPresentationLabel()
+  } finally {
+    matchNeuralLoadGateInFlight.value = false
+    scheduleAiTurnIfReady()
+    scheduleHumanAutoResolveIfReady()
+  }
 }
 
 async function ensureNnModelsReady() {
   await nnModelsWarmPromise?.catch(() => {})
+}
+
+function applyNeuralLoadGateSetupTerminal(setupSnapshot) {
+  resolveNeuralLoadGateSetupTerminal({
+    storage: window.localStorage,
+    setupSnapshot,
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget: setup,
+  })
+  match.value = null
+  lastAppliedAiTurnToken = null
+  resetAiTurnPrefetch()
+  nnModelsWarmPromise = null
+  presentationInputWasLocked = false
+  deferredPostDungeonState.value = null
+  nnDebugTraceText.value = ''
+  nnDebugTraceHistory.value = []
+  presentationOrchestrator.clear()
+  syncPresentationLabel()
+  neuralLoadGateTerminalOpen.value = true
+}
+
+function dismissNeuralLoadGateTerminal() {
+  neuralLoadGateTerminalOpen.value = false
+}
+
+function reloadPageForNeuralRefreshTerminal() {
+  window.location.reload()
+}
+
+function handleNeuralRecoveryTerminalError(error) {
+  if (!(error instanceof NeuralRecoveryTerminalError)) return false
+  const ux = resolveNeuralRecoveryTerminalUx({
+    terminal: error.terminal,
+    hasMatchSetup: Boolean(match.value?.setup),
+  })
+  if (ux.action === 'setup-restore') {
+    applyNeuralLoadGateSetupTerminal(cloneSetup(match.value.setup))
+  } else if (ux.action === 'refresh-dialog') {
+    neuralRefreshTerminalOpen.value = true
+    logNnRecoveryTrace(error.modelId, 'terminal', {
+      terminal: error.terminal,
+      failureKind: error.failureKind ?? null,
+    })
+  }
+  return true
 }
 
 function backToSetup() {
@@ -1592,12 +1808,11 @@ async function maybeRunHeadlessMatchCompletion() {
   if (!match.value) return
   const humanId = humanSeatId.value
   if (!humanId) return
+  if (!shouldRunHeadlessMatchCompletion(match.value, humanId)) {
+    return
+  }
 
-  const chooseAction = createLivePlayActionChooser({
-    nnFailureRecovery,
-    ensureNnModelsReady,
-    nnRuntimeOptions,
-  })
+  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps())
   try {
     const result = await runMaybeHeadlessMatchCompletionFromState(match.value.state, {
       humanPlayerSeatId: humanId,
@@ -1606,10 +1821,32 @@ async function maybeRunHeadlessMatchCompletion() {
       afterFlightStart: teardownForHeadlessMatchCompletion,
     })
     if (result.ran && !result.failed) {
-      match.value = { ...match.value, state: result.state }
+      const nextMatch = attachNeuralRecoverySnapshotToMatch(
+        { ...match.value, state: result.state },
+        nnRecovery,
+      )
+      delete nextMatch.neuralRecoveryByModelId
+      match.value = nextMatch
+      persistCurrentMatch(window.localStorage, match.value)
     } else if (result.ran && result.failed && debugMode.value) {
       console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
     }
+  } catch (error) {
+    if (handleNeuralRecoveryTerminalError(error)) {
+      if (error instanceof NeuralRecoveryTerminalError && match.value) {
+        const ux = resolveNeuralRecoveryTerminalUx({
+          terminal: error.terminal,
+          hasMatchSetup: Boolean(match.value.setup),
+        })
+        if (ux.action === 'refresh-dialog') {
+          match.value = attachNeuralRecoverySnapshotToMatch(match.value, nnRecovery)
+          persistCurrentMatch(window.localStorage, match.value)
+          notifyNnRecoveryStateChanged()
+        }
+      }
+      return
+    }
+    throw error
   } finally {
     syncPresentationLabel()
   }
@@ -1625,6 +1862,10 @@ function confirmVorpalDeclaration() {
 
 async function runAiTurn() {
   const trace = aiTurnTrace()
+  if (neuralRefreshTerminalOpen.value) {
+    trace('run.skip', { reason: 'neural-refresh-terminal' })
+    return
+  }
   if (aiTurnInFlight) {
     trace('run.skip', { reason: 'in-flight' })
     return
@@ -1655,6 +1896,10 @@ async function runAiTurn() {
     trace('run.skip', { reason: 'not-ai-seat', seatId, humanSeatId: humanSeatId.value })
     return
   }
+  if (shouldBlockAiTurnScheduleForRecovery({ state: match.value.state, recovery: nnRecovery })) {
+    trace('run.skip', { reason: 'model-recovering', seatId })
+    return
+  }
   const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
   if (runToken === lastAppliedAiTurnToken) {
     trace('run.skip', { reason: 'duplicate-token', runToken, lastAppliedAiTurnToken })
@@ -1673,16 +1918,26 @@ async function runAiTurn() {
   })
   const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
   const roleType = seat?.role?.type
-  const chooseAction = createLivePlayActionChooser({
-    nnFailureRecovery,
-    ensureNnModelsReady,
-    nnRuntimeOptions,
-    tryConsumePrefetch: async () => consumeAiTurnPrefetch(runToken, (step, detail) => trace(step, detail)),
-  })
-  let action = await chooseAction({ state: match.value.state, seatId, runToken })
-  if (roleType === 'nn' && action?.meta?.fallbackReason === 'MODEL_LOAD_FAILED') {
-    const modelId = seat.role.modelId ?? 'latest'
-    void handleNnModelFailure(seat, modelId, seatId, action)
+  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps({
+    tryConsumePrefetch: async ({ modelId }) => consumeAiTurnPrefetch(
+      runToken,
+      (step, detail) => trace(step, detail),
+      modelId,
+    ),
+  }))
+  let action
+  try {
+    action = await chooseAction({ state: match.value.state, seatId, runToken })
+  } catch (error) {
+    if (handleNeuralRecoveryTerminalError(error)) {
+      trace('run.abort', {
+        reason: 'nn-recovery-terminal',
+        terminal: error.terminal,
+        modelId: error.modelId,
+      })
+      return
+    }
+    throw error
   }
   if (!action) {
     trace('run.abort', { reason: 'no-action' })
@@ -1777,12 +2032,21 @@ function primeAiTurnPrefetch() {
   }
   lastPrimeSkipTraceKey = ''
   const modelId = seat.role.modelId ?? 'latest'
+  if (neuralRefreshTerminalOpen.value) {
+    logAiTurnPrimeSkip('neural-refresh-terminal', { modelId })
+    return
+  }
+  if (nnRecovery.isRecovering(modelId)) {
+    logAiTurnPrimeSkip('model-recovering', { modelId })
+    return
+  }
   startAiTurnPrefetch({
     runToken,
+    modelId,
     trace: (step, detail) => trace(step, detail),
     compute: async () => {
       await ensureNnModelsReady()
-      return chooseNnActionWithFallback(state, { seatId }, nnRuntimeOptions(modelId))
+      return chooseNnActionWithRecovery(state, { seatId }, nnRuntimeOptions(modelId))
     },
   })
 }
@@ -1927,6 +2191,14 @@ function humanDungeonAutoRevealGapMs() {
 }
 
 function scheduleAiTurnIfReady() {
+  if (neuralRefreshTerminalOpen.value) {
+    logAiTurnScheduleSkip('neural-refresh-terminal')
+    return
+  }
+  if (matchNeuralLoadGateInFlight.value) {
+    logAiTurnScheduleSkip('neural-load-gate')
+    return
+  }
   if (aiTurnInFlight) {
     logAiTurnScheduleSkip('in-flight')
     return
@@ -1940,6 +2212,17 @@ function scheduleAiTurnIfReady() {
     return
   }
   if (!match.value || isHumanTurn.value) {
+    return
+  }
+  if (shouldBlockAiTurnScheduleForRecovery({ state: match.value.state, recovery: nnRecovery })) {
+    logAiTurnScheduleSkip('model-recovering', {
+      activeSeatId: match.value.state.turn?.activeSeatId ?? null,
+    })
+    primeAiTurnPrefetch()
+    if (aiTurnTimerId) {
+      window.clearTimeout(aiTurnTimerId)
+      aiTurnTimerId = null
+    }
     return
   }
   if (gameplayInputLocked.value) {
@@ -2031,38 +2314,6 @@ function scheduleHumanAutoResolveIfReady() {
     if (!ok) return
     takeHumanAction(action)
   }, humanDungeonAutoRevealGapMs())
-}
-
-async function handleNnModelFailure(seat, modelId, seatId, fallbackAction) {
-  nnFailureRecovery.recordFailure(modelId)
-  const downgradeTarget = getDowngradeModelId(modelId)
-  const wantsRetry = await requestConfirmation({
-    title: 'Model load failed',
-    message: `Model "${modelId}" failed to load. Retry once?`,
-    okLabel: 'Retry',
-    cancelLabel: 'Recovery options',
-  })
-  if (wantsRetry) {
-    return chooseNnActionWithFallback(match.value.state, { seatId }, nnRuntimeOptions(modelId))
-  }
-  if (downgradeTarget) {
-    const wantsDowngrade = await requestConfirmation({
-      title: 'Downgrade model?',
-      message: `Downgrade to "${downgradeTarget}"?`,
-      okLabel: 'Downgrade',
-      cancelLabel: 'Use safe fallback',
-    })
-    if (wantsDowngrade) {
-      seat.role.modelId = downgradeTarget
-      return chooseNnActionWithFallback(match.value.state, { seatId }, nnRuntimeOptions(downgradeTarget))
-    }
-  }
-  return fallbackAction
-}
-
-function getDowngradeModelId(failedModelId) {
-  const candidates = modelOptions.value.filter((id) => id !== failedModelId && !nnFailureRecovery.isCoolingDown(id))
-  return candidates[0] ?? null
 }
 
 function nnRuntimeOptions(modelId) {


### PR DESCRIPTION
## Summary

Replaces silent neural-opponent fallbacks (legal-action substitutes, cooldown-driven Randombot, mid-match model downgrade) with an explicit **neural runtime recovery** pipeline for Dungeon Runner.

- **Recovery coordinator** — per-`modelId` load/infer attempt counters, recovering flag, WebGL→CPU escalation, terminal outcomes (`REFRESH` / `SETUP`)
- **Typed inference runtime** — `chooseNnAction` returns success or failure kinds (`LOAD`, `INFER`, `ILLEGAL_OUTPUT`); no `createFallbackAction`
- **Live play chooser + prefetch** — recovery-aware action selection; prefetch blocked/cancelled while recovering; pick-adventurer Randombot bypass retained
- **Match neural load gate** — single load attempt per NN model at match start and resume; hard failure restores setup and clears persisted match
- **Play page UX** — inline seat recovery indicator, refresh terminal (infer exhausted), setup terminal (load exhausted)
- **Headless completion parity** — same recovery rules; REFRESH terminal persisted for resume

Closes #167
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174

## Test plan

- [x] `npm test` — 1080 tests pass
- [ ] Manual: start match with neural opponent; play through at least one NN turn
- [ ] Manual: reload mid-match — resume gate passes, play continues
- [ ] Manual (optional): invalid model id → load gate blocks with setup restore dialog