### PR TITLE
Extract match/NN orchestration from DungeonRunnerPage

### DIFF
--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -318,6 +318,7 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - Headless completion of remaining **opponent** play after human **elimination** uses the same action choosers as live play (not a simplified bot).
 - The **current match** holds in-progress **match** state locally until **match over** or clear; optional **persisted neural recovery** may be attached.
 - **Match neural load gate** runs before the first turn on new **match** start and on **current match** resume; gate load failure yields **neural recovery terminal outcome** **SETUP** without **neural runtime recovery** retries.
+- On **current match** resume, **match neural load gate** must succeed before surfacing **persisted neural recovery** or **finishing match** headless resolution.
 - **Live AI turn pipeline gate** decides schedule, prefetch, and run together during live play; distinct from **match neural load gate** and from headless **finishing match** resolution (headless supplies in-flight state as an input only).
 - **Neural runtime recovery** coordinates load/infer failures per **neural opponent** `modelId`; non-terminal recovery blocks only the active **neural opponent** seat.
 - **Neural recovery terminal outcome** **SETUP** clears the **current match** and restores **setup**; **REFRESH** keeps the **current match** and requires a page refresh.

--- a/src/features/dungeon-runner/createLiveMatchPageSessionSink.js
+++ b/src/features/dungeon-runner/createLiveMatchPageSessionSink.js
@@ -1,0 +1,47 @@
+/**
+ * Builds the live match page session sink consumed by {@link resetLiveMatchPageState}.
+ *
+ * @param {{
+ *   match: import('vue').Ref<object | null>
+ *   setNnModelsWarmPromise: (promise: Promise<void> | null) => void
+ *   resetAiTurnPrefetch: () => void
+ *   setLastAppliedAiTurnTokenNull: () => void
+ *   setPresentationInputWasLockedFalse: () => void
+ *   deferredPostDungeonState: import('vue').Ref<object | null>
+ *   nnDebugTraceText: import('vue').Ref<string>
+ *   nnDebugTraceHistory: import('vue').Ref<unknown[]>
+ *   presentationOrchestrator: { clear: () => void }
+ *   syncPresentationLabel: () => void
+ *   neuralLoadGateTerminalOpen: import('vue').Ref<boolean>
+ *   clearCurrentMatch: (storage: Storage) => void
+ *   storage: Storage
+ * }} deps
+ */
+export function createLiveMatchPageSessionSink(deps) {
+  return {
+    setMatchNull: () => {
+      deps.match.value = null
+    },
+    setNnModelsWarmPromise: deps.setNnModelsWarmPromise,
+    resetAiTurnPrefetch: deps.resetAiTurnPrefetch,
+    setLastAppliedAiTurnTokenNull: deps.setLastAppliedAiTurnTokenNull,
+    setPresentationInputWasLockedFalse: deps.setPresentationInputWasLockedFalse,
+    setDeferredPostDungeonStateNull: () => {
+      deps.deferredPostDungeonState.value = null
+    },
+    clearDebugTraces: () => {
+      deps.nnDebugTraceText.value = ''
+      deps.nnDebugTraceHistory.value = []
+    },
+    clearPresentation: () => {
+      deps.presentationOrchestrator.clear()
+    },
+    syncPresentationLabel: deps.syncPresentationLabel,
+    setNeuralLoadGateTerminalOpen: (open) => {
+      deps.neuralLoadGateTerminalOpen.value = open
+    },
+    clearPersistedMatch: () => {
+      deps.clearCurrentMatch(deps.storage)
+    },
+  }
+}

--- a/src/features/dungeon-runner/createLiveMatchPageSessionSink.test.js
+++ b/src/features/dungeon-runner/createLiveMatchPageSessionSink.test.js
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ref } from 'vue'
+import { createLiveMatchPageSessionSink } from './createLiveMatchPageSessionSink.js'
+import { resetLiveMatchPageState } from './resetLiveMatchPageState.js'
+
+function createTestDeps(overrides = {}) {
+  const match = ref({ id: 'm1' })
+  const deferredPostDungeonState = ref({ foo: 1 })
+  const nnDebugTraceText = ref('trace')
+  const nnDebugTraceHistory = ref(['a'])
+  const neuralLoadGateTerminalOpen = ref(false)
+  let nnModelsWarmPromise = 'initial'
+  let lastAppliedAiTurnToken = 'token'
+  let presentationInputWasLocked = true
+  const calls = []
+  const presentationOrchestrator = {
+    clear: () => {
+      calls.push('clearPresentation')
+    },
+  }
+
+  const deps = {
+    match,
+    setNnModelsWarmPromise: (promise) => {
+      nnModelsWarmPromise = promise
+      calls.push(['setNnModelsWarmPromise', promise === null ? null : 'promise'])
+    },
+    resetAiTurnPrefetch: () => {
+      calls.push('resetAiTurnPrefetch')
+    },
+    setLastAppliedAiTurnTokenNull: () => {
+      lastAppliedAiTurnToken = null
+      calls.push('setLastAppliedAiTurnTokenNull')
+    },
+    setPresentationInputWasLockedFalse: () => {
+      presentationInputWasLocked = false
+      calls.push('setPresentationInputWasLockedFalse')
+    },
+    deferredPostDungeonState,
+    nnDebugTraceText,
+    nnDebugTraceHistory,
+    presentationOrchestrator,
+    syncPresentationLabel: () => {
+      calls.push('syncPresentationLabel')
+    },
+    neuralLoadGateTerminalOpen,
+    clearCurrentMatch: (storage) => {
+      calls.push(['clearPersistedMatch', storage])
+    },
+    storage: { kind: 'mock-storage' },
+    ...overrides,
+  }
+
+  return {
+    deps,
+    calls,
+    match,
+    deferredPostDungeonState,
+    nnDebugTraceText,
+    nnDebugTraceHistory,
+    neuralLoadGateTerminalOpen,
+    get nnModelsWarmPromise() {
+      return nnModelsWarmPromise
+    },
+    get lastAppliedAiTurnToken() {
+      return lastAppliedAiTurnToken
+    },
+    get presentationInputWasLocked() {
+      return presentationInputWasLocked
+    },
+  }
+}
+
+test('createLiveMatchPageSessionSink wires all reset policy handlers', () => {
+  const ctx = createTestDeps()
+  const sink = createLiveMatchPageSessionSink(ctx.deps)
+
+  sink.setMatchNull()
+  sink.setNnModelsWarmPromise(Promise.resolve())
+  sink.resetAiTurnPrefetch()
+  sink.setLastAppliedAiTurnTokenNull()
+  sink.setPresentationInputWasLockedFalse()
+  sink.setDeferredPostDungeonStateNull()
+  sink.clearDebugTraces()
+  sink.clearPresentation()
+  sink.syncPresentationLabel()
+  sink.setNeuralLoadGateTerminalOpen(true)
+  sink.clearPersistedMatch()
+
+  assert.equal(ctx.match.value, null)
+  assert.equal(ctx.deferredPostDungeonState.value, null)
+  assert.equal(ctx.nnDebugTraceText.value, '')
+  assert.deepEqual(ctx.nnDebugTraceHistory.value, [])
+  assert.equal(ctx.neuralLoadGateTerminalOpen.value, true)
+  assert.equal(ctx.lastAppliedAiTurnToken, null)
+  assert.equal(ctx.presentationInputWasLocked, false)
+  assert.deepEqual(ctx.calls.at(-1), ['clearPersistedMatch', ctx.deps.storage])
+})
+
+test('createLiveMatchPageSessionSink integrates with resetLiveMatchPageState for fresh match entry', () => {
+  const ctx = createTestDeps()
+  const sink = createLiveMatchPageSessionSink(ctx.deps)
+
+  resetLiveMatchPageState(sink, { warmModelsResolved: true })
+
+  assert.deepEqual(ctx.calls, [
+    'setLastAppliedAiTurnTokenNull',
+    'resetAiTurnPrefetch',
+    ['setNnModelsWarmPromise', 'promise'],
+    'setPresentationInputWasLockedFalse',
+    'clearPresentation',
+    'syncPresentationLabel',
+  ])
+  assert.equal(ctx.deferredPostDungeonState.value, null)
+  assert.equal(ctx.nnDebugTraceText.value, '')
+  assert.deepEqual(ctx.nnDebugTraceHistory.value, [])
+})

--- a/src/features/dungeon-runner/createMatchPageOrchestrationContext.js
+++ b/src/features/dungeon-runner/createMatchPageOrchestrationContext.js
@@ -1,0 +1,70 @@
+import { resolveNeuralLoadGateSetupTerminal } from './nn/matchNeuralLoadGate.js'
+
+/**
+ * Page-local dependencies shared by match/NN orchestration entry points.
+ *
+ * @typedef {object} MatchPageOrchestrationContext
+ * @property {Storage} storage
+ * @property {ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>} recovery
+ * @property {(modelId: string) => Promise<void>} loadModel
+ * @property {(inFlight: boolean) => void} setMatchNeuralLoadGateInFlight
+ * @property {(storage: Storage) => void} clearCurrentMatch
+ * @property {(storage: Storage, match: object) => void} persistCurrentMatch
+ * @property {(setupTarget: object, setupSnapshot: object) => void} applySetupSnapshot
+ * @property {object} setupTarget
+ * @property {(setup: object) => object} cloneSetup
+ * @property {(setupSnapshot: object) => void} resolveSetupTerminal
+ * @property {(setupSnapshot: object) => void} applySetupTerminal
+ */
+
+/**
+ * Bundles page-local storage, setup, load-model, in-flight, and recovery deps
+ * for {@link import('./matchPageOrchestration.js')} entry points.
+ *
+ * @param {{
+ *   storage: Storage
+ *   recovery: ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
+ *   loadModel: (modelId: string) => Promise<void>
+ *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
+ *   clearCurrentMatch: (storage: Storage) => void
+ *   persistCurrentMatch: (storage: Storage, match: object) => void
+ *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
+ *   setupTarget: object
+ *   cloneSetup: (setup: object) => object
+ *   applySetupTerminal?: (setupSnapshot: object) => void
+ *   onSetupTerminal?: () => void
+ * }} deps
+ * @returns {MatchPageOrchestrationContext}
+ */
+export function createMatchPageOrchestrationContext(deps) {
+  /** @param {object} setupSnapshot */
+  function resolveSetupTerminal(setupSnapshot) {
+    resolveNeuralLoadGateSetupTerminal({
+      storage: deps.storage,
+      setupSnapshot,
+      clearCurrentMatch: deps.clearCurrentMatch,
+      applySetupSnapshot: deps.applySetupSnapshot,
+      setupTarget: deps.setupTarget,
+    })
+  }
+
+  /** @param {object} setupSnapshot */
+  function applySetupTerminal(setupSnapshot) {
+    resolveSetupTerminal(setupSnapshot)
+    deps.onSetupTerminal?.()
+  }
+
+  return {
+    storage: deps.storage,
+    recovery: deps.recovery,
+    loadModel: deps.loadModel,
+    setMatchNeuralLoadGateInFlight: deps.setMatchNeuralLoadGateInFlight,
+    clearCurrentMatch: deps.clearCurrentMatch,
+    persistCurrentMatch: deps.persistCurrentMatch,
+    applySetupSnapshot: deps.applySetupSnapshot,
+    setupTarget: deps.setupTarget,
+    cloneSetup: deps.cloneSetup,
+    resolveSetupTerminal,
+    applySetupTerminal: deps.applySetupTerminal ?? applySetupTerminal,
+  }
+}

--- a/src/features/dungeon-runner/createMatchPageOrchestrationContext.test.js
+++ b/src/features/dungeon-runner/createMatchPageOrchestrationContext.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { applySetupSnapshot } from './setup/state.js'
+import {
+  clearCurrentMatch,
+  loadCurrentMatch,
+  persistCurrentMatch,
+} from './persistence/currentMatch.js'
+import { createNeuralRuntimeRecoveryCoordinator } from './nn/recovery.js'
+import { createMatchPageOrchestrationContext } from './createMatchPageOrchestrationContext.js'
+
+function createMemoryStorage() {
+  const map = new Map()
+  return {
+    getItem(key) {
+      return map.has(key) ? map.get(key) : null
+    },
+    setItem(key, value) {
+      map.set(key, String(value))
+    },
+    removeItem(key) {
+      map.delete(key)
+    },
+  }
+}
+
+function createTestContext(overrides = {}) {
+  const storage = overrides.storage ?? createMemoryStorage()
+  const setupTarget = overrides.setupTarget ?? { totalSeats: 2, opponents: [] }
+  const inFlightCalls = []
+  const loadCalls = []
+  const setupTerminalCalls = []
+  const onSetupTerminalCalls = []
+
+  const ctx = createMatchPageOrchestrationContext({
+    storage,
+    recovery: overrides.recovery ?? createNeuralRuntimeRecoveryCoordinator(),
+    loadModel:
+      overrides.loadModel ??
+      ((modelId) => {
+        loadCalls.push(modelId)
+        return Promise.resolve()
+      }),
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      inFlightCalls.push(inFlight)
+    },
+    clearCurrentMatch,
+    persistCurrentMatch,
+    applySetupSnapshot,
+    setupTarget,
+    cloneSetup: overrides.cloneSetup ?? ((setup) => structuredClone(setup)),
+    onSetupTerminal: () => {
+      onSetupTerminalCalls.push(true)
+    },
+    ...overrides.factoryOverrides,
+  })
+
+  return {
+    ctx,
+    storage,
+    setupTarget,
+    inFlightCalls,
+    loadCalls,
+    setupTerminalCalls,
+    onSetupTerminalCalls,
+  }
+}
+
+test('createMatchPageOrchestrationContext exposes bundled page dependencies', () => {
+  const { ctx } = createTestContext()
+
+  assert.equal(typeof ctx.storage.getItem, 'function')
+  assert.equal(typeof ctx.recovery.importSnapshot, 'function')
+  assert.equal(typeof ctx.loadModel, 'function')
+  assert.equal(typeof ctx.setMatchNeuralLoadGateInFlight, 'function')
+  assert.equal(typeof ctx.clearCurrentMatch, 'function')
+  assert.equal(typeof ctx.persistCurrentMatch, 'function')
+  assert.equal(typeof ctx.applySetupSnapshot, 'function')
+  assert.equal(typeof ctx.setupTarget, 'object')
+  assert.equal(typeof ctx.cloneSetup, 'function')
+  assert.equal(typeof ctx.resolveSetupTerminal, 'function')
+  assert.equal(typeof ctx.applySetupTerminal, 'function')
+})
+
+test('createMatchPageOrchestrationContext resolveSetupTerminal restores setup and clears match', () => {
+  const setupSnapshot = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const { ctx, storage, setupTarget } = createTestContext({
+    setupTarget: { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+  })
+  persistCurrentMatch(storage, {
+    schemaVersion: 1,
+    id: 'm-context-setup-terminal',
+    setup: setupSnapshot,
+    state: {},
+    history: [],
+  })
+
+  ctx.resolveSetupTerminal(setupSnapshot)
+
+  assert.deepEqual(setupTarget, setupSnapshot)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+})
+
+test('createMatchPageOrchestrationContext applySetupTerminal runs optional page hook', () => {
+  const setupSnapshot = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'latest' }],
+  }
+  const { ctx, onSetupTerminalCalls } = createTestContext()
+
+  ctx.applySetupTerminal(setupSnapshot)
+
+  assert.deepEqual(onSetupTerminalCalls, [true])
+})

--- a/src/features/dungeon-runner/debug/replayBootstrap.js
+++ b/src/features/dungeon-runner/debug/replayBootstrap.js
@@ -1,32 +1,8 @@
-import {
-  createInitialMatchState,
-  shuffleMatchDeck,
-  shuffleMatchSeats,
-  MATCH_PHASES,
-} from '../engine/kernel.js'
-
-/** Must match `startMatch` / `rematch` in DungeonRunnerPage.vue. */
-export const REPLAY_SEAT_SHUFFLE_SEED_XOR = 0x5f3759df
-export const REPLAY_DECK_SHUFFLE_SEED_XOR = 0x9e3779b9
+import { materializeNewMatchState } from '../setup/materializeNewMatchState.js'
 
 /**
- * Web-authoritative pre-history state for completed-match replays:
- * seat shuffle, deck shuffle, then pick-adventurer phase with first actor set.
+ * Web-authoritative pre-history state for completed-match replays.
  */
 export function bootstrapMatchStateForReplay(setup, seed) {
-  const baseState = createInitialMatchState(setup, { seed })
-  const shuffledState = shuffleMatchDeck(
-    shuffleMatchSeats(baseState, { seed: seed ^ REPLAY_SEAT_SHUFFLE_SEED_XOR }),
-    { seed: seed ^ REPLAY_DECK_SHUFFLE_SEED_XOR },
-  )
-  const firstSeatId = shuffledState.turn.activeSeatId
-  return {
-    ...shuffledState,
-    phase: MATCH_PHASES.PICK_ADVENTURER,
-    hero: null,
-    pickAdventurer: {
-      ...shuffledState.pickAdventurer,
-      activeSeatId: firstSeatId,
-    },
-  }
+  return materializeNewMatchState(setup, seed)
 }

--- a/src/features/dungeon-runner/matchPageOrchestration.js
+++ b/src/features/dungeon-runner/matchPageOrchestration.js
@@ -1,31 +1,17 @@
 import { NeuralRecoveryTerminalError } from './nn/chooseWithRecovery.js'
-import {
-  resolveNeuralLoadGateSetupTerminal,
-  runMatchNeuralLoadGate,
-} from './nn/matchNeuralLoadGate.js'
+import { runMatchNeuralLoadGate } from './nn/matchNeuralLoadGate.js'
 import { CURRENT_MATCH_SCHEMA_VERSION, loadCurrentMatch } from './persistence/currentMatch.js'
-import { surfacePersistedNeuralRecoveryTerminal } from './ui/headlessNeuralRecoveryPersistence.js'
-import { materializeNewMatchState } from './setup/materializeNewMatchState.js'
 import {
   attachNeuralRecoverySnapshotToMatch,
   shouldRunHeadlessMatchCompletion,
+  surfacePersistedNeuralRecoveryTerminal,
 } from './ui/headlessNeuralRecoveryPersistence.js'
+import { materializeNewMatchState } from './setup/materializeNewMatchState.js'
 import { resolveNeuralRecoveryTerminalUx } from './ui/neuralSeatRecoveryView.js'
 import { runMaybeHeadlessMatchCompletionFromState } from './ui/headlessMatchCompletionRunner.js'
 
-/**
- * @param {{
- *   setupSnapshot: object
- *   loadModel: (modelId: string) => Promise<void>
- *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
- *   releaseInFlightAfterGate?: boolean
- *   storage: Storage
- *   clearCurrentMatch: (storage: Storage) => void
- *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
- *   setupTarget: object
- * }} options
- * @returns {Promise<{ kind: 'success' } | { kind: 'setup-terminal' }>}
- */
+/** @typedef {import('./createMatchPageOrchestrationContext.js').MatchPageOrchestrationContext} MatchPageOrchestrationContext */
+
 function resolvePresentationSpeedProfile(profile) {
   if (profile === 'brisk' || profile === 'cinematic') {
     return profile
@@ -34,16 +20,7 @@ function resolvePresentationSpeedProfile(profile) {
 }
 
 /**
- * @param {{
- *   storage: Storage
- *   loadModel: (modelId: string) => Promise<void>
- *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
- *   clearCurrentMatch: (storage: Storage) => void
- *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
- *   setupTarget: object
- *   cloneSetup: (setup: object) => object
- *   recovery: ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
- * }} options
+ * @param {MatchPageOrchestrationContext} ctx
  * @returns {Promise<
  *   { kind: 'no-saved-match' }
  *   | { kind: 'setup-terminal' }
@@ -51,22 +28,16 @@ function resolvePresentationSpeedProfile(profile) {
  *   | { kind: 'resume', match: object, presentationSpeedProfile: string }
  * >}
  */
-export async function bootstrapCurrentMatchFromStorage(options) {
-  const loaded = loadCurrentMatch(options.storage)
+export async function bootstrapCurrentMatchFromStorage(ctx) {
+  const loaded = loadCurrentMatch(ctx.storage)
   if (!loaded.ok) {
     return { kind: 'no-saved-match' }
   }
 
-  const setupSnapshot = options.cloneSetup(loaded.match.setup)
-  const gateResult = await runMatchEntryNeuralLoadGateForPage({
+  const setupSnapshot = ctx.cloneSetup(loaded.match.setup)
+  const gateResult = await runMatchEntryNeuralLoadGateForPage(ctx, {
     setupSnapshot,
-    loadModel: options.loadModel,
-    setMatchNeuralLoadGateInFlight: options.setMatchNeuralLoadGateInFlight,
     releaseInFlightAfterGate: true,
-    storage: options.storage,
-    clearCurrentMatch: options.clearCurrentMatch,
-    applySetupSnapshot: options.applySetupSnapshot,
-    setupTarget: options.setupTarget,
   })
   if (gateResult.kind === 'setup-terminal') {
     return { kind: 'setup-terminal' }
@@ -77,30 +48,19 @@ export async function bootstrapCurrentMatchFromStorage(options) {
   )
   const match = { ...loaded.match, presentationSpeedProfile }
 
-  let surfacedAction = null
-  const surfaced = surfacePersistedNeuralRecoveryTerminal({
-    recovery: options.recovery,
+  const recoverySurface = surfacePersistedNeuralRecoveryTerminal({
+    recovery: ctx.recovery,
     neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
     hasMatchSetup: Boolean(loaded.match.setup),
     applySetupTerminal: () => {
-      surfacedAction = 'setup-restore'
-      resolveNeuralLoadGateSetupTerminal({
-        storage: options.storage,
-        setupSnapshot: options.cloneSetup(loaded.match.setup),
-        clearCurrentMatch: options.clearCurrentMatch,
-        applySetupSnapshot: options.applySetupSnapshot,
-        setupTarget: options.setupTarget,
-      })
-    },
-    openRefreshTerminal: () => {
-      surfacedAction = 'refresh-dialog'
+      ctx.resolveSetupTerminal(ctx.cloneSetup(loaded.match.setup))
     },
   })
 
-  if (surfaced && surfacedAction === 'setup-restore') {
+  if (recoverySurface.surfaced && recoverySurface.action === 'setup-restore') {
     return { kind: 'setup-terminal' }
   }
-  if (surfaced && surfacedAction === 'refresh-dialog') {
+  if (recoverySurface.surfaced && recoverySurface.action === 'refresh-dialog') {
     return { kind: 'refresh-terminal', match, presentationSpeedProfile }
   }
 
@@ -108,44 +68,33 @@ export async function bootstrapCurrentMatchFromStorage(options) {
 }
 
 /**
+ * @param {MatchPageOrchestrationContext} ctx
  * @param {{
- *   storage: Storage
  *   setupSnapshot: object
- *   clearCurrentMatch: (storage: Storage) => void
- *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
- *   setupTarget: object
+ *   releaseInFlightAfterGate?: boolean
  * }} options
+ * @returns {Promise<{ kind: 'success' } | { kind: 'setup-terminal' }>}
  */
-export function applyNeuralLoadGateSetupTerminalForPage(options) {
-  resolveNeuralLoadGateSetupTerminal(options)
-}
-
-export async function runMatchEntryNeuralLoadGateForPage(options) {
+export async function runMatchEntryNeuralLoadGateForPage(ctx, options) {
   const releaseInFlightAfterGate = options.releaseInFlightAfterGate ?? false
-  options.setMatchNeuralLoadGateInFlight(true)
+  ctx.setMatchNeuralLoadGateInFlight(true)
   try {
     const gate = await runMatchNeuralLoadGate(options.setupSnapshot, {
-      loadModel: options.loadModel,
+      loadModel: ctx.loadModel,
     })
     if (!gate.ok) {
-      resolveNeuralLoadGateSetupTerminal({
-        storage: options.storage,
-        setupSnapshot: options.setupSnapshot,
-        clearCurrentMatch: options.clearCurrentMatch,
-        applySetupSnapshot: options.applySetupSnapshot,
-        setupTarget: options.setupTarget,
-      })
+      ctx.resolveSetupTerminal(options.setupSnapshot)
       if (releaseInFlightAfterGate) {
-        options.setMatchNeuralLoadGateInFlight(false)
+        ctx.setMatchNeuralLoadGateInFlight(false)
       }
       return { kind: 'setup-terminal' }
     }
     if (releaseInFlightAfterGate) {
-      options.setMatchNeuralLoadGateInFlight(false)
+      ctx.setMatchNeuralLoadGateInFlight(false)
     }
     return { kind: 'success' }
   } catch (error) {
-    options.setMatchNeuralLoadGateInFlight(false)
+    ctx.setMatchNeuralLoadGateInFlight(false)
     throw error
   }
 }
@@ -175,20 +124,17 @@ export function buildNewMatchEnvelope(options) {
 }
 
 /**
+ * @param {MatchPageOrchestrationContext} ctx
  * @param {{
  *   match: object | null | undefined
  *   humanPlayerSeatId: string | null | undefined
  *   chooseAction: (ctx: { state: object, seatId: string }) => Promise<object | null> | object | null
- *   recovery: ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
  *   gate: { inFlight: boolean, tryStart(): boolean, finish(): void }
  *   teardown?: () => void
- *   storage: Storage
- *   persistCurrentMatch: (storage: Storage, match: object) => void
- *   applySetupTerminal: (setupSnapshot: object) => void
  * }} options
  * @param {{ maxActions?: number, yieldEvery?: number }} [runOptions]
  */
-export async function runHeadlessMatchCompletionForPage(options, runOptions = {}) {
+export async function runHeadlessMatchCompletionForPage(ctx, options, runOptions = {}) {
   const match = options.match
   const humanPlayerSeatId = options.humanPlayerSeatId
 
@@ -232,12 +178,12 @@ export async function runHeadlessMatchCompletionForPage(options, runOptions = {}
 
     let nextMatch = attachNeuralRecoverySnapshotToMatch(
       { ...match, state: result.state },
-      options.recovery,
+      ctx.recovery,
     )
     if ('neuralRecoveryByModelId' in nextMatch) {
       delete nextMatch.neuralRecoveryByModelId
     }
-    options.persistCurrentMatch(options.storage, nextMatch)
+    ctx.persistCurrentMatch(ctx.storage, nextMatch)
     return { kind: 'completed', match: nextMatch }
   } catch (error) {
     if (!(error instanceof NeuralRecoveryTerminalError) || !match) {
@@ -250,13 +196,13 @@ export async function runHeadlessMatchCompletionForPage(options, runOptions = {}
     })
 
     if (ux.action === 'setup-restore') {
-      options.applySetupTerminal(match.setup)
+      ctx.applySetupTerminal(match.setup)
       return { kind: 'setup-terminal' }
     }
 
     if (ux.action === 'refresh-dialog') {
-      const nextMatch = attachNeuralRecoverySnapshotToMatch(match, options.recovery)
-      options.persistCurrentMatch(options.storage, nextMatch)
+      const nextMatch = attachNeuralRecoverySnapshotToMatch(match, ctx.recovery)
+      ctx.persistCurrentMatch(ctx.storage, nextMatch)
       return {
         kind: 'refresh-terminal',
         match: nextMatch,

--- a/src/features/dungeon-runner/matchPageOrchestration.js
+++ b/src/features/dungeon-runner/matchPageOrchestration.js
@@ -1,0 +1,271 @@
+import { NeuralRecoveryTerminalError } from './nn/chooseWithRecovery.js'
+import {
+  resolveNeuralLoadGateSetupTerminal,
+  runMatchNeuralLoadGate,
+} from './nn/matchNeuralLoadGate.js'
+import { CURRENT_MATCH_SCHEMA_VERSION, loadCurrentMatch } from './persistence/currentMatch.js'
+import { surfacePersistedNeuralRecoveryTerminal } from './ui/headlessNeuralRecoveryPersistence.js'
+import { materializeNewMatchState } from './setup/materializeNewMatchState.js'
+import {
+  attachNeuralRecoverySnapshotToMatch,
+  shouldRunHeadlessMatchCompletion,
+} from './ui/headlessNeuralRecoveryPersistence.js'
+import { resolveNeuralRecoveryTerminalUx } from './ui/neuralSeatRecoveryView.js'
+import { runMaybeHeadlessMatchCompletionFromState } from './ui/headlessMatchCompletionRunner.js'
+
+/**
+ * @param {{
+ *   setupSnapshot: object
+ *   loadModel: (modelId: string) => Promise<void>
+ *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
+ *   releaseInFlightAfterGate?: boolean
+ *   storage: Storage
+ *   clearCurrentMatch: (storage: Storage) => void
+ *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
+ *   setupTarget: object
+ * }} options
+ * @returns {Promise<{ kind: 'success' } | { kind: 'setup-terminal' }>}
+ */
+function resolvePresentationSpeedProfile(profile) {
+  if (profile === 'brisk' || profile === 'cinematic') {
+    return profile
+  }
+  return 'cinematic'
+}
+
+/**
+ * @param {{
+ *   storage: Storage
+ *   loadModel: (modelId: string) => Promise<void>
+ *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
+ *   clearCurrentMatch: (storage: Storage) => void
+ *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
+ *   setupTarget: object
+ *   cloneSetup: (setup: object) => object
+ *   recovery: ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
+ * }} options
+ * @returns {Promise<
+ *   { kind: 'no-saved-match' }
+ *   | { kind: 'setup-terminal' }
+ *   | { kind: 'refresh-terminal', match: object, presentationSpeedProfile: string }
+ *   | { kind: 'resume', match: object, presentationSpeedProfile: string }
+ * >}
+ */
+export async function bootstrapCurrentMatchFromStorage(options) {
+  const loaded = loadCurrentMatch(options.storage)
+  if (!loaded.ok) {
+    return { kind: 'no-saved-match' }
+  }
+
+  const setupSnapshot = options.cloneSetup(loaded.match.setup)
+  const gateResult = await runMatchEntryNeuralLoadGateForPage({
+    setupSnapshot,
+    loadModel: options.loadModel,
+    setMatchNeuralLoadGateInFlight: options.setMatchNeuralLoadGateInFlight,
+    releaseInFlightAfterGate: true,
+    storage: options.storage,
+    clearCurrentMatch: options.clearCurrentMatch,
+    applySetupSnapshot: options.applySetupSnapshot,
+    setupTarget: options.setupTarget,
+  })
+  if (gateResult.kind === 'setup-terminal') {
+    return { kind: 'setup-terminal' }
+  }
+
+  const presentationSpeedProfile = resolvePresentationSpeedProfile(
+    loaded.match.presentationSpeedProfile,
+  )
+  const match = { ...loaded.match, presentationSpeedProfile }
+
+  let surfacedAction = null
+  const surfaced = surfacePersistedNeuralRecoveryTerminal({
+    recovery: options.recovery,
+    neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
+    hasMatchSetup: Boolean(loaded.match.setup),
+    applySetupTerminal: () => {
+      surfacedAction = 'setup-restore'
+      resolveNeuralLoadGateSetupTerminal({
+        storage: options.storage,
+        setupSnapshot: options.cloneSetup(loaded.match.setup),
+        clearCurrentMatch: options.clearCurrentMatch,
+        applySetupSnapshot: options.applySetupSnapshot,
+        setupTarget: options.setupTarget,
+      })
+    },
+    openRefreshTerminal: () => {
+      surfacedAction = 'refresh-dialog'
+    },
+  })
+
+  if (surfaced && surfacedAction === 'setup-restore') {
+    return { kind: 'setup-terminal' }
+  }
+  if (surfaced && surfacedAction === 'refresh-dialog') {
+    return { kind: 'refresh-terminal', match, presentationSpeedProfile }
+  }
+
+  return { kind: 'resume', match, presentationSpeedProfile }
+}
+
+/**
+ * @param {{
+ *   storage: Storage
+ *   setupSnapshot: object
+ *   clearCurrentMatch: (storage: Storage) => void
+ *   applySetupSnapshot: (setupTarget: object, setupSnapshot: object) => void
+ *   setupTarget: object
+ * }} options
+ */
+export function applyNeuralLoadGateSetupTerminalForPage(options) {
+  resolveNeuralLoadGateSetupTerminal(options)
+}
+
+export async function runMatchEntryNeuralLoadGateForPage(options) {
+  const releaseInFlightAfterGate = options.releaseInFlightAfterGate ?? false
+  options.setMatchNeuralLoadGateInFlight(true)
+  try {
+    const gate = await runMatchNeuralLoadGate(options.setupSnapshot, {
+      loadModel: options.loadModel,
+    })
+    if (!gate.ok) {
+      resolveNeuralLoadGateSetupTerminal({
+        storage: options.storage,
+        setupSnapshot: options.setupSnapshot,
+        clearCurrentMatch: options.clearCurrentMatch,
+        applySetupSnapshot: options.applySetupSnapshot,
+        setupTarget: options.setupTarget,
+      })
+      if (releaseInFlightAfterGate) {
+        options.setMatchNeuralLoadGateInFlight(false)
+      }
+      return { kind: 'setup-terminal' }
+    }
+    if (releaseInFlightAfterGate) {
+      options.setMatchNeuralLoadGateInFlight(false)
+    }
+    return { kind: 'success' }
+  } catch (error) {
+    options.setMatchNeuralLoadGateInFlight(false)
+    throw error
+  }
+}
+
+/**
+ * @param {{
+ *   setupSnapshot: object
+ *   seed: number
+ *   id: string
+ *   presentationSpeedProfile: string
+ *   preservedBotLabels?: string[]
+ * }} options
+ */
+export function buildNewMatchEnvelope(options) {
+  const materializeOptions =
+    options.preservedBotLabels?.length > 0
+      ? { preservedBotLabels: options.preservedBotLabels }
+      : {}
+  return {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: options.id,
+    setup: options.setupSnapshot,
+    state: materializeNewMatchState(options.setupSnapshot, options.seed, materializeOptions),
+    history: [],
+    presentationSpeedProfile: options.presentationSpeedProfile,
+  }
+}
+
+/**
+ * @param {{
+ *   match: object | null | undefined
+ *   humanPlayerSeatId: string | null | undefined
+ *   chooseAction: (ctx: { state: object, seatId: string }) => Promise<object | null> | object | null
+ *   recovery: ReturnType<import('./nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
+ *   gate: { inFlight: boolean, tryStart(): boolean, finish(): void }
+ *   teardown?: () => void
+ *   storage: Storage
+ *   persistCurrentMatch: (storage: Storage, match: object) => void
+ *   applySetupTerminal: (setupSnapshot: object) => void
+ * }} options
+ * @param {{ maxActions?: number, yieldEvery?: number }} [runOptions]
+ */
+export async function runHeadlessMatchCompletionForPage(options, runOptions = {}) {
+  const match = options.match
+  const humanPlayerSeatId = options.humanPlayerSeatId
+
+  if (!match) {
+    return { kind: 'skipped', reason: 'NO_MATCH' }
+  }
+  if (!humanPlayerSeatId) {
+    return { kind: 'skipped', reason: 'NO_HUMAN' }
+  }
+  if (!shouldRunHeadlessMatchCompletion(match, humanPlayerSeatId)) {
+    if (match.neuralRecoveryByModelId) {
+      return { kind: 'skipped', reason: 'REFRESH_DEFERRED' }
+    }
+    return { kind: 'skipped', reason: 'NOT_NEEDED' }
+  }
+
+  try {
+    const result = await runMaybeHeadlessMatchCompletionFromState(match.state, {
+      humanPlayerSeatId,
+      chooseAction: options.chooseAction,
+      gate: options.gate,
+      afterFlightStart: options.teardown,
+      maxActions: runOptions.maxActions,
+      yieldEvery: runOptions.yieldEvery,
+    })
+
+    if (!result.ran) {
+      if (result.skippedReason === 'IN_FLIGHT') {
+        return { kind: 'skipped', reason: 'IN_FLIGHT' }
+      }
+      return { kind: 'skipped', reason: 'NOT_NEEDED' }
+    }
+
+    if (result.failed) {
+      return {
+        kind: 'failed',
+        errorCode: result.errorCode,
+        actionCount: result.actionCount,
+      }
+    }
+
+    let nextMatch = attachNeuralRecoverySnapshotToMatch(
+      { ...match, state: result.state },
+      options.recovery,
+    )
+    if ('neuralRecoveryByModelId' in nextMatch) {
+      delete nextMatch.neuralRecoveryByModelId
+    }
+    options.persistCurrentMatch(options.storage, nextMatch)
+    return { kind: 'completed', match: nextMatch }
+  } catch (error) {
+    if (!(error instanceof NeuralRecoveryTerminalError) || !match) {
+      throw error
+    }
+
+    const ux = resolveNeuralRecoveryTerminalUx({
+      terminal: error.terminal,
+      hasMatchSetup: Boolean(match.setup),
+    })
+
+    if (ux.action === 'setup-restore') {
+      options.applySetupTerminal(match.setup)
+      return { kind: 'setup-terminal' }
+    }
+
+    if (ux.action === 'refresh-dialog') {
+      const nextMatch = attachNeuralRecoverySnapshotToMatch(match, options.recovery)
+      options.persistCurrentMatch(options.storage, nextMatch)
+      return {
+        kind: 'refresh-terminal',
+        match: nextMatch,
+        modelId: error.modelId,
+        terminal: error.terminal,
+        failureKind: error.failureKind,
+      }
+    }
+
+    throw error
+  }
+}

--- a/src/features/dungeon-runner/matchPageOrchestration.test.js
+++ b/src/features/dungeon-runner/matchPageOrchestration.test.js
@@ -1,0 +1,870 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chooseRandombotAction } from './bots/randombot.js'
+import {
+  MATCH_PHASES,
+  createInitialMatchState,
+  getLegalActions,
+} from './engine/kernel.js'
+import { createChooseNnActionWithRecovery } from './nn/chooseWithRecovery.js'
+import { NN_FAILURE_KIND } from './nn/runtime.js'
+import {
+  NEURAL_RECOVERY_TERMINAL,
+  createNeuralRuntimeRecoveryCoordinator,
+} from './nn/recovery.js'
+import { applySetupSnapshot } from './setup/state.js'
+import {
+  CURRENT_MATCH_SCHEMA_VERSION,
+  clearCurrentMatch,
+  loadCurrentMatch,
+  persistCurrentMatch,
+} from './persistence/currentMatch.js'
+import {
+  HEADLESS_COMPLETION_ERROR_CODES,
+  createHeadlessCompletionFlightGate,
+  shouldBlockLiveAiPipelineWhileHeadless,
+  shouldShowFinishingMatchOverlay,
+} from './ui/headlessMatchCompletionRunner.js'
+import { createLivePlayActionChooser } from './ui/livePlayActionChooser.js'
+import { needsHeadlessCompletion } from './ui/humanEliminationCompletionPolicy.js'
+import {
+  applyNeuralLoadGateSetupTerminalForPage,
+  bootstrapCurrentMatchFromStorage,
+  buildNewMatchEnvelope,
+  runHeadlessMatchCompletionForPage,
+  runMatchEntryNeuralLoadGateForPage,
+} from './matchPageOrchestration.js'
+import { materializeNewMatchState } from './setup/materializeNewMatchState.js'
+
+const FOUR_PLAYER_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'randombot' }, { type: 'randombot' }],
+}
+
+const NN_TWO_PLAYER_SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'nn', modelId: 'latest' }],
+}
+
+const MIXED_SETUP = {
+  totalSeats: 4,
+  opponents: [{ type: 'randombot' }, { type: 'nn', modelId: 'latest' }, { type: 'randombot' }],
+}
+
+function createMemoryStorage() {
+  const map = new Map()
+  return {
+    getItem(key) {
+      return map.has(key) ? map.get(key) : null
+    },
+    setItem(key, value) {
+      map.set(key, String(value))
+    },
+    removeItem(key) {
+      map.delete(key)
+    },
+  }
+}
+
+function seatByRole(state, roleType) {
+  return state.seats.find((seat) => seat.role.type === roleType)
+}
+
+function humanEliminatedPickState(state, humanSeatId) {
+  const opponent = state.seats.find(
+    (seat) => seat.id !== humanSeatId && !state.scoreboard[seat.id]?.eliminated,
+  )
+  assert.ok(opponent)
+  return {
+    ...state,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    scoreboard: {
+      ...state.scoreboard,
+      [humanSeatId]: {
+        ...state.scoreboard[humanSeatId],
+        lives: 0,
+        eliminated: true,
+        successes: 0,
+      },
+    },
+    turn: { ...state.turn, activeSeatId: opponent.id, turnNumber: state.turn.turnNumber + 1 },
+    pickAdventurer: {
+      ...state.pickAdventurer,
+      activeSeatId: opponent.id,
+    },
+  }
+}
+
+function buildMatchEnvelope(setup, state, overrides = {}) {
+  return {
+    schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+    id: overrides.id ?? 'm-headless-orchestration',
+    setup,
+    state,
+    history: state.history ?? [],
+    ...overrides,
+  }
+}
+
+function createPageDeps(overrides = {}) {
+  const storage = overrides.storage ?? createMemoryStorage()
+  const recovery = overrides.recovery ?? createNeuralRuntimeRecoveryCoordinator()
+  const gate = overrides.gate ?? createHeadlessCompletionFlightGate()
+  const setupTarget = overrides.setupTarget ?? { totalSeats: 2, opponents: [] }
+  let setupTerminalCalls = 0
+
+  return {
+    storage,
+    recovery,
+    gate,
+    setupTarget,
+    setupTerminalCalls: () => setupTerminalCalls,
+    deps: {
+      match: overrides.match,
+      humanPlayerSeatId: overrides.humanPlayerSeatId,
+      chooseAction: overrides.chooseAction,
+      recovery,
+      gate,
+      teardown: overrides.teardown ?? (() => {}),
+      storage,
+      persistCurrentMatch,
+      applySetupTerminal: overrides.applySetupTerminal ?? ((setupSnapshot) => {
+        setupTerminalCalls += 1
+        applyNeuralLoadGateSetupTerminalForPage({
+          storage,
+          setupSnapshot,
+          clearCurrentMatch,
+          applySetupSnapshot,
+          setupTarget,
+        })
+      }),
+    },
+  }
+}
+
+function createMatchEntryGateDeps(overrides = {}) {
+  const storage = overrides.storage ?? createMemoryStorage()
+  const setupTarget = overrides.setupTarget ?? { totalSeats: 2, opponents: [] }
+  const inFlightCalls = []
+  const loadCalls = []
+
+  return {
+    storage,
+    setupTarget,
+    inFlightCalls,
+    loadCalls,
+    deps: {
+      setupSnapshot: overrides.setupSnapshot ?? NN_TWO_PLAYER_SETUP,
+      loadModel: overrides.loadModel ?? ((modelId) => {
+        loadCalls.push(modelId)
+        return Promise.resolve()
+      }),
+      setMatchNeuralLoadGateInFlight: (inFlight) => {
+        inFlightCalls.push(inFlight)
+      },
+      releaseInFlightAfterGate: overrides.releaseInFlightAfterGate,
+      storage,
+      clearCurrentMatch,
+      applySetupSnapshot,
+      setupTarget,
+    },
+  }
+}
+
+test('runMatchEntryNeuralLoadGateForPage returns success when every nn model loads', async () => {
+  const { deps, inFlightCalls, loadCalls } = createMatchEntryGateDeps()
+
+  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.equal(result.kind, 'success')
+  assert.deepEqual(loadCalls, ['latest'])
+  assert.deepEqual(inFlightCalls, [true])
+})
+
+test('runMatchEntryNeuralLoadGateForPage succeeds without load attempts when setup has no nn seats', async () => {
+  const { deps, inFlightCalls, loadCalls } = createMatchEntryGateDeps({
+    setupSnapshot: {
+      totalSeats: 2,
+      opponents: [{ type: 'randombot' }],
+    },
+  })
+
+  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.equal(result.kind, 'success')
+  assert.deepEqual(loadCalls, [])
+  assert.deepEqual(inFlightCalls, [true])
+})
+
+test('runMatchEntryNeuralLoadGateForPage returns setup-terminal and clears persisted match', async () => {
+  const storage = createMemoryStorage()
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  const setupSnapshot = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'missing-model' }],
+  }
+  const match = buildMatchEnvelope(setupSnapshot, createInitialMatchState(setupSnapshot, { seed: 1 }), {
+    id: 'm-entry-gate-setup',
+  })
+  persistCurrentMatch(storage, match)
+  const { deps, inFlightCalls } = createMatchEntryGateDeps({
+    storage,
+    setupTarget,
+    setupSnapshot,
+    loadModel: async () => {
+      throw new Error('missing model')
+    },
+  })
+
+  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.deepEqual(setupTarget, setupSnapshot)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+  assert.deepEqual(inFlightCalls, [true])
+})
+
+test('runMatchEntryNeuralLoadGateForPage keeps in-flight until page release by default', async () => {
+  const { deps, inFlightCalls } = createMatchEntryGateDeps()
+
+  await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.deepEqual(inFlightCalls, [true])
+})
+
+test('runMatchEntryNeuralLoadGateForPage releases in-flight after gate when requested', async () => {
+  const { deps, inFlightCalls } = createMatchEntryGateDeps({ releaseInFlightAfterGate: true })
+
+  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.equal(result.kind, 'success')
+  assert.deepEqual(inFlightCalls, [true, false])
+})
+
+test('applyNeuralLoadGateSetupTerminalForPage restores setup and clears persisted match', () => {
+  const storage = createMemoryStorage()
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  const setupSnapshot = NN_TWO_PLAYER_SETUP
+  persistCurrentMatch(
+    storage,
+    buildMatchEnvelope(setupSnapshot, createInitialMatchState(setupSnapshot, { seed: 1 }), {
+      id: 'm-setup-terminal-page',
+    }),
+  )
+
+  applyNeuralLoadGateSetupTerminalForPage({
+    storage,
+    setupSnapshot,
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget,
+  })
+
+  assert.deepEqual(setupTarget, setupSnapshot)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+})
+
+function createBootstrapDeps(overrides = {}) {
+  const storage = overrides.storage ?? createMemoryStorage()
+  const setupTarget = overrides.setupTarget ?? { totalSeats: 2, opponents: [] }
+  const inFlightCalls = []
+  const loadCalls = []
+  const recovery = overrides.recovery ?? createNeuralRuntimeRecoveryCoordinator()
+  const importCalls = []
+  const wrappedRecovery = {
+    ...recovery,
+    importSnapshot(snapshot) {
+      importCalls.push(snapshot)
+      return recovery.importSnapshot(snapshot)
+    },
+  }
+
+  return {
+    storage,
+    setupTarget,
+    inFlightCalls,
+    loadCalls,
+    importCalls,
+    recovery: wrappedRecovery,
+    deps: {
+      storage,
+      loadModel: overrides.loadModel ?? ((modelId) => {
+        loadCalls.push(modelId)
+        return Promise.resolve()
+      }),
+      setMatchNeuralLoadGateInFlight: (inFlight) => {
+        inFlightCalls.push(inFlight)
+      },
+      clearCurrentMatch,
+      applySetupSnapshot,
+      setupTarget,
+      cloneSetup: overrides.cloneSetup ?? ((setup) => structuredClone(setup)),
+      recovery: wrappedRecovery,
+    },
+  }
+}
+
+test('bootstrapCurrentMatchFromStorage returns no-saved-match when storage is empty', async () => {
+  const { deps } = createBootstrapDeps()
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'no-saved-match')
+})
+
+test('bootstrapCurrentMatchFromStorage returns setup-terminal when neural load gate fails', async () => {
+  const storage = createMemoryStorage()
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  const setupSnapshot = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'missing-model' }],
+  }
+  const match = buildMatchEnvelope(setupSnapshot, createInitialMatchState(setupSnapshot, { seed: 1 }), {
+    id: 'm-bootstrap-gate-setup',
+  })
+  persistCurrentMatch(storage, match)
+  const { deps, inFlightCalls, importCalls } = createBootstrapDeps({
+    storage,
+    setupTarget,
+    loadModel: async () => {
+      throw new Error('missing model')
+    },
+  })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.deepEqual(setupTarget, setupSnapshot)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+  assert.deepEqual(inFlightCalls, [true, false])
+  assert.equal(importCalls.length, 0)
+})
+
+test('runMatchEntryNeuralLoadGateForPage releases in-flight on setup-terminal when requested', async () => {
+  const { deps, inFlightCalls } = createMatchEntryGateDeps({
+    releaseInFlightAfterGate: true,
+    loadModel: async () => {
+      throw new Error('missing model')
+    },
+  })
+
+  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.deepEqual(inFlightCalls, [true, false])
+})
+
+test('bootstrapCurrentMatchFromStorage returns setup-terminal for persisted SETUP recovery', async () => {
+  const storage = createMemoryStorage()
+  const setupTarget = { totalSeats: 2, opponents: [] }
+  const setupSnapshot = NN_TWO_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 201 })
+  const match = buildMatchEnvelope(setupSnapshot, initial, {
+    id: 'm-bootstrap-persisted-setup',
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 3,
+        inferAttempts: 0,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.SETUP,
+      },
+    },
+  })
+  persistCurrentMatch(storage, match)
+  const { deps, importCalls } = createBootstrapDeps({ storage, setupTarget })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.deepEqual(setupTarget, setupSnapshot)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+  assert.equal(importCalls.length, 1)
+})
+
+test('bootstrapCurrentMatchFromStorage returns refresh-terminal for persisted REFRESH recovery', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = NN_TWO_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 202 })
+  const match = buildMatchEnvelope(setupSnapshot, initial, {
+    id: 'm-bootstrap-persisted-refresh',
+    presentationSpeedProfile: 'brisk',
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 0,
+        inferAttempts: 3,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.REFRESH,
+      },
+    },
+  })
+  persistCurrentMatch(storage, match)
+  const { deps } = createBootstrapDeps({ storage })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'refresh-terminal')
+  assert.equal(result.presentationSpeedProfile, 'brisk')
+  assert.equal(result.match.id, 'm-bootstrap-persisted-refresh')
+  assert.equal(
+    result.match.neuralRecoveryByModelId.latest.terminal,
+    NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(
+    loaded.match.neuralRecoveryByModelId.latest.terminal,
+    NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+})
+
+test('bootstrapCurrentMatchFromStorage returns resume with normalized presentation pace', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = FOUR_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 203 })
+  const match = buildMatchEnvelope(setupSnapshot, initial, {
+    id: 'm-bootstrap-resume',
+  })
+  delete match.presentationSpeedProfile
+  persistCurrentMatch(storage, match)
+  const { deps, loadCalls, importCalls } = createBootstrapDeps({ storage })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'resume')
+  assert.equal(result.presentationSpeedProfile, 'cinematic')
+  assert.equal(result.match.id, 'm-bootstrap-resume')
+  assert.equal(result.match.presentationSpeedProfile, 'cinematic')
+  assert.deepEqual(loadCalls, [])
+  assert.equal(importCalls.length, 0)
+})
+
+test('bootstrapCurrentMatchFromStorage returns resume preserving brisk presentation pace', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = FOUR_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 206 })
+  persistCurrentMatch(
+    storage,
+    buildMatchEnvelope(setupSnapshot, initial, {
+      id: 'm-bootstrap-resume-brisk',
+      presentationSpeedProfile: 'brisk',
+    }),
+  )
+  const { deps } = createBootstrapDeps({ storage })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'resume')
+  assert.equal(result.presentationSpeedProfile, 'brisk')
+  assert.equal(result.match.presentationSpeedProfile, 'brisk')
+})
+
+test('bootstrapCurrentMatchFromStorage gate failure does not import persisted recovery', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'missing-model' }],
+  }
+  const initial = createInitialMatchState(setupSnapshot, { seed: 208 })
+  persistCurrentMatch(
+    storage,
+    buildMatchEnvelope(setupSnapshot, initial, {
+      neuralRecoveryByModelId: {
+        latest: {
+          loadAttempts: 0,
+          inferAttempts: 3,
+          recovering: false,
+          terminal: NEURAL_RECOVERY_TERMINAL.REFRESH,
+        },
+      },
+    }),
+  )
+  const { deps, importCalls } = createBootstrapDeps({
+    storage,
+    loadModel: async () => {
+      throw new Error('missing model')
+    },
+  })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.equal(importCalls.length, 0)
+})
+
+test('bootstrapCurrentMatchFromStorage runs load gate before importing persisted recovery', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = NN_TWO_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 204 })
+  const match = buildMatchEnvelope(setupSnapshot, initial, {
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 0,
+        inferAttempts: 3,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.REFRESH,
+      },
+    },
+  })
+  persistCurrentMatch(storage, match)
+  const order = []
+  const { deps } = createBootstrapDeps({
+    storage,
+    loadModel: async (modelId) => {
+      order.push(['load', modelId])
+    },
+    recovery: createNeuralRuntimeRecoveryCoordinator(),
+  })
+  const originalImport = deps.recovery.importSnapshot.bind(deps.recovery)
+  deps.recovery.importSnapshot = (snapshot) => {
+    order.push(['import', snapshot])
+    return originalImport(snapshot)
+  }
+
+  await bootstrapCurrentMatchFromStorage(deps)
+  assert.deepEqual(order, [['load', 'latest'], ['import', match.neuralRecoveryByModelId]])
+})
+
+test('bootstrapCurrentMatchFromStorage releases in-flight after gate before recovery', async () => {
+  const storage = createMemoryStorage()
+  const setupSnapshot = NN_TWO_PLAYER_SETUP
+  const initial = createInitialMatchState(setupSnapshot, { seed: 205 })
+  persistCurrentMatch(storage, buildMatchEnvelope(setupSnapshot, initial))
+  const { deps, inFlightCalls } = createBootstrapDeps({ storage })
+
+  const result = await bootstrapCurrentMatchFromStorage(deps)
+  assert.equal(result.kind, 'resume')
+  assert.deepEqual(inFlightCalls, [true, false])
+})
+
+test('runMatchEntryNeuralLoadGateForPage releases in-flight when gate throws unexpectedly', async () => {
+  const inFlightCalls = []
+  const deps = {
+    setupSnapshot: NN_TWO_PLAYER_SETUP,
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      inFlightCalls.push(inFlight)
+    },
+    releaseInFlightAfterGate: false,
+    storage: createMemoryStorage(),
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget: { totalSeats: 2, opponents: [] },
+  }
+
+  await assert.rejects(
+    () => runMatchEntryNeuralLoadGateForPage(deps),
+    /loadModel required/,
+  )
+  assert.deepEqual(inFlightCalls, [true, false])
+})
+
+test('buildNewMatchEnvelope uses materializeNewMatchState for initial state', () => {
+  const setupSnapshot = MIXED_SETUP
+  const seed = 4242
+  const envelope = buildNewMatchEnvelope({
+    setupSnapshot,
+    seed,
+    id: 'match-test',
+    presentationSpeedProfile: 'cinematic',
+  })
+  assert.equal(envelope.schemaVersion, CURRENT_MATCH_SCHEMA_VERSION)
+  assert.equal(envelope.id, 'match-test')
+  assert.deepEqual(envelope.setup, setupSnapshot)
+  assert.deepEqual(envelope.state, materializeNewMatchState(setupSnapshot, seed))
+  assert.deepEqual(envelope.history, [])
+  assert.equal(envelope.presentationSpeedProfile, 'cinematic')
+})
+
+test('buildNewMatchEnvelope forwards preservedBotLabels for rematch materialization', () => {
+  const setupSnapshot = MIXED_SETUP
+  const seed = 3333
+  const initial = materializeNewMatchState(setupSnapshot, 8080)
+  const preservedBotLabels = initial.seats
+    .filter((seat) => seat.role.type !== 'human' && seat.label)
+    .map((seat) => seat.label)
+
+  const envelope = buildNewMatchEnvelope({
+    setupSnapshot,
+    seed,
+    id: 'match-rematch',
+    presentationSpeedProfile: 'brisk',
+    preservedBotLabels,
+  })
+  assert.deepEqual(
+    envelope.state,
+    materializeNewMatchState(setupSnapshot, seed, { preservedBotLabels }),
+  )
+})
+
+test('buildNewMatchEnvelope omits preservedBotLabels when rematch has none', () => {
+  const setupSnapshot = MIXED_SETUP
+  const seed = 4444
+  const envelope = buildNewMatchEnvelope({
+    setupSnapshot,
+    seed,
+    id: 'match-rematch-empty-labels',
+    presentationSpeedProfile: 'brisk',
+    preservedBotLabels: [],
+  })
+  assert.deepEqual(envelope.state, materializeNewMatchState(setupSnapshot, seed))
+})
+
+test('runHeadlessMatchCompletionForPage skips when match is missing', async () => {
+  const { deps } = createPageDeps({
+    match: null,
+    humanPlayerSeatId: 'seat-human',
+    chooseAction: async () => null,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'NO_MATCH')
+})
+
+test('runHeadlessMatchCompletionForPage skips when human seat is missing', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 99 })
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
+    humanPlayerSeatId: null,
+    chooseAction: async () => null,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'NO_HUMAN')
+})
+
+test('runHeadlessMatchCompletionForPage skips when headless is not needed', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 100 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
+    humanPlayerSeatId: human.id,
+    chooseAction: async () => null,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'NOT_NEEDED')
+})
+
+test('runHeadlessMatchCompletionForPage skips when persisted neural recovery is REFRESH', async () => {
+  const initial = createInitialMatchState(NN_TWO_PLAYER_SETUP, { seed: 101 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+  const match = buildMatchEnvelope(NN_TWO_PLAYER_SETUP, start, {
+    neuralRecoveryByModelId: {
+      latest: {
+        loadAttempts: 0,
+        inferAttempts: 3,
+        recovering: false,
+        terminal: NEURAL_RECOVERY_TERMINAL.REFRESH,
+      },
+    },
+  })
+  const { deps } = createPageDeps({
+    match,
+    humanPlayerSeatId: human.id,
+    chooseAction: async () => null,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'REFRESH_DEFERRED')
+})
+
+test('runHeadlessMatchCompletionForPage skips duplicate start while in flight', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 102 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  const gate = createHeadlessCompletionFlightGate()
+  assert.equal(gate.tryStart(), true)
+  let teardownCalls = 0
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
+    humanPlayerSeatId: human.id,
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    gate,
+    teardown: () => {
+      teardownCalls += 1
+    },
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'IN_FLIGHT')
+  assert.equal(teardownCalls, 0)
+  gate.finish()
+})
+
+test('runHeadlessMatchCompletionForPage does not teardown when skipped before flight', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 1025 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  let teardownCalls = 0
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
+    humanPlayerSeatId: human.id,
+    chooseAction: async () => null,
+    teardown: () => {
+      teardownCalls += 1
+    },
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'skipped')
+  assert.equal(result.reason, 'NOT_NEEDED')
+  assert.equal(teardownCalls, 0)
+})
+
+test('runHeadlessMatchCompletionForPage teardown runs after flight start then clears gate', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 103 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  const gate = createHeadlessCompletionFlightGate()
+  let sawOverlayDuringTeardown = false
+  let teardownCalls = 0
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
+    humanPlayerSeatId: human.id,
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+    gate,
+    teardown: () => {
+      teardownCalls += 1
+      assert.equal(gate.inFlight, true)
+      assert.equal(shouldShowFinishingMatchOverlay(gate.inFlight), true)
+      assert.equal(shouldBlockLiveAiPipelineWhileHeadless(gate.inFlight), true)
+      sawOverlayDuringTeardown = true
+    },
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'completed')
+  assert.equal(teardownCalls, 1)
+  assert.equal(sawOverlayDuringTeardown, true)
+  assert.equal(gate.inFlight, false)
+  assert.equal(shouldShowFinishingMatchOverlay(gate.inFlight), false)
+})
+
+test('runHeadlessMatchCompletionForPage completes and persists updated match', async () => {
+  const storage = createMemoryStorage()
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 103 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  const match = buildMatchEnvelope(FOUR_PLAYER_SETUP, start, { id: 'm-headless-complete' })
+  persistCurrentMatch(storage, match)
+  const { deps } = createPageDeps({
+    storage,
+    match,
+    humanPlayerSeatId: human.id,
+    chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'completed')
+  assert.equal(result.match.state.phase, MATCH_PHASES.MATCH_OVER)
+  assert.equal('neuralRecoveryByModelId' in result.match, false)
+
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(loaded.match.id, 'm-headless-complete')
+  assert.equal(loaded.match.state.phase, MATCH_PHASES.MATCH_OVER)
+})
+
+test('runHeadlessMatchCompletionForPage returns setup-terminal and clears current match', async () => {
+  const storage = createMemoryStorage()
+  const setupTarget = { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] }
+  const initial = createInitialMatchState(NN_TWO_PLAYER_SETUP, { seed: 104 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  const match = buildMatchEnvelope(NN_TWO_PLAYER_SETUP, start, { id: 'm-headless-setup' })
+  persistCurrentMatch(storage, match)
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ loadMaxAttempts: 1 })
+  const chooseAction = createLivePlayActionChooser({
+    nnRecovery: recovery,
+    nnRuntimeOptions: () => ({}),
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction: async () => ({ ok: false, kind: NN_FAILURE_KIND.LOAD, modelId: 'latest' }),
+      resetRuntimeForModel: () => {},
+    }),
+  })
+  const { deps, setupTerminalCalls, setupTarget: target } = createPageDeps({
+    storage,
+    setupTarget,
+    recovery,
+    match,
+    humanPlayerSeatId: human.id,
+    chooseAction,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'setup-terminal')
+  assert.equal(setupTerminalCalls(), 1)
+  assert.deepEqual(target, NN_TWO_PLAYER_SETUP)
+  assert.equal(loadCurrentMatch(storage).ok, false)
+})
+
+test('runHeadlessMatchCompletionForPage returns refresh-terminal and persists recovery snapshot', async () => {
+  const storage = createMemoryStorage()
+  const initial = createInitialMatchState(NN_TWO_PLAYER_SETUP, { seed: 105 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  const match = buildMatchEnvelope(NN_TWO_PLAYER_SETUP, start, { id: 'm-headless-refresh' })
+  persistCurrentMatch(storage, match)
+  const recovery = createNeuralRuntimeRecoveryCoordinator({ inferMaxAttempts: 1 })
+  const chooseAction = createLivePlayActionChooser({
+    nnRecovery: recovery,
+    nnRuntimeOptions: () => ({}),
+    chooseNnActionWithRecovery: createChooseNnActionWithRecovery({
+      recovery,
+      chooseNnAction: async () => ({ ok: false, kind: NN_FAILURE_KIND.INFER, modelId: 'latest' }),
+      resetRuntimeForModel: () => {},
+    }),
+  })
+  const { deps } = createPageDeps({
+    storage,
+    recovery,
+    match,
+    humanPlayerSeatId: human.id,
+    chooseAction,
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps)
+  assert.equal(result.kind, 'refresh-terminal')
+  assert.equal(result.match.neuralRecoveryByModelId.latest.terminal, NEURAL_RECOVERY_TERMINAL.REFRESH)
+  assert.equal(result.modelId, 'latest')
+
+  const loaded = loadCurrentMatch(storage)
+  assert.equal(loaded.ok, true)
+  assert.equal(
+    loaded.match.neuralRecoveryByModelId.latest.terminal,
+    NEURAL_RECOVERY_TERMINAL.REFRESH,
+  )
+})
+
+test('runHeadlessMatchCompletionForPage returns failed when safety cap is exceeded', async () => {
+  const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 106 })
+  const human = seatByRole(initial, 'human')
+  assert.ok(human)
+  const start = humanEliminatedPickState(initial, human.id)
+  assert.equal(needsHeadlessCompletion(start, human.id), true)
+  const gate = createHeadlessCompletionFlightGate()
+  let teardownCalls = 0
+  const chooseAction = async ({ state, seatId }) => {
+    const legal = getLegalActions(state, { seatId })
+    return legal[0] ?? null
+  }
+  const { deps } = createPageDeps({
+    match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
+    humanPlayerSeatId: human.id,
+    chooseAction,
+    gate,
+    teardown: () => {
+      teardownCalls += 1
+      assert.equal(gate.inFlight, true)
+    },
+  })
+
+  const result = await runHeadlessMatchCompletionForPage(deps, { maxActions: 3 })
+  assert.equal(result.kind, 'failed')
+  assert.equal(result.errorCode, HEADLESS_COMPLETION_ERROR_CODES.SAFETY_CAP)
+  assert.equal(result.actionCount, 3)
+  assert.equal(teardownCalls, 1)
+  assert.equal(gate.inFlight, false)
+})

--- a/src/features/dungeon-runner/matchPageOrchestration.test.js
+++ b/src/features/dungeon-runner/matchPageOrchestration.test.js
@@ -27,13 +27,14 @@ import {
 } from './ui/headlessMatchCompletionRunner.js'
 import { createLivePlayActionChooser } from './ui/livePlayActionChooser.js'
 import { needsHeadlessCompletion } from './ui/humanEliminationCompletionPolicy.js'
+import { resolveNeuralLoadGateSetupTerminal } from './nn/matchNeuralLoadGate.js'
 import {
-  applyNeuralLoadGateSetupTerminalForPage,
   bootstrapCurrentMatchFromStorage,
   buildNewMatchEnvelope,
   runHeadlessMatchCompletionForPage,
   runMatchEntryNeuralLoadGateForPage,
 } from './matchPageOrchestration.js'
+import { createMatchPageOrchestrationContext } from './createMatchPageOrchestrationContext.js'
 import { materializeNewMatchState } from './setup/materializeNewMatchState.js'
 
 const FOUR_PLAYER_SETUP = {
@@ -106,31 +107,27 @@ function buildMatchEnvelope(setup, state, overrides = {}) {
   }
 }
 
-function createPageDeps(overrides = {}) {
+function createPageContext(overrides = {}) {
   const storage = overrides.storage ?? createMemoryStorage()
   const recovery = overrides.recovery ?? createNeuralRuntimeRecoveryCoordinator()
-  const gate = overrides.gate ?? createHeadlessCompletionFlightGate()
   const setupTarget = overrides.setupTarget ?? { totalSeats: 2, opponents: [] }
   let setupTerminalCalls = 0
 
-  return {
+  const ctx = createMatchPageOrchestrationContext({
     storage,
     recovery,
-    gate,
+    loadModel: async () => {},
+    setMatchNeuralLoadGateInFlight: () => {},
+    clearCurrentMatch,
+    persistCurrentMatch,
+    applySetupSnapshot,
     setupTarget,
-    setupTerminalCalls: () => setupTerminalCalls,
-    deps: {
-      match: overrides.match,
-      humanPlayerSeatId: overrides.humanPlayerSeatId,
-      chooseAction: overrides.chooseAction,
-      recovery,
-      gate,
-      teardown: overrides.teardown ?? (() => {}),
-      storage,
-      persistCurrentMatch,
-      applySetupTerminal: overrides.applySetupTerminal ?? ((setupSnapshot) => {
+    cloneSetup: (setup) => structuredClone(setup),
+    applySetupTerminal:
+      overrides.applySetupTerminal ??
+      ((setupSnapshot) => {
         setupTerminalCalls += 1
-        applyNeuralLoadGateSetupTerminalForPage({
+        resolveNeuralLoadGateSetupTerminal({
           storage,
           setupSnapshot,
           clearCurrentMatch,
@@ -138,6 +135,33 @@ function createPageDeps(overrides = {}) {
           setupTarget,
         })
       }),
+  })
+
+  return {
+    storage,
+    recovery,
+    setupTarget,
+    ctx,
+    setupTerminalCalls: () => setupTerminalCalls,
+  }
+}
+
+function createPageDeps(overrides = {}) {
+  const gate = overrides.gate ?? createHeadlessCompletionFlightGate()
+  const { ctx, storage, setupTarget, setupTerminalCalls } = createPageContext(overrides)
+
+  return {
+    storage,
+    gate,
+    setupTarget,
+    setupTerminalCalls,
+    ctx,
+    deps: {
+      match: overrides.match,
+      humanPlayerSeatId: overrides.humanPlayerSeatId,
+      chooseAction: overrides.chooseAction,
+      gate,
+      teardown: overrides.teardown ?? (() => {}),
     },
   }
 }
@@ -148,47 +172,56 @@ function createMatchEntryGateDeps(overrides = {}) {
   const inFlightCalls = []
   const loadCalls = []
 
+  const ctx = createMatchPageOrchestrationContext({
+    storage,
+    recovery: createNeuralRuntimeRecoveryCoordinator(),
+    loadModel:
+      overrides.loadModel ??
+      ((modelId) => {
+        loadCalls.push(modelId)
+        return Promise.resolve()
+      }),
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      inFlightCalls.push(inFlight)
+    },
+    clearCurrentMatch,
+    persistCurrentMatch,
+    applySetupSnapshot,
+    setupTarget,
+    cloneSetup: (setup) => structuredClone(setup),
+  })
+
   return {
     storage,
     setupTarget,
     inFlightCalls,
     loadCalls,
-    deps: {
+    ctx,
+    gateOptions: {
       setupSnapshot: overrides.setupSnapshot ?? NN_TWO_PLAYER_SETUP,
-      loadModel: overrides.loadModel ?? ((modelId) => {
-        loadCalls.push(modelId)
-        return Promise.resolve()
-      }),
-      setMatchNeuralLoadGateInFlight: (inFlight) => {
-        inFlightCalls.push(inFlight)
-      },
       releaseInFlightAfterGate: overrides.releaseInFlightAfterGate,
-      storage,
-      clearCurrentMatch,
-      applySetupSnapshot,
-      setupTarget,
     },
   }
 }
 
 test('runMatchEntryNeuralLoadGateForPage returns success when every nn model loads', async () => {
-  const { deps, inFlightCalls, loadCalls } = createMatchEntryGateDeps()
+  const { ctx, gateOptions, inFlightCalls, loadCalls } = createMatchEntryGateDeps()
 
-  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  const result = await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.equal(result.kind, 'success')
   assert.deepEqual(loadCalls, ['latest'])
   assert.deepEqual(inFlightCalls, [true])
 })
 
 test('runMatchEntryNeuralLoadGateForPage succeeds without load attempts when setup has no nn seats', async () => {
-  const { deps, inFlightCalls, loadCalls } = createMatchEntryGateDeps({
+  const { ctx, gateOptions, inFlightCalls, loadCalls } = createMatchEntryGateDeps({
     setupSnapshot: {
       totalSeats: 2,
       opponents: [{ type: 'randombot' }],
     },
   })
 
-  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  const result = await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.equal(result.kind, 'success')
   assert.deepEqual(loadCalls, [])
   assert.deepEqual(inFlightCalls, [true])
@@ -205,7 +238,7 @@ test('runMatchEntryNeuralLoadGateForPage returns setup-terminal and clears persi
     id: 'm-entry-gate-setup',
   })
   persistCurrentMatch(storage, match)
-  const { deps, inFlightCalls } = createMatchEntryGateDeps({
+  const { ctx, gateOptions, inFlightCalls } = createMatchEntryGateDeps({
     storage,
     setupTarget,
     setupSnapshot,
@@ -214,7 +247,7 @@ test('runMatchEntryNeuralLoadGateForPage returns setup-terminal and clears persi
     },
   })
 
-  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  const result = await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.equal(result.kind, 'setup-terminal')
   assert.deepEqual(setupTarget, setupSnapshot)
   assert.equal(loadCurrentMatch(storage).ok, false)
@@ -222,21 +255,23 @@ test('runMatchEntryNeuralLoadGateForPage returns setup-terminal and clears persi
 })
 
 test('runMatchEntryNeuralLoadGateForPage keeps in-flight until page release by default', async () => {
-  const { deps, inFlightCalls } = createMatchEntryGateDeps()
+  const { ctx, gateOptions, inFlightCalls } = createMatchEntryGateDeps()
 
-  await runMatchEntryNeuralLoadGateForPage(deps)
+  await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.deepEqual(inFlightCalls, [true])
 })
 
 test('runMatchEntryNeuralLoadGateForPage releases in-flight after gate when requested', async () => {
-  const { deps, inFlightCalls } = createMatchEntryGateDeps({ releaseInFlightAfterGate: true })
+  const { ctx, gateOptions, inFlightCalls } = createMatchEntryGateDeps({
+    releaseInFlightAfterGate: true,
+  })
 
-  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  const result = await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.equal(result.kind, 'success')
   assert.deepEqual(inFlightCalls, [true, false])
 })
 
-test('applyNeuralLoadGateSetupTerminalForPage restores setup and clears persisted match', () => {
+test('resolveNeuralLoadGateSetupTerminal restores setup and clears persisted match', () => {
   const storage = createMemoryStorage()
   const setupTarget = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
   const setupSnapshot = NN_TWO_PLAYER_SETUP
@@ -247,7 +282,7 @@ test('applyNeuralLoadGateSetupTerminalForPage restores setup and clears persiste
     }),
   )
 
-  applyNeuralLoadGateSetupTerminalForPage({
+  resolveNeuralLoadGateSetupTerminal({
     storage,
     setupSnapshot,
     clearCurrentMatch,
@@ -274,6 +309,25 @@ function createBootstrapDeps(overrides = {}) {
     },
   }
 
+  const ctx = createMatchPageOrchestrationContext({
+    storage,
+    recovery: wrappedRecovery,
+    loadModel:
+      overrides.loadModel ??
+      ((modelId) => {
+        loadCalls.push(modelId)
+        return Promise.resolve()
+      }),
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      inFlightCalls.push(inFlight)
+    },
+    clearCurrentMatch,
+    persistCurrentMatch,
+    applySetupSnapshot,
+    setupTarget,
+    cloneSetup: overrides.cloneSetup ?? ((setup) => structuredClone(setup)),
+  })
+
   return {
     storage,
     setupTarget,
@@ -281,28 +335,14 @@ function createBootstrapDeps(overrides = {}) {
     loadCalls,
     importCalls,
     recovery: wrappedRecovery,
-    deps: {
-      storage,
-      loadModel: overrides.loadModel ?? ((modelId) => {
-        loadCalls.push(modelId)
-        return Promise.resolve()
-      }),
-      setMatchNeuralLoadGateInFlight: (inFlight) => {
-        inFlightCalls.push(inFlight)
-      },
-      clearCurrentMatch,
-      applySetupSnapshot,
-      setupTarget,
-      cloneSetup: overrides.cloneSetup ?? ((setup) => structuredClone(setup)),
-      recovery: wrappedRecovery,
-    },
+    ctx,
   }
 }
 
 test('bootstrapCurrentMatchFromStorage returns no-saved-match when storage is empty', async () => {
-  const { deps } = createBootstrapDeps()
+  const { ctx } = createBootstrapDeps()
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'no-saved-match')
 })
 
@@ -317,7 +357,7 @@ test('bootstrapCurrentMatchFromStorage returns setup-terminal when neural load g
     id: 'm-bootstrap-gate-setup',
   })
   persistCurrentMatch(storage, match)
-  const { deps, inFlightCalls, importCalls } = createBootstrapDeps({
+  const { ctx, inFlightCalls, importCalls } = createBootstrapDeps({
     storage,
     setupTarget,
     loadModel: async () => {
@@ -325,7 +365,7 @@ test('bootstrapCurrentMatchFromStorage returns setup-terminal when neural load g
     },
   })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'setup-terminal')
   assert.deepEqual(setupTarget, setupSnapshot)
   assert.equal(loadCurrentMatch(storage).ok, false)
@@ -334,14 +374,14 @@ test('bootstrapCurrentMatchFromStorage returns setup-terminal when neural load g
 })
 
 test('runMatchEntryNeuralLoadGateForPage releases in-flight on setup-terminal when requested', async () => {
-  const { deps, inFlightCalls } = createMatchEntryGateDeps({
+  const { ctx, gateOptions, inFlightCalls } = createMatchEntryGateDeps({
     releaseInFlightAfterGate: true,
     loadModel: async () => {
       throw new Error('missing model')
     },
   })
 
-  const result = await runMatchEntryNeuralLoadGateForPage(deps)
+  const result = await runMatchEntryNeuralLoadGateForPage(ctx, gateOptions)
   assert.equal(result.kind, 'setup-terminal')
   assert.deepEqual(inFlightCalls, [true, false])
 })
@@ -363,9 +403,9 @@ test('bootstrapCurrentMatchFromStorage returns setup-terminal for persisted SETU
     },
   })
   persistCurrentMatch(storage, match)
-  const { deps, importCalls } = createBootstrapDeps({ storage, setupTarget })
+  const { ctx, importCalls } = createBootstrapDeps({ storage, setupTarget })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'setup-terminal')
   assert.deepEqual(setupTarget, setupSnapshot)
   assert.equal(loadCurrentMatch(storage).ok, false)
@@ -389,9 +429,9 @@ test('bootstrapCurrentMatchFromStorage returns refresh-terminal for persisted RE
     },
   })
   persistCurrentMatch(storage, match)
-  const { deps } = createBootstrapDeps({ storage })
+  const { ctx } = createBootstrapDeps({ storage })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'refresh-terminal')
   assert.equal(result.presentationSpeedProfile, 'brisk')
   assert.equal(result.match.id, 'm-bootstrap-persisted-refresh')
@@ -417,9 +457,9 @@ test('bootstrapCurrentMatchFromStorage returns resume with normalized presentati
   })
   delete match.presentationSpeedProfile
   persistCurrentMatch(storage, match)
-  const { deps, loadCalls, importCalls } = createBootstrapDeps({ storage })
+  const { ctx, loadCalls, importCalls } = createBootstrapDeps({ storage })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'resume')
   assert.equal(result.presentationSpeedProfile, 'cinematic')
   assert.equal(result.match.id, 'm-bootstrap-resume')
@@ -439,9 +479,9 @@ test('bootstrapCurrentMatchFromStorage returns resume preserving brisk presentat
       presentationSpeedProfile: 'brisk',
     }),
   )
-  const { deps } = createBootstrapDeps({ storage })
+  const { ctx } = createBootstrapDeps({ storage })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'resume')
   assert.equal(result.presentationSpeedProfile, 'brisk')
   assert.equal(result.match.presentationSpeedProfile, 'brisk')
@@ -467,14 +507,14 @@ test('bootstrapCurrentMatchFromStorage gate failure does not import persisted re
       },
     }),
   )
-  const { deps, importCalls } = createBootstrapDeps({
+  const { ctx, importCalls } = createBootstrapDeps({
     storage,
     loadModel: async () => {
       throw new Error('missing model')
     },
   })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'setup-terminal')
   assert.equal(importCalls.length, 0)
 })
@@ -495,20 +535,20 @@ test('bootstrapCurrentMatchFromStorage runs load gate before importing persisted
   })
   persistCurrentMatch(storage, match)
   const order = []
-  const { deps } = createBootstrapDeps({
+  const { ctx } = createBootstrapDeps({
     storage,
     loadModel: async (modelId) => {
       order.push(['load', modelId])
     },
     recovery: createNeuralRuntimeRecoveryCoordinator(),
   })
-  const originalImport = deps.recovery.importSnapshot.bind(deps.recovery)
-  deps.recovery.importSnapshot = (snapshot) => {
+  const originalImport = ctx.recovery.importSnapshot.bind(ctx.recovery)
+  ctx.recovery.importSnapshot = (snapshot) => {
     order.push(['import', snapshot])
     return originalImport(snapshot)
   }
 
-  await bootstrapCurrentMatchFromStorage(deps)
+  await bootstrapCurrentMatchFromStorage(ctx)
   assert.deepEqual(order, [['load', 'latest'], ['import', match.neuralRecoveryByModelId]])
 })
 
@@ -517,29 +557,36 @@ test('bootstrapCurrentMatchFromStorage releases in-flight after gate before reco
   const setupSnapshot = NN_TWO_PLAYER_SETUP
   const initial = createInitialMatchState(setupSnapshot, { seed: 205 })
   persistCurrentMatch(storage, buildMatchEnvelope(setupSnapshot, initial))
-  const { deps, inFlightCalls } = createBootstrapDeps({ storage })
+  const { ctx, inFlightCalls } = createBootstrapDeps({ storage })
 
-  const result = await bootstrapCurrentMatchFromStorage(deps)
+  const result = await bootstrapCurrentMatchFromStorage(ctx)
   assert.equal(result.kind, 'resume')
   assert.deepEqual(inFlightCalls, [true, false])
 })
 
 test('runMatchEntryNeuralLoadGateForPage releases in-flight when gate throws unexpectedly', async () => {
   const inFlightCalls = []
-  const deps = {
-    setupSnapshot: NN_TWO_PLAYER_SETUP,
+  const ctx = createMatchPageOrchestrationContext({
+    storage: createMemoryStorage(),
+    recovery: createNeuralRuntimeRecoveryCoordinator(),
+    loadModel: async () => {},
     setMatchNeuralLoadGateInFlight: (inFlight) => {
       inFlightCalls.push(inFlight)
     },
-    releaseInFlightAfterGate: false,
-    storage: createMemoryStorage(),
     clearCurrentMatch,
+    persistCurrentMatch,
     applySetupSnapshot,
     setupTarget: { totalSeats: 2, opponents: [] },
-  }
+    cloneSetup: (setup) => structuredClone(setup),
+  })
+  ctx.loadModel = undefined
 
   await assert.rejects(
-    () => runMatchEntryNeuralLoadGateForPage(deps),
+    () =>
+      runMatchEntryNeuralLoadGateForPage(ctx, {
+        setupSnapshot: NN_TWO_PLAYER_SETUP,
+        releaseInFlightAfterGate: false,
+      }),
     /loadModel required/,
   )
   assert.deepEqual(inFlightCalls, [true, false])
@@ -597,26 +644,26 @@ test('buildNewMatchEnvelope omits preservedBotLabels when rematch has none', () 
 })
 
 test('runHeadlessMatchCompletionForPage skips when match is missing', async () => {
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: null,
     humanPlayerSeatId: 'seat-human',
     chooseAction: async () => null,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'NO_MATCH')
 })
 
 test('runHeadlessMatchCompletionForPage skips when human seat is missing', async () => {
   const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 99 })
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
     humanPlayerSeatId: null,
     chooseAction: async () => null,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'NO_HUMAN')
 })
@@ -625,13 +672,13 @@ test('runHeadlessMatchCompletionForPage skips when headless is not needed', asyn
   const initial = createInitialMatchState(FOUR_PLAYER_SETUP, { seed: 100 })
   const human = seatByRole(initial, 'human')
   assert.ok(human)
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
     humanPlayerSeatId: human.id,
     chooseAction: async () => null,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'NOT_NEEDED')
 })
@@ -652,13 +699,13 @@ test('runHeadlessMatchCompletionForPage skips when persisted neural recovery is 
       },
     },
   })
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match,
     humanPlayerSeatId: human.id,
     chooseAction: async () => null,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'REFRESH_DEFERRED')
 })
@@ -671,7 +718,7 @@ test('runHeadlessMatchCompletionForPage skips duplicate start while in flight', 
   const gate = createHeadlessCompletionFlightGate()
   assert.equal(gate.tryStart(), true)
   let teardownCalls = 0
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
     humanPlayerSeatId: human.id,
     chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
@@ -681,7 +728,7 @@ test('runHeadlessMatchCompletionForPage skips duplicate start while in flight', 
     },
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'IN_FLIGHT')
   assert.equal(teardownCalls, 0)
@@ -693,7 +740,7 @@ test('runHeadlessMatchCompletionForPage does not teardown when skipped before fl
   const human = seatByRole(initial, 'human')
   assert.ok(human)
   let teardownCalls = 0
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, initial),
     humanPlayerSeatId: human.id,
     chooseAction: async () => null,
@@ -702,7 +749,7 @@ test('runHeadlessMatchCompletionForPage does not teardown when skipped before fl
     },
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'skipped')
   assert.equal(result.reason, 'NOT_NEEDED')
   assert.equal(teardownCalls, 0)
@@ -716,7 +763,7 @@ test('runHeadlessMatchCompletionForPage teardown runs after flight start then cl
   const gate = createHeadlessCompletionFlightGate()
   let sawOverlayDuringTeardown = false
   let teardownCalls = 0
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
     humanPlayerSeatId: human.id,
     chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
@@ -730,7 +777,7 @@ test('runHeadlessMatchCompletionForPage teardown runs after flight start then cl
     },
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'completed')
   assert.equal(teardownCalls, 1)
   assert.equal(sawOverlayDuringTeardown, true)
@@ -746,14 +793,14 @@ test('runHeadlessMatchCompletionForPage completes and persists updated match', a
   const start = humanEliminatedPickState(initial, human.id)
   const match = buildMatchEnvelope(FOUR_PLAYER_SETUP, start, { id: 'm-headless-complete' })
   persistCurrentMatch(storage, match)
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     storage,
     match,
     humanPlayerSeatId: human.id,
     chooseAction: async ({ state, seatId }) => chooseRandombotAction(state, { seatId }),
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'completed')
   assert.equal(result.match.state.phase, MATCH_PHASES.MATCH_OVER)
   assert.equal('neuralRecoveryByModelId' in result.match, false)
@@ -783,7 +830,7 @@ test('runHeadlessMatchCompletionForPage returns setup-terminal and clears curren
       resetRuntimeForModel: () => {},
     }),
   })
-  const { deps, setupTerminalCalls, setupTarget: target } = createPageDeps({
+  const { ctx, deps, setupTerminalCalls, setupTarget: target } = createPageDeps({
     storage,
     setupTarget,
     recovery,
@@ -792,7 +839,7 @@ test('runHeadlessMatchCompletionForPage returns setup-terminal and clears curren
     chooseAction,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'setup-terminal')
   assert.equal(setupTerminalCalls(), 1)
   assert.deepEqual(target, NN_TWO_PLAYER_SETUP)
@@ -817,7 +864,7 @@ test('runHeadlessMatchCompletionForPage returns refresh-terminal and persists re
       resetRuntimeForModel: () => {},
     }),
   })
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     storage,
     recovery,
     match,
@@ -825,7 +872,7 @@ test('runHeadlessMatchCompletionForPage returns refresh-terminal and persists re
     chooseAction,
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps)
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps)
   assert.equal(result.kind, 'refresh-terminal')
   assert.equal(result.match.neuralRecoveryByModelId.latest.terminal, NEURAL_RECOVERY_TERMINAL.REFRESH)
   assert.equal(result.modelId, 'latest')
@@ -850,7 +897,7 @@ test('runHeadlessMatchCompletionForPage returns failed when safety cap is exceed
     const legal = getLegalActions(state, { seatId })
     return legal[0] ?? null
   }
-  const { deps } = createPageDeps({
+  const { ctx, deps } = createPageDeps({
     match: buildMatchEnvelope(FOUR_PLAYER_SETUP, start),
     humanPlayerSeatId: human.id,
     chooseAction,
@@ -861,7 +908,7 @@ test('runHeadlessMatchCompletionForPage returns failed when safety cap is exceed
     },
   })
 
-  const result = await runHeadlessMatchCompletionForPage(deps, { maxActions: 3 })
+  const result = await runHeadlessMatchCompletionForPage(ctx, deps, { maxActions: 3 })
   assert.equal(result.kind, 'failed')
   assert.equal(result.errorCode, HEADLESS_COMPLETION_ERROR_CODES.SAFETY_CAP)
   assert.equal(result.actionCount, 3)

--- a/src/features/dungeon-runner/persistence/currentMatch.test.js
+++ b/src/features/dungeon-runner/persistence/currentMatch.test.js
@@ -339,7 +339,7 @@ test('headless infer terminal persists refresh snapshot and defers completion on
       openRefreshTerminal: () => {
         refreshOpen = true
       },
-    }),
+    }).surfaced,
     true,
   )
   assert.equal(refreshOpen, true)
@@ -376,7 +376,7 @@ test('persisted neural recovery terminal round-trips and surfaces refresh on res
       openRefreshTerminal: () => {
         refreshOpen = true
       },
-    }),
+    }).surfaced,
     true,
   )
   assert.equal(refreshOpen, true)

--- a/src/features/dungeon-runner/resetLiveMatchPageState.js
+++ b/src/features/dungeon-runner/resetLiveMatchPageState.js
@@ -1,0 +1,53 @@
+/**
+ * Resets live match page session artifacts shared by setup exit, neural load-gate
+ * terminal, and fresh match entry paths.
+ *
+ * @param {{
+ *   setMatchNull?: () => void
+ *   setNnModelsWarmPromise: (promise: Promise<void> | null) => void
+ *   resetAiTurnPrefetch: () => void
+ *   setLastAppliedAiTurnTokenNull: () => void
+ *   setPresentationInputWasLockedFalse: () => void
+ *   setDeferredPostDungeonStateNull: () => void
+ *   clearDebugTraces: () => void
+ *   clearPresentation: () => void
+ *   syncPresentationLabel: () => void
+ *   setNeuralLoadGateTerminalOpen?: (open: boolean) => void
+ *   clearPersistedMatch?: () => void
+ * }} sink
+ * @param {{
+ *   clearMatch?: boolean
+ *   openNeuralLoadGateTerminal?: boolean
+ *   warmModelsResolved?: boolean
+ *   clearPersistedMatch?: boolean
+ * }} [options]
+ */
+export function resetLiveMatchPageState(sink, options = {}) {
+  const {
+    clearMatch = false,
+    openNeuralLoadGateTerminal = false,
+    warmModelsResolved = false,
+    clearPersistedMatch = false,
+  } = options
+
+  if (clearMatch && sink.setMatchNull) {
+    sink.setMatchNull()
+  }
+
+  sink.setLastAppliedAiTurnTokenNull()
+  sink.resetAiTurnPrefetch()
+  sink.setNnModelsWarmPromise(warmModelsResolved ? Promise.resolve() : null)
+  sink.setPresentationInputWasLockedFalse()
+  sink.setDeferredPostDungeonStateNull()
+  sink.clearDebugTraces()
+  sink.clearPresentation()
+  sink.syncPresentationLabel()
+
+  if (openNeuralLoadGateTerminal && sink.setNeuralLoadGateTerminalOpen) {
+    sink.setNeuralLoadGateTerminalOpen(true)
+  }
+
+  if (clearPersistedMatch && sink.clearPersistedMatch) {
+    sink.clearPersistedMatch()
+  }
+}

--- a/src/features/dungeon-runner/resetLiveMatchPageState.test.js
+++ b/src/features/dungeon-runner/resetLiveMatchPageState.test.js
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resetLiveMatchPageState } from './resetLiveMatchPageState.js'
+
+function createRecordingSink(overrides = {}) {
+  const calls = []
+  return {
+    calls,
+    sink: {
+      setMatchNull: () => {
+        calls.push('setMatchNull')
+      },
+      setNnModelsWarmPromise: (promise) => {
+        calls.push(['setNnModelsWarmPromise', promise === null ? null : 'resolved'])
+      },
+      resetAiTurnPrefetch: () => {
+        calls.push('resetAiTurnPrefetch')
+      },
+      setLastAppliedAiTurnTokenNull: () => {
+        calls.push('setLastAppliedAiTurnTokenNull')
+      },
+      setPresentationInputWasLockedFalse: () => {
+        calls.push('setPresentationInputWasLockedFalse')
+      },
+      setDeferredPostDungeonStateNull: () => {
+        calls.push('setDeferredPostDungeonStateNull')
+      },
+      clearDebugTraces: () => {
+        calls.push('clearDebugTraces')
+      },
+      clearPresentation: () => {
+        calls.push('clearPresentation')
+      },
+      syncPresentationLabel: () => {
+        calls.push('syncPresentationLabel')
+      },
+      setNeuralLoadGateTerminalOpen: (open) => {
+        calls.push(['setNeuralLoadGateTerminalOpen', open])
+      },
+      clearPersistedMatch: () => {
+        calls.push('clearPersistedMatch')
+      },
+      ...overrides,
+    },
+  }
+}
+
+test('resetLiveMatchPageState clears shared session artifacts for fresh match entry', () => {
+  const { sink, calls } = createRecordingSink()
+
+  resetLiveMatchPageState(sink, { warmModelsResolved: true })
+
+  assert.deepEqual(calls, [
+    'setLastAppliedAiTurnTokenNull',
+    'resetAiTurnPrefetch',
+    ['setNnModelsWarmPromise', 'resolved'],
+    'setPresentationInputWasLockedFalse',
+    'setDeferredPostDungeonStateNull',
+    'clearDebugTraces',
+    'clearPresentation',
+    'syncPresentationLabel',
+  ])
+})
+
+test('resetLiveMatchPageState exits to setup and clears persisted match', () => {
+  const { sink, calls } = createRecordingSink()
+
+  resetLiveMatchPageState(sink, {
+    clearMatch: true,
+    clearPersistedMatch: true,
+  })
+
+  assert.deepEqual(calls, [
+    'setMatchNull',
+    'setLastAppliedAiTurnTokenNull',
+    'resetAiTurnPrefetch',
+    ['setNnModelsWarmPromise', null],
+    'setPresentationInputWasLockedFalse',
+    'setDeferredPostDungeonStateNull',
+    'clearDebugTraces',
+    'clearPresentation',
+    'syncPresentationLabel',
+    'clearPersistedMatch',
+  ])
+})
+
+test('resetLiveMatchPageState opens neural load gate terminal when requested', () => {
+  const { sink, calls } = createRecordingSink()
+
+  resetLiveMatchPageState(sink, {
+    clearMatch: true,
+    openNeuralLoadGateTerminal: true,
+  })
+
+  assert.ok(calls.includes('setMatchNull'))
+  assert.deepEqual(calls.at(-1), ['setNeuralLoadGateTerminalOpen', true])
+})
+
+test('resetLiveMatchPageState back-to-setup clears match without opening load gate terminal', () => {
+  const { sink, calls } = createRecordingSink()
+
+  resetLiveMatchPageState(sink, {
+    clearMatch: true,
+    clearPersistedMatch: true,
+  })
+
+  assert.ok(calls.includes('setMatchNull'))
+  assert.ok(calls.includes('clearPersistedMatch'))
+  assert.equal(
+    calls.some(
+      (call) => Array.isArray(call) && call[0] === 'setNeuralLoadGateTerminalOpen',
+    ),
+    false,
+  )
+})
+
+test('resetLiveMatchPageState skips optional sinks when flags and handlers are absent', () => {
+  const calls = []
+  const sink = {
+    setNnModelsWarmPromise: (promise) => {
+      calls.push(['setNnModelsWarmPromise', promise === null ? null : 'resolved'])
+    },
+    resetAiTurnPrefetch: () => {
+      calls.push('resetAiTurnPrefetch')
+    },
+    setLastAppliedAiTurnTokenNull: () => {
+      calls.push('setLastAppliedAiTurnTokenNull')
+    },
+    setPresentationInputWasLockedFalse: () => {
+      calls.push('setPresentationInputWasLockedFalse')
+    },
+    setDeferredPostDungeonStateNull: () => {
+      calls.push('setDeferredPostDungeonStateNull')
+    },
+    clearDebugTraces: () => {
+      calls.push('clearDebugTraces')
+    },
+    clearPresentation: () => {
+      calls.push('clearPresentation')
+    },
+    syncPresentationLabel: () => {
+      calls.push('syncPresentationLabel')
+    },
+  }
+
+  resetLiveMatchPageState(sink, {
+    clearMatch: true,
+    openNeuralLoadGateTerminal: true,
+    clearPersistedMatch: true,
+  })
+
+  assert.deepEqual(calls, [
+    'setLastAppliedAiTurnTokenNull',
+    'resetAiTurnPrefetch',
+    ['setNnModelsWarmPromise', null],
+    'setPresentationInputWasLockedFalse',
+    'setDeferredPostDungeonStateNull',
+    'clearDebugTraces',
+    'clearPresentation',
+    'syncPresentationLabel',
+  ])
+})

--- a/src/features/dungeon-runner/setup/materializeNewMatchState.js
+++ b/src/features/dungeon-runner/setup/materializeNewMatchState.js
@@ -1,0 +1,36 @@
+import {
+  createInitialMatchState,
+  shuffleMatchDeck,
+  shuffleMatchSeats,
+  MATCH_PHASES,
+} from '../engine/kernel.js'
+
+export const MATCH_SEAT_SHUFFLE_SEED_XOR = 0x5f3759df
+export const MATCH_DECK_SHUFFLE_SEED_XOR = 0x9e3779b9
+
+/**
+ * Pre-history match engine state for new match start and replay bootstrap:
+ * seat shuffle, deck shuffle, then pick-adventurer phase with first actor set.
+ */
+export function materializeNewMatchState(setup, seed, options = {}) {
+  const { preservedBotLabels } = options
+  const baseState = createInitialMatchState(setup, { seed })
+  const seatShuffleOptions = { seed: seed ^ MATCH_SEAT_SHUFFLE_SEED_XOR }
+  if (preservedBotLabels) {
+    seatShuffleOptions.preservedBotLabels = preservedBotLabels
+  }
+  const shuffledState = shuffleMatchDeck(
+    shuffleMatchSeats(baseState, seatShuffleOptions),
+    { seed: seed ^ MATCH_DECK_SHUFFLE_SEED_XOR },
+  )
+  const firstSeatId = shuffledState.turn.activeSeatId
+  return {
+    ...shuffledState,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    hero: null,
+    pickAdventurer: {
+      ...shuffledState.pickAdventurer,
+      activeSeatId: firstSeatId,
+    },
+  }
+}

--- a/src/features/dungeon-runner/setup/materializeNewMatchState.test.js
+++ b/src/features/dungeon-runner/setup/materializeNewMatchState.test.js
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createInitialMatchState,
+  MATCH_PHASES,
+  shuffleMatchDeck,
+  shuffleMatchSeats,
+} from '../engine/kernel.js'
+import { bootstrapMatchStateForReplay } from '../debug/replayBootstrap.js'
+import {
+  MATCH_DECK_SHUFFLE_SEED_XOR,
+  MATCH_SEAT_SHUFFLE_SEED_XOR,
+  materializeNewMatchState,
+} from './materializeNewMatchState.js'
+
+const FOUR_NN_SETUP = {
+  totalSeats: 4,
+  opponents: [
+    { type: 'nn', modelId: 'latest' },
+    { type: 'nn', modelId: 'latest' },
+    { type: 'nn', modelId: 'latest' },
+  ],
+}
+
+const MIXED_SETUP = {
+  totalSeats: 4,
+  opponents: [
+    { type: 'randombot' },
+    { type: 'nn', modelId: 'latest' },
+    { type: 'randombot' },
+  ],
+}
+
+test('materializeNewMatchState is deterministic for same setup and seed', () => {
+  const a = materializeNewMatchState(MIXED_SETUP, 4242)
+  const b = materializeNewMatchState(MIXED_SETUP, 4242)
+  assert.deepEqual(a, b)
+})
+
+test('materializeNewMatchState varies with seed', () => {
+  const a = materializeNewMatchState(MIXED_SETUP, 111)
+  const b = materializeNewMatchState(MIXED_SETUP, 222)
+  assert.notDeepEqual(a, b)
+})
+
+test('materializeNewMatchState enters pick-adventurer with first actor aligned', () => {
+  const state = materializeNewMatchState(FOUR_NN_SETUP, 1355487512)
+  assert.equal(state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(state.hero, null)
+  assert.equal(state.turn.activeSeatId, 'seat-4')
+  assert.equal(state.pickAdventurer.activeSeatId, state.turn.activeSeatId)
+  assert.equal(state.rng.step, 0)
+})
+
+test('materializeNewMatchState preserves opponent seat labels when requested', () => {
+  const initial = materializeNewMatchState(MIXED_SETUP, 8080)
+  const preservedBotLabels = initial.seats
+    .filter((seat) => seat.role.type !== 'human' && seat.label)
+    .map((seat) => seat.label)
+
+  const rematchState = materializeNewMatchState(MIXED_SETUP, 3333, { preservedBotLabels })
+  assert.deepEqual(
+    rematchState.seats.filter((seat) => seat.role.type !== 'human').map((seat) => seat.label),
+    preservedBotLabels,
+  )
+})
+
+test('materializeNewMatchState applies shuffles with exported XOR seed constants', () => {
+  const setup = MIXED_SETUP
+  const seed = 4242
+  const baseState = createInitialMatchState(setup, { seed })
+  const shuffledState = shuffleMatchDeck(
+    shuffleMatchSeats(baseState, { seed: seed ^ MATCH_SEAT_SHUFFLE_SEED_XOR }),
+    { seed: seed ^ MATCH_DECK_SHUFFLE_SEED_XOR },
+  )
+  const firstSeatId = shuffledState.turn.activeSeatId
+  const expected = {
+    ...shuffledState,
+    phase: MATCH_PHASES.PICK_ADVENTURER,
+    hero: null,
+    pickAdventurer: {
+      ...shuffledState.pickAdventurer,
+      activeSeatId: firstSeatId,
+    },
+  }
+  assert.deepEqual(materializeNewMatchState(setup, seed), expected)
+})
+
+test('bootstrapMatchStateForReplay delegates to materializeNewMatchState', () => {
+  const setup = FOUR_NN_SETUP
+  const seed = 1355487512
+  assert.deepEqual(bootstrapMatchStateForReplay(setup, seed), materializeNewMatchState(setup, seed))
+})

--- a/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js
+++ b/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js
@@ -25,12 +25,12 @@ export function attachNeuralRecoverySnapshotToMatch(match, recovery) {
  *   applySetupTerminal?: () => void
  *   openRefreshTerminal?: () => void
  * }} options
- * @returns {boolean} whether a blocking terminal UX was surfaced
+ * @returns {{ surfaced: false } | { surfaced: true, action: 'setup-restore' | 'refresh-dialog' }}
  */
 export function surfacePersistedNeuralRecoveryTerminal(options) {
   const snapshot = options.neuralRecoveryByModelId
   if (!snapshot || !neuralRecoverySnapshotHasTerminal(snapshot)) {
-    return false
+    return { surfaced: false }
   }
   options.recovery.importSnapshot(snapshot)
   for (const state of Object.values(snapshot)) {
@@ -41,14 +41,14 @@ export function surfacePersistedNeuralRecoveryTerminal(options) {
     })
     if (ux.action === 'setup-restore') {
       options.applySetupTerminal?.()
-      return true
+      return { surfaced: true, action: 'setup-restore' }
     }
     if (ux.action === 'refresh-dialog') {
       options.openRefreshTerminal?.()
-      return true
+      return { surfaced: true, action: 'refresh-dialog' }
     }
   }
-  return false
+  return { surfaced: false }
 }
 
 /**

--- a/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.test.js
+++ b/src/features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.test.js
@@ -44,7 +44,8 @@ test('surfacePersistedNeuralRecoveryTerminal opens refresh dialog for REFRESH sn
       refreshOpen = true
     },
   })
-  assert.equal(surfaced, true)
+  assert.equal(surfaced.surfaced, true)
+  assert.equal(surfaced.action, 'refresh-dialog')
   assert.equal(refreshOpen, true)
   assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.REFRESH)
 })
@@ -67,7 +68,8 @@ test('surfacePersistedNeuralRecoveryTerminal restores setup for SETUP snapshot',
       setupRestored = true
     },
   })
-  assert.equal(surfaced, true)
+  assert.equal(surfaced.surfaced, true)
+  assert.equal(surfaced.action, 'setup-restore')
   assert.equal(setupRestored, true)
   assert.equal(recovery.getTerminalOutcome('latest'), NEURAL_RECOVERY_TERMINAL.SETUP)
 })

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -634,16 +634,12 @@ import { useDungeonRunnerSettingsStore } from '../../stores/dungeonRunnerSetting
 import {
   MATCH_PHASES,
   applyAction,
-  createInitialMatchState,
   getLegalActions,
   getPlayerView,
-  shuffleMatchDeck,
-  shuffleMatchSeats,
 } from '../../features/dungeon-runner/engine/kernel.js'
 import {
   CURRENT_MATCH_SCHEMA_VERSION,
   clearCurrentMatch,
-  loadCurrentMatch,
   persistCurrentMatch,
 } from '../../features/dungeon-runner/persistence/currentMatch.js'
 import { createDefaultSetupConfig, validateSetupConfig } from '../../features/dungeon-runner/setup/config.js'
@@ -663,10 +659,6 @@ import {
 } from '../../features/dungeon-runner/nn/runtime.js'
 import { createNeuralRuntimeRecoveryCoordinator } from '../../features/dungeon-runner/nn/recovery.js'
 import { createChooseNnActionWithRecovery, NeuralRecoveryTerminalError } from '../../features/dungeon-runner/nn/chooseWithRecovery.js'
-import {
-  resolveNeuralLoadGateSetupTerminal,
-  runMatchNeuralLoadGate,
-} from '../../features/dungeon-runner/nn/matchNeuralLoadGate.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
 import { pickDefaultModelId, validateSelectedModels } from '../../features/dungeon-runner/models/discovery.js'
 import {
@@ -728,9 +720,16 @@ import {
 } from '../../features/dungeon-runner/ui/humanGameplayGate.js'
 import { MATCH_OVER_END_VARIANTS } from '../../features/dungeon-runner/ui/humanEliminationCompletionPolicy.js'
 import {
-  runMaybeHeadlessMatchCompletionFromState,
   shouldDeferDungeonExitUntilOutcomeAck,
 } from '../../features/dungeon-runner/ui/headlessMatchCompletionRunner.js'
+import {
+  applyNeuralLoadGateSetupTerminalForPage,
+  bootstrapCurrentMatchFromStorage,
+  runHeadlessMatchCompletionForPage,
+  buildNewMatchEnvelope,
+  runMatchEntryNeuralLoadGateForPage,
+} from '../../features/dungeon-runner/matchPageOrchestration.js'
+import { resetLiveMatchPageState } from '../../features/dungeon-runner/resetLiveMatchPageState.js'
 import { createLivePlayActionChooser } from '../../features/dungeon-runner/ui/livePlayActionChooser.js'
 import { buildMatchOverSummary } from '../../features/dungeon-runner/ui/matchOverSummaryBuilder.js'
 import MonsterCardFace from '../../components/dungeon-runner/MonsterCardFace.vue'
@@ -751,11 +750,6 @@ import {
   resolveNeuralRecoveryTerminalUx,
   shouldBlockAiTurnScheduleForRecovery,
 } from '../../features/dungeon-runner/ui/neuralSeatRecoveryView.js'
-import {
-  attachNeuralRecoverySnapshotToMatch,
-  shouldRunHeadlessMatchCompletion,
-  surfacePersistedNeuralRecoveryTerminal,
-} from '../../features/dungeon-runner/ui/headlessNeuralRecoveryPersistence.js'
 
 const completedMatchReplayUpload = createCompletedMatchReplayUploadTracker(window.sessionStorage)
 
@@ -1405,50 +1399,47 @@ onMounted(() => {
   }, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS)
 })
 
+function applyBootstrappedMatchSession(matchEnvelope, pace) {
+  dungeonRunnerSettingsStore.setAnimationPace(pace)
+  match.value = matchEnvelope
+  syncSeatRecoveryIndicators()
+  activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
+  deferredPostDungeonState.value = null
+  presentationOrchestrator.clear()
+  presentationSpeedProfile.value = pace
+  presentationOrchestrator.setSpeedProfile(pace)
+  nnModelsWarmPromise = Promise.resolve()
+  syncPresentationLabel()
+}
+
 async function bootstrapDungeonRunnerPage() {
-  const loaded = loadCurrentMatch(window.localStorage)
-  if (!loaded.ok) return
-  const setupSnapshot = cloneSetup(loaded.match.setup)
-  matchNeuralLoadGateInFlight.value = true
-  try {
-    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
-    if (!gate.ok) {
-      applyNeuralLoadGateSetupTerminal(setupSnapshot)
-      return
-    }
-    const pace =
-      loaded.match.presentationSpeedProfile === 'brisk' || loaded.match.presentationSpeedProfile === 'cinematic'
-        ? loaded.match.presentationSpeedProfile
-        : 'cinematic'
-    dungeonRunnerSettingsStore.setAnimationPace(pace)
-    matchNeuralLoadGateInFlight.value = false
-    match.value = { ...loaded.match, presentationSpeedProfile: pace }
-    syncSeatRecoveryIndicators()
-    activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
-    deferredPostDungeonState.value = null
-    presentationOrchestrator.clear()
-    presentationSpeedProfile.value = pace
-    presentationOrchestrator.setSpeedProfile(pace)
-    nnModelsWarmPromise = Promise.resolve()
-    syncPresentationLabel()
-    const surfacedTerminal = surfacePersistedNeuralRecoveryTerminal({
-      recovery: nnRecovery,
-      neuralRecoveryByModelId: loaded.match.neuralRecoveryByModelId,
-      hasMatchSetup: Boolean(loaded.match.setup),
-      applySetupTerminal: () => applyNeuralLoadGateSetupTerminal(cloneSetup(loaded.match.setup)),
-      openRefreshTerminal: () => {
-        neuralRefreshTerminalOpen.value = true
-      },
-    })
-    if (surfacedTerminal) {
-      syncSeatRecoveryIndicators()
-      activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
-      return
-    }
-    void maybeRunHeadlessMatchCompletion()
-  } finally {
-    matchNeuralLoadGateInFlight.value = false
+  const result = await bootstrapCurrentMatchFromStorage({
+    storage: window.localStorage,
+    loadModel: loadNnModel,
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      matchNeuralLoadGateInFlight.value = inFlight
+    },
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget: setup,
+    cloneSetup,
+    recovery: nnRecovery,
+  })
+
+  if (result.kind === 'no-saved-match') return
+  if (result.kind === 'setup-terminal') {
+    resetLiveMatchPageStateForSetupTerminal()
+    return
   }
+
+  applyBootstrappedMatchSession(result.match, result.presentationSpeedProfile)
+
+  if (result.kind === 'refresh-terminal') {
+    neuralRefreshTerminalOpen.value = true
+    return
+  }
+
+  void maybeRunHeadlessMatchCompletion()
 }
 
 onBeforeUnmount(() => {
@@ -1516,6 +1507,76 @@ watch(
   },
 )
 
+function createLiveMatchPageSessionSink() {
+  return {
+    setMatchNull: () => {
+      match.value = null
+    },
+    setNnModelsWarmPromise: (promise) => {
+      nnModelsWarmPromise = promise
+    },
+    resetAiTurnPrefetch,
+    setLastAppliedAiTurnTokenNull: () => {
+      lastAppliedAiTurnToken = null
+    },
+    setPresentationInputWasLockedFalse: () => {
+      presentationInputWasLocked = false
+    },
+    setDeferredPostDungeonStateNull: () => {
+      deferredPostDungeonState.value = null
+    },
+    clearDebugTraces: () => {
+      nnDebugTraceText.value = ''
+      nnDebugTraceHistory.value = []
+    },
+    clearPresentation: () => {
+      presentationOrchestrator.clear()
+    },
+    syncPresentationLabel,
+    setNeuralLoadGateTerminalOpen: (open) => {
+      neuralLoadGateTerminalOpen.value = open
+    },
+    clearPersistedMatch: () => {
+      clearCurrentMatch(window.localStorage)
+    },
+  }
+}
+
+function resetLiveMatchPageStateForSetupTerminal() {
+  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+    clearMatch: true,
+    openNeuralLoadGateTerminal: true,
+  })
+}
+
+function resetLiveMatchPageStateForFreshMatchEntry() {
+  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+    warmModelsResolved: true,
+  })
+}
+
+function resetLiveMatchPageStateForBackToSetup() {
+  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+    clearMatch: true,
+    clearPersistedMatch: true,
+  })
+}
+
+async function runLivePageMatchEntryGate(setupSnapshot) {
+  return runMatchEntryNeuralLoadGateForPage({
+    setupSnapshot,
+    loadModel: loadNnModel,
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      matchNeuralLoadGateInFlight.value = inFlight
+    },
+    releaseInFlightAfterGate: false,
+    storage: window.localStorage,
+    clearCurrentMatch,
+    applySetupSnapshot,
+    setupTarget: setup,
+  })
+}
+
 async function startNewMatch() {
   const modelValidation = validateSelectedModels(setup.opponents, modelOptions.value)
   if (!modelValidation.ok) {
@@ -1531,45 +1592,20 @@ async function startNewMatch() {
   const setupSnapshot = cloneSetup()
   matchNeuralLoadGateInFlight.value = true
   try {
-    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
-    if (!gate.ok) {
-      applyNeuralLoadGateSetupTerminal(setupSnapshot)
+    const gateResult = await runLivePageMatchEntryGate(setupSnapshot)
+    if (gateResult.kind === 'setup-terminal') {
+      resetLiveMatchPageStateForSetupTerminal()
       return
     }
     clearCurrentMatch(window.localStorage)
     const seed = createMatchSeed()
-    const id = `match-${Date.now()}`
-    const baseState = createInitialMatchState(setupSnapshot, { seed })
-    const shuffledState = shuffleMatchDeck(shuffleMatchSeats(baseState, { seed: seed ^ 0x5f3759df }), {
-      seed: seed ^ 0x9e3779b9,
-    })
-    const firstSeatId = shuffledState.turn.activeSeatId
-    const initialPickState = {
-      ...shuffledState,
-      phase: MATCH_PHASES.PICK_ADVENTURER,
-      hero: null,
-      pickAdventurer: {
-        ...shuffledState.pickAdventurer,
-        activeSeatId: firstSeatId,
-      },
-    }
-    match.value = {
-      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-      id,
-      setup: setupSnapshot,
-      state: initialPickState,
-      history: [],
+    resetLiveMatchPageStateForFreshMatchEntry()
+    match.value = buildNewMatchEnvelope({
+      setupSnapshot,
+      seed,
+      id: `match-${Date.now()}`,
       presentationSpeedProfile: presentationSpeedProfile.value,
-    }
-    deferredPostDungeonState.value = null
-    nnDebugTraceText.value = ''
-    nnDebugTraceHistory.value = []
-    presentationOrchestrator.clear()
-    lastAppliedAiTurnToken = null
-    resetAiTurnPrefetch()
-    presentationInputWasLocked = false
-    nnModelsWarmPromise = Promise.resolve()
-    syncPresentationLabel()
+    })
   } finally {
     matchNeuralLoadGateInFlight.value = false
     scheduleAiTurnIfReady()
@@ -1582,53 +1618,23 @@ async function rematch() {
   const setupSnapshot = cloneSetup(match.value.setup)
   matchNeuralLoadGateInFlight.value = true
   try {
-    const gate = await runMatchNeuralLoadGate(setupSnapshot, { loadModel: loadNnModel })
-    if (!gate.ok) {
-      applyNeuralLoadGateSetupTerminal(setupSnapshot)
+    const gateResult = await runLivePageMatchEntryGate(setupSnapshot)
+    if (gateResult.kind === 'setup-terminal') {
+      resetLiveMatchPageStateForSetupTerminal()
       return
     }
-    const seed = createMatchSeed()
-    const id = `match-${Date.now()}`
-    const baseState = createInitialMatchState(setupSnapshot, { seed })
     const preservedBotLabels = match.value.state.seats
       .filter((seat) => seat.role?.type !== 'human' && seat.label)
       .map((seat) => seat.label)
-    const shuffledState = shuffleMatchDeck(
-      shuffleMatchSeats(baseState, {
-        seed: seed ^ 0x5f3759df,
-        preservedBotLabels,
-      }),
-      {
-        seed: seed ^ 0x9e3779b9,
-      },
-    )
-    const firstSeatId = shuffledState.turn.activeSeatId
-    const initialPickState = {
-      ...shuffledState,
-      phase: MATCH_PHASES.PICK_ADVENTURER,
-      hero: null,
-      pickAdventurer: {
-        ...shuffledState.pickAdventurer,
-        activeSeatId: firstSeatId,
-      },
-    }
-    match.value = {
-      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-      id,
-      setup: setupSnapshot,
-      state: initialPickState,
-      history: [],
+    const seed = createMatchSeed()
+    resetLiveMatchPageStateForFreshMatchEntry()
+    match.value = buildNewMatchEnvelope({
+      setupSnapshot,
+      seed,
+      id: `match-${Date.now()}`,
       presentationSpeedProfile: presentationSpeedProfile.value,
-    }
-    deferredPostDungeonState.value = null
-    nnDebugTraceText.value = ''
-    nnDebugTraceHistory.value = []
-    presentationOrchestrator.clear()
-    lastAppliedAiTurnToken = null
-    resetAiTurnPrefetch()
-    presentationInputWasLocked = false
-    nnModelsWarmPromise = Promise.resolve()
-    syncPresentationLabel()
+      preservedBotLabels,
+    })
   } finally {
     matchNeuralLoadGateInFlight.value = false
     scheduleAiTurnIfReady()
@@ -1641,24 +1647,14 @@ async function ensureNnModelsReady() {
 }
 
 function applyNeuralLoadGateSetupTerminal(setupSnapshot) {
-  resolveNeuralLoadGateSetupTerminal({
+  applyNeuralLoadGateSetupTerminalForPage({
     storage: window.localStorage,
     setupSnapshot,
     clearCurrentMatch,
     applySetupSnapshot,
     setupTarget: setup,
   })
-  match.value = null
-  lastAppliedAiTurnToken = null
-  resetAiTurnPrefetch()
-  nnModelsWarmPromise = null
-  presentationInputWasLocked = false
-  deferredPostDungeonState.value = null
-  nnDebugTraceText.value = ''
-  nnDebugTraceHistory.value = []
-  presentationOrchestrator.clear()
-  syncPresentationLabel()
-  neuralLoadGateTerminalOpen.value = true
+  resetLiveMatchPageStateForSetupTerminal()
 }
 
 function dismissNeuralLoadGateTerminal() {
@@ -1688,17 +1684,7 @@ function handleNeuralRecoveryTerminalError(error) {
 }
 
 function backToSetup() {
-  match.value = null
-  lastAppliedAiTurnToken = null
-  resetAiTurnPrefetch()
-  nnModelsWarmPromise = null
-  presentationInputWasLocked = false
-  deferredPostDungeonState.value = null
-  clearCurrentMatch(window.localStorage)
-  nnDebugTraceText.value = ''
-  nnDebugTraceHistory.value = []
-  presentationOrchestrator.clear()
-  syncPresentationLabel()
+  resetLiveMatchPageStateForBackToSetup()
 }
 
 function takeHumanAction(action) {
@@ -1851,47 +1837,31 @@ function createPageHeadlessCompletionFlightGate() {
 }
 
 async function maybeRunHeadlessMatchCompletion() {
-  if (!match.value) return
-  const humanId = humanSeatId.value
-  if (!humanId) return
-  if (!shouldRunHeadlessMatchCompletion(match.value, humanId)) {
-    return
-  }
-
-  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps())
   try {
-    const result = await runMaybeHeadlessMatchCompletionFromState(match.value.state, {
-      humanPlayerSeatId: humanId,
-      chooseAction,
+    const result = await runHeadlessMatchCompletionForPage({
+      match: match.value,
+      humanPlayerSeatId: humanSeatId.value,
+      chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
+      recovery: nnRecovery,
       gate: createPageHeadlessCompletionFlightGate(),
-      afterFlightStart: teardownForHeadlessMatchCompletion,
+      teardown: teardownForHeadlessMatchCompletion,
+      storage: window.localStorage,
+      persistCurrentMatch,
+      applySetupTerminal: (setupSnapshot) => applyNeuralLoadGateSetupTerminal(cloneSetup(setupSnapshot)),
     })
-    if (result.ran && !result.failed) {
-      const nextMatch = attachNeuralRecoverySnapshotToMatch(
-        { ...match.value, state: result.state },
-        nnRecovery,
-      )
-      delete nextMatch.neuralRecoveryByModelId
-      match.value = nextMatch
-      persistCurrentMatch(window.localStorage, match.value)
-    } else if (result.ran && result.failed && debugMode.value) {
+
+    if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
+      match.value = result.match
+    }
+    if (result.kind === 'refresh-terminal') {
+      neuralRefreshTerminalOpen.value = true
+      logNnRecoveryTrace(result.modelId, 'terminal', {
+        terminal: result.terminal,
+        failureKind: result.failureKind ?? null,
+      })
+    } else if (result.kind === 'failed' && debugMode.value) {
       console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
     }
-  } catch (error) {
-    if (handleNeuralRecoveryTerminalError(error)) {
-      if (error instanceof NeuralRecoveryTerminalError && match.value) {
-        const ux = resolveNeuralRecoveryTerminalUx({
-          terminal: error.terminal,
-          hasMatchSetup: Boolean(match.value.setup),
-        })
-        if (ux.action === 'refresh-dialog') {
-          match.value = attachNeuralRecoverySnapshotToMatch(match.value, nnRecovery)
-          persistCurrentMatch(window.localStorage, match.value)
-        }
-      }
-      return
-    }
-    throw error
   } finally {
     syncPresentationLabel()
   }

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -723,12 +723,13 @@ import {
   shouldDeferDungeonExitUntilOutcomeAck,
 } from '../../features/dungeon-runner/ui/headlessMatchCompletionRunner.js'
 import {
-  applyNeuralLoadGateSetupTerminalForPage,
   bootstrapCurrentMatchFromStorage,
   runHeadlessMatchCompletionForPage,
   buildNewMatchEnvelope,
   runMatchEntryNeuralLoadGateForPage,
 } from '../../features/dungeon-runner/matchPageOrchestration.js'
+import { createMatchPageOrchestrationContext } from '../../features/dungeon-runner/createMatchPageOrchestrationContext.js'
+import { createLiveMatchPageSessionSink } from '../../features/dungeon-runner/createLiveMatchPageSessionSink.js'
 import { resetLiveMatchPageState } from '../../features/dungeon-runner/resetLiveMatchPageState.js'
 import { createLivePlayActionChooser } from '../../features/dungeon-runner/ui/livePlayActionChooser.js'
 import { buildMatchOverSummary } from '../../features/dungeon-runner/ui/matchOverSummaryBuilder.js'
@@ -1009,6 +1010,28 @@ let lastScheduleSkipKey = ''
 let lastPrimeSkipTraceKey = ''
 /** @type {Promise<void> | null} */
 let nnModelsWarmPromise = null
+
+const liveMatchPageSessionSink = createLiveMatchPageSessionSink({
+  match,
+  setNnModelsWarmPromise: (promise) => {
+    nnModelsWarmPromise = promise
+  },
+  resetAiTurnPrefetch,
+  setLastAppliedAiTurnTokenNull: () => {
+    lastAppliedAiTurnToken = null
+  },
+  setPresentationInputWasLockedFalse: () => {
+    presentationInputWasLocked = false
+  },
+  deferredPostDungeonState,
+  nnDebugTraceText,
+  nnDebugTraceHistory,
+  presentationOrchestrator,
+  syncPresentationLabel,
+  neuralLoadGateTerminalOpen,
+  clearCurrentMatch,
+  storage: window.localStorage,
+})
 
 const AI_TURN_SCHEDULE_DELAY_MS = 300
 
@@ -1413,18 +1436,7 @@ function applyBootstrappedMatchSession(matchEnvelope, pace) {
 }
 
 async function bootstrapDungeonRunnerPage() {
-  const result = await bootstrapCurrentMatchFromStorage({
-    storage: window.localStorage,
-    loadModel: loadNnModel,
-    setMatchNeuralLoadGateInFlight: (inFlight) => {
-      matchNeuralLoadGateInFlight.value = inFlight
-    },
-    clearCurrentMatch,
-    applySetupSnapshot,
-    setupTarget: setup,
-    cloneSetup,
-    recovery: nnRecovery,
-  })
+  const result = await bootstrapCurrentMatchFromStorage(matchPageOrchestrationCtx)
 
   if (result.kind === 'no-saved-match') return
   if (result.kind === 'setup-terminal') {
@@ -1507,73 +1519,47 @@ watch(
   },
 )
 
-function createLiveMatchPageSessionSink() {
-  return {
-    setMatchNull: () => {
-      match.value = null
-    },
-    setNnModelsWarmPromise: (promise) => {
-      nnModelsWarmPromise = promise
-    },
-    resetAiTurnPrefetch,
-    setLastAppliedAiTurnTokenNull: () => {
-      lastAppliedAiTurnToken = null
-    },
-    setPresentationInputWasLockedFalse: () => {
-      presentationInputWasLocked = false
-    },
-    setDeferredPostDungeonStateNull: () => {
-      deferredPostDungeonState.value = null
-    },
-    clearDebugTraces: () => {
-      nnDebugTraceText.value = ''
-      nnDebugTraceHistory.value = []
-    },
-    clearPresentation: () => {
-      presentationOrchestrator.clear()
-    },
-    syncPresentationLabel,
-    setNeuralLoadGateTerminalOpen: (open) => {
-      neuralLoadGateTerminalOpen.value = open
-    },
-    clearPersistedMatch: () => {
-      clearCurrentMatch(window.localStorage)
-    },
-  }
-}
-
 function resetLiveMatchPageStateForSetupTerminal() {
-  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
     clearMatch: true,
     openNeuralLoadGateTerminal: true,
   })
 }
 
 function resetLiveMatchPageStateForFreshMatchEntry() {
-  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
     warmModelsResolved: true,
   })
 }
 
 function resetLiveMatchPageStateForBackToSetup() {
-  resetLiveMatchPageState(createLiveMatchPageSessionSink(), {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
     clearMatch: true,
     clearPersistedMatch: true,
   })
 }
 
+const matchPageOrchestrationCtx = createMatchPageOrchestrationContext({
+  storage: window.localStorage,
+  recovery: nnRecovery,
+  loadModel: loadNnModel,
+  setMatchNeuralLoadGateInFlight: (inFlight) => {
+    matchNeuralLoadGateInFlight.value = inFlight
+  },
+  clearCurrentMatch,
+  persistCurrentMatch,
+  applySetupSnapshot,
+  setupTarget: setup,
+  cloneSetup,
+  onSetupTerminal: () => {
+    resetLiveMatchPageStateForSetupTerminal()
+  },
+})
+
 async function runLivePageMatchEntryGate(setupSnapshot) {
-  return runMatchEntryNeuralLoadGateForPage({
+  return runMatchEntryNeuralLoadGateForPage(matchPageOrchestrationCtx, {
     setupSnapshot,
-    loadModel: loadNnModel,
-    setMatchNeuralLoadGateInFlight: (inFlight) => {
-      matchNeuralLoadGateInFlight.value = inFlight
-    },
     releaseInFlightAfterGate: false,
-    storage: window.localStorage,
-    clearCurrentMatch,
-    applySetupSnapshot,
-    setupTarget: setup,
   })
 }
 
@@ -1647,14 +1633,7 @@ async function ensureNnModelsReady() {
 }
 
 function applyNeuralLoadGateSetupTerminal(setupSnapshot) {
-  applyNeuralLoadGateSetupTerminalForPage({
-    storage: window.localStorage,
-    setupSnapshot,
-    clearCurrentMatch,
-    applySetupSnapshot,
-    setupTarget: setup,
-  })
-  resetLiveMatchPageStateForSetupTerminal()
+  matchPageOrchestrationCtx.applySetupTerminal(setupSnapshot)
 }
 
 function dismissNeuralLoadGateTerminal() {
@@ -1838,16 +1817,12 @@ function createPageHeadlessCompletionFlightGate() {
 
 async function maybeRunHeadlessMatchCompletion() {
   try {
-    const result = await runHeadlessMatchCompletionForPage({
+    const result = await runHeadlessMatchCompletionForPage(matchPageOrchestrationCtx, {
       match: match.value,
       humanPlayerSeatId: humanSeatId.value,
       chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
-      recovery: nnRecovery,
       gate: createPageHeadlessCompletionFlightGate(),
       teardown: teardownForHeadlessMatchCompletion,
-      storage: window.localStorage,
-      persistCurrentMatch,
-      applySetupTerminal: (setupSnapshot) => applyNeuralLoadGateSetupTerminal(cloneSetup(setupSnapshot)),
     })
 
     if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
@@ -1859,6 +1834,8 @@ async function maybeRunHeadlessMatchCompletion() {
         terminal: result.terminal,
         failureKind: result.failureKind ?? null,
       })
+    } else if (result.kind === 'setup-terminal') {
+      // applySetupTerminal already ran inside runHeadlessMatchCompletionForPage
     } else if (result.kind === 'failed' && debugMode.value) {
       console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
     }


### PR DESCRIPTION
## Summary

- Add plain-JS **match page orchestration** (`matchPageOrchestration.js`) composing the **match neural load gate** wrapper, **current match** bootstrap resume, and **finishing match** headless runner with discriminated results for thin page wiring.
- Consolidate new **match** materialization into `materializeNewMatchState` (shared by live start/rematch and replay bootstrap) and deduplicate live session reset via `resetLiveMatchPageState`.
- Refactor `DungeonRunnerPage.vue` to call orchestrators for bootstrap, start, rematch, and headless paths while keeping the recovery subscribe handler, AI scheduling, and presentation orchestrator on the page.

Closes #176. Implements slices #193–#197.

## Test plan

- [x] Dungeon-runner unit suite green (orchestration, materialization, session reset)
- [x] ESLint clean on changed files
- [x] Manual smoke: start **match** with **neural opponent**, reload page, **current match** resumes