### PR TITLE
Move live-play action chooser out of headless completion runner

### DIFF
--- a/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
+++ b/src/features/dungeon-runner/firebase/completedMatchReplayUpload.test.js
@@ -4,10 +4,10 @@ import { chooseRandombotAction } from '../bots/randombot.js'
 import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
 import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
 import {
-  createLivePlayActionChooser,
   DEFAULT_MAX_HEADLESS_ACTIONS,
   runHeadlessMatchCompletion,
 } from '../ui/headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from '../ui/livePlayActionChooser.js'
 import { needsHeadlessCompletion } from '../ui/humanEliminationCompletionPolicy.js'
 import {
   UPLOADED_MATCH_IDS_STORAGE_KEY,

--- a/src/features/dungeon-runner/persistence/currentMatch.test.js
+++ b/src/features/dungeon-runner/persistence/currentMatch.test.js
@@ -12,11 +12,11 @@ import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '.
 import { NN_FAILURE_KIND } from '../nn/runtime.js'
 import {
   buildDeferredDungeonOutcomeDisplayState,
-  createLivePlayActionChooser,
   DEFAULT_MAX_HEADLESS_ACTIONS,
   resolveHeadlessCompletionStartState,
   runMaybeHeadlessMatchCompletionFromState,
 } from '../ui/headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from '../ui/livePlayActionChooser.js'
 import {
   shouldDeferHeadlessForPersistedNeuralTerminal,
   shouldRunHeadlessMatchCompletion,

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.js
@@ -1,7 +1,3 @@
-import { chooseRandombotAction } from '../bots/randombot.js'
-import { createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
-import { chooseNnAction } from '../nn/runtime.js'
-import { isNnAdventurerPickEnabled } from '../setup/nnAdventurerPick.js'
 import { MATCH_PHASES, applyAction } from '../engine/kernel.js'
 import { isHumanEliminated, needsHeadlessCompletion } from './humanEliminationCompletionPolicy.js'
 
@@ -237,48 +233,4 @@ export async function runHeadlessMatchCompletion(state, options) {
   }
 
   return { ok: true, state: currentState, actionCount }
-}
-
-/**
- * Mirrors live AI turn chooser semantics (Randombot, NN with recovery coordinator, adventurer pick flag).
- * @param {{
- *   nnRecovery: {
- *     isRecovering: (modelId: string) => boolean
- *     getTerminalOutcome: (modelId: string) => string
- *   }
- *   ensureNnModelsReady?: () => Promise<void>
- *   nnRuntimeOptions: (modelId: string) => object
- *   isNnAdventurerPickEnabled?: () => boolean
- *   chooseNnActionWithRecovery?: ReturnType<typeof createChooseNnActionWithRecovery>
- *   tryConsumePrefetch?: (ctx: { state: object, seatId: string, runToken?: string, modelId: string }) => Promise<{ type: string } | null> | { type: string } | null
- *   onRecoveryBegin?: (modelId: string) => void
- * }} deps
- */
-export function createLivePlayActionChooser(deps) {
-  const adventurerPickEnabled = deps.isNnAdventurerPickEnabled ?? isNnAdventurerPickEnabled
-  const chooseNnWithRecovery = deps.chooseNnActionWithRecovery ?? createChooseNnActionWithRecovery({
-    recovery: deps.nnRecovery,
-    chooseNnAction,
-    onRecoveryBegin: deps.onRecoveryBegin,
-  })
-  return async function chooseAction({ state, seatId, runToken }) {
-    const seat = state.seats.find((candidate) => candidate.id === seatId)
-    const roleType = seat?.role?.type
-    if (roleType === 'nn') {
-      const modelId = seat.role.modelId ?? 'latest'
-      if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !adventurerPickEnabled()) {
-        return chooseRandombotAction(state, { seatId })
-      }
-      await deps.ensureNnModelsReady?.()
-      let action = null
-      if (!deps.nnRecovery.isRecovering(modelId) && deps.tryConsumePrefetch) {
-        action = await deps.tryConsumePrefetch({ state, seatId, runToken, modelId })
-      }
-      if (!action) {
-        action = await chooseNnWithRecovery(state, { seatId }, deps.nnRuntimeOptions(modelId))
-      }
-      return action
-    }
-    return chooseRandombotAction(state, { seatId })
-  }
 }

--- a/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
+++ b/src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js
@@ -18,7 +18,6 @@ import { buildMatchOverSummary } from './matchOverSummaryBuilder.js'
 import {
   buildDeferredDungeonOutcomeDisplayState,
   createHeadlessCompletionFlightGate,
-  createLivePlayActionChooser,
   DEFAULT_MAX_HEADLESS_ACTIONS,
   HEADLESS_COMPLETION_ERROR_CODES,
   resolveHeadlessCompletionStartState,
@@ -28,6 +27,7 @@ import {
   shouldBlockLiveAiPipelineWhileHeadless,
   shouldShowFinishingMatchOverlay,
 } from './headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from './livePlayActionChooser.js'
 import {
   NEURAL_RECOVERY_TERMINAL,
   createNeuralRuntimeRecoveryCoordinator,
@@ -188,102 +188,6 @@ test('runHeadlessMatchCompletion reaches match over from reloaded deferred dunge
   assert.equal(result.state.phase, MATCH_PHASES.MATCH_OVER)
 })
 
-const NN_SETUP = {
-  totalSeats: 2,
-  opponents: [{ type: 'nn', modelId: 'latest' }],
-}
-
-function liveChooserDeps(overrides = {}) {
-  return {
-    nnRecovery: overrides.nnRecovery ?? createNeuralRuntimeRecoveryCoordinator(),
-    nnRuntimeOptions: overrides.nnRuntimeOptions ?? (() => ({})),
-    isNnAdventurerPickEnabled: overrides.isNnAdventurerPickEnabled ?? (() => true),
-    chooseNnActionWithRecovery: overrides.chooseNnActionWithRecovery,
-    tryConsumePrefetch: overrides.tryConsumePrefetch,
-    onRecoveryBegin: overrides.onRecoveryBegin,
-  }
-}
-
-test('createLivePlayActionChooser matches randombot for randombot seats', async () => {
-  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 11 })
-  const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
-  assert.ok(bot)
-  const chooser = createLivePlayActionChooser(liveChooserDeps())
-  const action = await chooser({ state: initial, seatId: bot.id })
-  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: bot.id }))
-})
-
-test('createLivePlayActionChooser propagates terminal error instead of randombot on nn failure', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 12 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    chooseNnActionWithRecovery: async () => {
-      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest')
-    },
-  }))
-  await assert.rejects(
-    () => chooser({ state: initial, seatId: nnSeat.id }),
-    (error) => error instanceof NeuralRecoveryTerminalError,
-  )
-})
-
-test('createLivePlayActionChooser blocks concurrent nn calls while recovery is in flight', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 120 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const recovery = createNeuralRuntimeRecoveryCoordinator()
-  let attempts = 0
-  let releaseRetry
-  const retryGate = new Promise((resolve) => { releaseRetry = resolve })
-  const chooseNnAction = async () => {
-    attempts += 1
-    if (attempts === 1) {
-      return { ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }
-    }
-    await retryGate
-    return { ok: true, action: { type: 'DRAW', meta: { modelId: 'latest' } } }
-  }
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    nnRecovery: recovery,
-    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
-      recovery,
-      chooseNnAction,
-      resetRuntimeForModel: () => {},
-    }),
-  }))
-  const first = chooser({ state: initial, seatId: nnSeat.id })
-  await Promise.resolve()
-  const second = chooser({ state: initial, seatId: nnSeat.id })
-  releaseRetry()
-  const [a, b] = await Promise.all([first, second])
-  assert.equal(a.type, 'DRAW')
-  assert.equal(b.type, 'DRAW')
-  assert.equal(attempts, 2)
-})
-
-test('createLivePlayActionChooser never returns randombot on nn infer failure', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 121 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const randombotAction = chooseRandombotAction(initial, { seatId: nnSeat.id })
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    chooseNnActionWithRecovery: async () => {
-      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest', {
-        failureKind: NN_FAILURE_KIND.INFER,
-      })
-    },
-  }))
-  await assert.rejects(
-    () => chooser({ state: initial, seatId: nnSeat.id }),
-    (error) => {
-      assert.ok(error instanceof NeuralRecoveryTerminalError)
-      assert.notDeepEqual(error, randombotAction)
-      return true
-    },
-  )
-})
-
 test('buildDeferredDungeonOutcomeDisplayState defers pick-adventurer behind dungeon phase', () => {
   const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 9001 })
   const human = seatByRole(initial, 'human')
@@ -300,56 +204,6 @@ test('buildDeferredDungeonOutcomeDisplayState defers pick-adventurer behind dung
   assert.equal(deferredState?.phase, MATCH_PHASES.PICK_ADVENTURER)
   const continued = resolveStateAfterDungeonOutcomeContinue(displayState, deferredState)
   assert.equal(continued.phase, MATCH_PHASES.PICK_ADVENTURER)
-})
-
-test('createLivePlayActionChooser uses randombot on pick-adventurer when nn pick flag is off', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 13 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const pickState = {
-    ...initial,
-    phase: MATCH_PHASES.PICK_ADVENTURER,
-    turn: { ...initial.turn, activeSeatId: nnSeat.id },
-    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
-  }
-  let nnCalled = false
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    isNnAdventurerPickEnabled: () => false,
-    chooseNnActionWithRecovery: async () => {
-      nnCalled = true
-      return { type: 'PASS' }
-    },
-  }))
-  const action = await chooser({ state: pickState, seatId: nnSeat.id })
-  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
-  assert.equal(nnCalled, false)
-})
-
-test('createLivePlayActionChooser uses nn path when model ready and pick enabled', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 14 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const pickState = {
-    ...initial,
-    phase: MATCH_PHASES.PICK_ADVENTURER,
-    turn: { ...initial.turn, activeSeatId: nnSeat.id },
-    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
-  }
-  let nnCallCount = 0
-  let lastNnOptions = null
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    nnRuntimeOptions: () => ({ modelId: 'latest', samplingMode: 'greedy' }),
-    isNnAdventurerPickEnabled: () => true,
-    chooseNnActionWithRecovery: async (state, actor, options) => {
-      nnCallCount += 1
-      lastNnOptions = options
-      return { type: 'PASS' }
-    },
-  }))
-  const action = await chooser({ state: pickState, seatId: nnSeat.id })
-  assert.equal(nnCallCount, 1)
-  assert.deepEqual(lastNnOptions, { modelId: 'latest', samplingMode: 'greedy' })
-  assert.equal(action.type, 'PASS')
 })
 
 test('headless completion appends actions to state history through match over', async () => {
@@ -452,42 +306,21 @@ test('headless orchestration skips duplicate start while in flight', async () =>
   gate.finish()
 })
 
-test('createLivePlayActionChooser consumes prefetch before nn inference', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 99 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  let nnCalled = false
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    chooseNnActionWithRecovery: async () => {
-      nnCalled = true
-      return { type: 'PASS' }
-    },
-    tryConsumePrefetch: async () => ({ type: 'DRAW' }),
-  }))
-  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
-  assert.equal(action.type, 'DRAW')
-  assert.equal(nnCalled, false)
-})
+const NN_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
 
-test('createLivePlayActionChooser skips prefetch while model is recovering', async () => {
-  const initial = createInitialMatchState(NN_SETUP, { seed: 100 })
-  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
-  assert.ok(nnSeat)
-  const recovery = createNeuralRuntimeRecoveryCoordinator()
-  recovery.beginRecovery('latest')
-  let prefetchConsumed = false
-  const chooser = createLivePlayActionChooser(liveChooserDeps({
-    nnRecovery: recovery,
-    tryConsumePrefetch: async () => {
-      prefetchConsumed = true
-      return { type: 'DRAW' }
-    },
-    chooseNnActionWithRecovery: async () => ({ type: 'PASS' }),
-  }))
-  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
-  assert.equal(prefetchConsumed, false)
-  assert.equal(action.type, 'PASS')
-})
+function liveChooserDeps(overrides = {}) {
+  return {
+    nnRecovery: overrides.nnRecovery ?? createNeuralRuntimeRecoveryCoordinator(),
+    nnRuntimeOptions: overrides.nnRuntimeOptions ?? (() => ({})),
+    isNnAdventurerPickEnabled: overrides.isNnAdventurerPickEnabled ?? (() => true),
+    chooseNnActionWithRecovery: overrides.chooseNnActionWithRecovery,
+    tryConsumePrefetch: overrides.tryConsumePrefetch,
+    onRecoveryBegin: overrides.onRecoveryBegin,
+  }
+}
 
 test('runHeadlessMatchCompletion propagates nn load terminal without randombot fallback', async () => {
   const initial = createInitialMatchState(NN_SETUP, { seed: 500 })

--- a/src/features/dungeon-runner/ui/livePlayActionChooser.js
+++ b/src/features/dungeon-runner/ui/livePlayActionChooser.js
@@ -1,0 +1,49 @@
+import { chooseRandombotAction } from '../bots/randombot.js'
+import { createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { chooseNnAction } from '../nn/runtime.js'
+import { isNnAdventurerPickEnabled } from '../setup/nnAdventurerPick.js'
+import { MATCH_PHASES } from '../engine/kernel.js'
+
+/**
+ * Mirrors live AI turn chooser semantics (Randombot, NN with recovery coordinator, adventurer pick flag).
+ * @param {{
+ *   nnRecovery: {
+ *     isRecovering: (modelId: string) => boolean
+ *     getTerminalOutcome: (modelId: string) => string
+ *   }
+ *   ensureNnModelsReady?: () => Promise<void>
+ *   nnRuntimeOptions: (modelId: string) => object
+ *   isNnAdventurerPickEnabled?: () => boolean
+ *   chooseNnActionWithRecovery?: ReturnType<typeof createChooseNnActionWithRecovery>
+ *   tryConsumePrefetch?: (ctx: { state: object, seatId: string, runToken?: string, modelId: string }) => Promise<{ type: string } | null> | { type: string } | null
+ *   onRecoveryBegin?: (modelId: string) => void
+ * }} deps
+ */
+export function createLivePlayActionChooser(deps) {
+  const adventurerPickEnabled = deps.isNnAdventurerPickEnabled ?? isNnAdventurerPickEnabled
+  const chooseNnWithRecovery = deps.chooseNnActionWithRecovery ?? createChooseNnActionWithRecovery({
+    recovery: deps.nnRecovery,
+    chooseNnAction,
+    onRecoveryBegin: deps.onRecoveryBegin,
+  })
+  return async function chooseAction({ state, seatId, runToken }) {
+    const seat = state.seats.find((candidate) => candidate.id === seatId)
+    const roleType = seat?.role?.type
+    if (roleType === 'nn') {
+      const modelId = seat.role.modelId ?? 'latest'
+      if (state.phase === MATCH_PHASES.PICK_ADVENTURER && !adventurerPickEnabled()) {
+        return chooseRandombotAction(state, { seatId })
+      }
+      await deps.ensureNnModelsReady?.()
+      let action = null
+      if (!deps.nnRecovery.isRecovering(modelId) && deps.tryConsumePrefetch) {
+        action = await deps.tryConsumePrefetch({ state, seatId, runToken, modelId })
+      }
+      if (!action) {
+        action = await chooseNnWithRecovery(state, { seatId }, deps.nnRuntimeOptions(modelId))
+      }
+      return action
+    }
+    return chooseRandombotAction(state, { seatId })
+  }
+}

--- a/src/features/dungeon-runner/ui/livePlayActionChooser.test.js
+++ b/src/features/dungeon-runner/ui/livePlayActionChooser.test.js
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chooseRandombotAction } from '../bots/randombot.js'
+import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
+import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
+import { NN_FAILURE_KIND } from '../nn/runtime.js'
+import { createNeuralRuntimeRecoveryCoordinator, NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
+import { createLivePlayActionChooser } from './livePlayActionChooser.js'
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+const NN_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
+
+function liveChooserDeps(overrides = {}) {
+  return {
+    nnRecovery: overrides.nnRecovery ?? createNeuralRuntimeRecoveryCoordinator(),
+    nnRuntimeOptions: overrides.nnRuntimeOptions ?? (() => ({})),
+    isNnAdventurerPickEnabled: overrides.isNnAdventurerPickEnabled ?? (() => true),
+    chooseNnActionWithRecovery: overrides.chooseNnActionWithRecovery,
+    tryConsumePrefetch: overrides.tryConsumePrefetch,
+    onRecoveryBegin: overrides.onRecoveryBegin,
+  }
+}
+
+test('createLivePlayActionChooser matches randombot for randombot seats', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 11 })
+  const bot = initial.seats.find((seat) => seat.role.type === 'randombot')
+  assert.ok(bot)
+  const chooser = createLivePlayActionChooser(liveChooserDeps())
+  const action = await chooser({ state: initial, seatId: bot.id })
+  assert.deepEqual(action, chooseRandombotAction(initial, { seatId: bot.id }))
+})
+
+test('createLivePlayActionChooser propagates terminal error instead of randombot on nn failure', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 12 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
+      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest')
+    },
+  }))
+  await assert.rejects(
+    () => chooser({ state: initial, seatId: nnSeat.id }),
+    (error) => error instanceof NeuralRecoveryTerminalError,
+  )
+})
+
+test('createLivePlayActionChooser blocks concurrent nn calls while recovery is in flight', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 120 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  let attempts = 0
+  let releaseRetry
+  const retryGate = new Promise((resolve) => { releaseRetry = resolve })
+  const chooseNnAction = async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return { ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }
+    }
+    await retryGate
+    return { ok: true, action: { type: 'DRAW', meta: { modelId: 'latest' } } }
+  }
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction,
+      resetRuntimeForModel: () => {},
+    }),
+  }))
+  const first = chooser({ state: initial, seatId: nnSeat.id })
+  await Promise.resolve()
+  const second = chooser({ state: initial, seatId: nnSeat.id })
+  releaseRetry()
+  const [a, b] = await Promise.all([first, second])
+  assert.equal(a.type, 'DRAW')
+  assert.equal(b.type, 'DRAW')
+  assert.equal(attempts, 2)
+})
+
+test('createLivePlayActionChooser never returns randombot on nn infer failure', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 121 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const randombotAction = chooseRandombotAction(initial, { seatId: nnSeat.id })
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
+      throw new NeuralRecoveryTerminalError(NEURAL_RECOVERY_TERMINAL.REFRESH, 'latest', {
+        failureKind: NN_FAILURE_KIND.INFER,
+      })
+    },
+  }))
+  await assert.rejects(
+    () => chooser({ state: initial, seatId: nnSeat.id }),
+    (error) => {
+      assert.ok(error instanceof NeuralRecoveryTerminalError)
+      assert.notDeepEqual(error, randombotAction)
+      return true
+    },
+  )
+})
+
+test('createLivePlayActionChooser uses randombot on pick-adventurer when nn pick flag is off', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 13 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const pickState = {
+    ...initial,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    turn: { ...initial.turn, activeSeatId: nnSeat.id },
+    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
+  }
+  let nnCalled = false
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    isNnAdventurerPickEnabled: () => false,
+    chooseNnActionWithRecovery: async () => {
+      nnCalled = true
+      return { type: 'PASS' }
+    },
+  }))
+  const action = await chooser({ state: pickState, seatId: nnSeat.id })
+  assert.deepEqual(action, chooseRandombotAction(pickState, { seatId: nnSeat.id }))
+  assert.equal(nnCalled, false)
+})
+
+test('createLivePlayActionChooser uses nn path when model ready and pick enabled', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 14 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const pickState = {
+    ...initial,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    turn: { ...initial.turn, activeSeatId: nnSeat.id },
+    pickAdventurer: { ...initial.pickAdventurer, activeSeatId: nnSeat.id },
+  }
+  let nnCallCount = 0
+  let lastNnOptions = null
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    nnRuntimeOptions: () => ({ modelId: 'latest', samplingMode: 'greedy' }),
+    isNnAdventurerPickEnabled: () => true,
+    chooseNnActionWithRecovery: async (state, actor, options) => {
+      nnCallCount += 1
+      lastNnOptions = options
+      return { type: 'PASS' }
+    },
+  }))
+  const action = await chooser({ state: pickState, seatId: nnSeat.id })
+  assert.equal(nnCallCount, 1)
+  assert.deepEqual(lastNnOptions, { modelId: 'latest', samplingMode: 'greedy' })
+  assert.equal(action.type, 'PASS')
+})
+
+test('createLivePlayActionChooser consumes prefetch before nn inference', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 99 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  let nnCalled = false
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    chooseNnActionWithRecovery: async () => {
+      nnCalled = true
+      return { type: 'PASS' }
+    },
+    tryConsumePrefetch: async () => ({ type: 'DRAW' }),
+  }))
+  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
+  assert.equal(action.type, 'DRAW')
+  assert.equal(nnCalled, false)
+})
+
+test('createLivePlayActionChooser skips prefetch while model is recovering', async () => {
+  const initial = createInitialMatchState(NN_SETUP, { seed: 100 })
+  const nnSeat = initial.seats.find((seat) => seat.role.type === 'nn')
+  assert.ok(nnSeat)
+  const recovery = createNeuralRuntimeRecoveryCoordinator()
+  recovery.beginRecovery('latest')
+  let prefetchConsumed = false
+  const chooser = createLivePlayActionChooser(liveChooserDeps({
+    nnRecovery: recovery,
+    tryConsumePrefetch: async () => {
+      prefetchConsumed = true
+      return { type: 'DRAW' }
+    },
+    chooseNnActionWithRecovery: async () => ({ type: 'PASS' }),
+  }))
+  const action = await chooser({ state: initial, seatId: nnSeat.id, runToken: 'token-a' })
+  assert.equal(prefetchConsumed, false)
+  assert.equal(action.type, 'PASS')
+})

--- a/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
+++ b/src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js
@@ -5,7 +5,7 @@ import { MATCH_PHASES, createInitialMatchState } from '../engine/kernel.js'
 import { createNeuralRuntimeRecoveryCoordinator } from '../nn/recovery.js'
 import { NeuralRecoveryTerminalError, createChooseNnActionWithRecovery } from '../nn/chooseWithRecovery.js'
 import { NEURAL_RECOVERY_TERMINAL } from '../nn/recovery.js'
-import { createLivePlayActionChooser } from './headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from './livePlayActionChooser.js'
 
 const RANDOMBOT_SETUP = {
   totalSeats: 2,

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -721,10 +721,10 @@ import {
 } from '../../features/dungeon-runner/ui/dungeonOutcomeDialog.js'
 import { MATCH_OVER_END_VARIANTS } from '../../features/dungeon-runner/ui/humanEliminationCompletionPolicy.js'
 import {
-  createLivePlayActionChooser,
   runMaybeHeadlessMatchCompletionFromState,
   shouldDeferDungeonExitUntilOutcomeAck,
 } from '../../features/dungeon-runner/ui/headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from '../../features/dungeon-runner/ui/livePlayActionChooser.js'
 import { buildMatchOverSummary } from '../../features/dungeon-runner/ui/matchOverSummaryBuilder.js'
 import MonsterCardFace from '../../components/dungeon-runner/MonsterCardFace.vue'
 import DungeonRunnerHelpDialog from '../../features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue'


### PR DESCRIPTION
## Summary

- Extract `createLivePlayActionChooser` into `livePlayActionChooser.js` so headless completion stays focused on the completion loop and flight gate.
- Move chooser unit tests into `livePlayActionChooser.test.js` and update imports across the page and test consumers.

Closes #179

## Test plan

- [x] `node --test src/features/dungeon-runner/ui/livePlayActionChooser.test.js`
- [x] `node --test src/features/dungeon-runner/ui/livePlayActionChooserParity.test.js`
- [x] `node --test src/features/dungeon-runner/ui/headlessMatchCompletionRunner.test.js`
- [x] `node --test src/features/dungeon-runner/release.integration.test.js`
- [ ] Start a match with a neural opponent and confirm opponent turns still resolve