### PR TITLE
Dungeon Runner: decompose play page into setup / live / match-over shells

### DIFF
--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -106,6 +106,36 @@ Headless resolution of remaining **opponent** play after the **human player seat
 
 _Avoid_: Treating **finishing match** as **match over**; implying the whole **match** stops when only the human is **eliminated**; conflating with **neural runtime recovery** blocking (recovery can interrupt headless completion).
 
+### Play setup surface
+
+The pre-**match** play UI for seat count, **opponent** roles, validation, and starting a **match**; active while there is no **current match** in play-route state (including after **neural recovery terminal outcome** **SETUP** or **match neural load gate** failure clears the **current match**).
+
+_Avoid_: “Setup screen,” “lobby”; conflating with **setup** (configuration data, not the surface); switching here because a blocking dialog is open while a **current match** still exists (**REFRESH** stays on **live match shell**).
+
+### Live match shell
+
+The in-progress play surface from first turn through **finishing match** (if any): board, human actions, **opponent** turn scheduling, presentation bindings, and mid-**match** dialogs ( **dungeon run** outcome, equipment, Vorpal, deck splay, **finishing match** overlay, **REFRESH** terminal). Active while a **current match** exists in play-route state and **match-over shell** has not taken over—including when blocked by **REFRESH** terminal, **finishing match**, or presentation locks.
+
+_Avoid_: “Game board” alone when meaning the whole live surface; treating **finishing match** as **match over**; conflating with **play setup surface**; using open dialogs alone as the shell switch; hosting **match neural load gate** pre-**match** failure UI here (that belongs on **play setup surface** when no **current match** yet exists).
+
+### Match-over shell
+
+The post-**match over** play surface: outcome dialog, **completed match replay** upload hooks, rematch, and return to **play setup surface**. Replaces the **live match shell** once the engine records **match over**—not during **finishing match**. The bidding/dungeon board is not rendered while this surface is active; **current match** data may remain in memory for upload and rematch until cleared. **Rematch** starts a new **match** with the same **setup** snapshot and enters **live match shell** directly (after **match neural load gate**); **Back to setup** clears the **current match** and restores **play setup surface** with prior **setup** choices. **Completed match replay** and **completed match outcome** upload run once when this surface activates (background, idempotent—not deferred until the player dismisses outcome UX).
+
+_Avoid_: “End screen” without **match over** scope; conflating with **dungeon run** outcome dialogs (mid-**match**); activating during **finishing match**; leaving the live board mounted behind the outcome dialog; routing **Rematch** through **play setup surface** unless gate failure yields **SETUP** terminal; waiting for **Rematch**/**Back to setup** before upload; triggering upload from **live match shell** board wiring.
+
+### Play route chrome
+
+Shared header and controls on the Dungeon Runner play route outside the three shells: title, help, settings (**presentation pace**, memory aid, fullscreen), debug badge, and **play route bootstrap**. Shell-specific actions (e.g. intentional new **match** during live play) wire through the active shell but reuse this chrome frame. **Play route bootstrap** (resume **current match** from storage on first open) is coordinated here via orchestration modules—shells do not re-run gate, terminal recovery, or headless-completion policy.
+
+_Avoid_: Duplicating header/settings per shell; treating **match outcome dashboard** chrome as **play route chrome** (stats uses **portfolio shell**, not play **project** shell); duplicating **SETUP**/**REFRESH** bootstrap branches inside shells.
+
+### Debug replay panel
+
+Maintainer-only replay export/import UI when debug mode is on. Full panel (import, export, NN trace history) lives in **live match shell**; **match-over shell** may expose export-only when debug mode is on; **play setup surface** shows neither.
+
+_Avoid_: “Debug menu” without scope; import on **match-over shell** or **play setup surface**; moving the debug badge out of **play route chrome**.
+
 ### Elimination end (human)
 
 The **match** is over for the **human player seat** once that seat is **eliminated**; remaining **opponent** play finishes in **finishing match** before **match over** is recorded. The end dialog uses elimination-focused copy and does not name the winning **opponent**.
@@ -316,6 +346,21 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - A **match** contains one or more **dungeon runs** before **match over**.
 - **Elimination end (human)** and **Defeat (human, not eliminated)** use different end-dialog copy; only the latter names the winning seat.
 - Headless completion of remaining **opponent** play after human **elimination** uses the same action choosers as live play (not a simplified bot).
+- **Play setup surface**, **live match shell**, and **match-over shell** partition the play route; exactly one is active at a time.
+- **Play setup surface** ↔ **live match shell** is driven by whether a **current match** exists in play-route state, not by which dialog is open.
+- **Live match shell** stays active during **REFRESH** terminal blocking ( **current match** retained).
+- **Finishing match** belongs to the **live match shell**, not the **match-over shell**.
+- **Match-over shell** activates only after engine **match over**, not when the human is **eliminated** but **opponents** still play.
+- While **match-over shell** is active, the **live match shell** board is unmounted (outcome UX only); **current match** may persist in memory until rematch or return to **play setup surface**.
+- **Play route chrome** wraps all three shells; **presentation pace** and memory aid settings apply across **play setup surface** and **live match shell** (and rematch inherits them).
+- From **match-over shell**, **Rematch** reuses **setup** and enters **live match shell** without visiting **play setup surface**; **Back to setup** returns to **play setup surface** with **setup** restored.
+- Mid-**match** dialogs and **finishing match** overlay belong to **live match shell**; **match neural load gate** failure before a **current match** exists is shown on **play setup surface**.
+- **Play route bootstrap** maps orchestration outcomes to the active shell: no saved **match** or **SETUP** terminal → **play setup surface**; **REFRESH** terminal or successful resume → **live match shell** (headless completion when applicable).
+- **Completed match replay** and **completed match outcome** upload trigger when **match-over shell** activates, not from **live match shell**; not deferred until outcome dismissal.
+- **Opponent** turn scheduling, prefetch, **live AI turn pipeline gate** wiring, presentation-orchestrator callbacks during play, and the **neural runtime recovery** subscribe handler belong to **live match shell** (not **play setup surface** or **match-over shell**).
+- Debug badge stays on **play route chrome**; full **debug replay panel** on **live match shell**; export-only on **match-over shell** when debug mode is on.
+- **Play route bootstrap** with a **current match** already at **match over** enters **match-over shell** (outcome UX again, board unmounted); upload re-runs idempotently. **Persisted neural recovery** **REFRESH** on resume takes precedence over outcome (**live match shell** + refresh dialog)—**REFRESH** and terminal **match over** must not coexist on one saved **current match**.
+- Shared play-route state (**setup**, **current match**, orchestration inputs) lives outside the three shells; shells receive it via the page entry/session seam and own shell-local UI only—not a single composable owning the full **match** lifecycle (#176 rejection stands).
 - The **current match** holds in-progress **match** state locally until **match over** or clear; optional **persisted neural recovery** may be attached.
 - **Match neural load gate** runs before the first turn on new **match** start and on **current match** resume; gate load failure yields **neural recovery terminal outcome** **SETUP** without **neural runtime recovery** retries.
 - On **current match** resume, **match neural load gate** must succeed before surfacing **persisted neural recovery** or **finishing match** headless resolution.
@@ -350,6 +395,9 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 > **Dev:** “NN infer fails during **finishing match** — do we wipe the **current match**?”
 > **Domain expert:** “No — that’s **REFRESH**: keep the **current match**, block until the player refreshes. **SETUP** is for load exhaustion — clear the **current match** and restore **setup**, like **match neural load gate** failure at resume.”
 
+> **Dev:** “Player reloads mid-outcome — do we drop them on the board or back to **setup**?”
+> **Domain expert:** “**Match-over shell** again — same outcome UX, upload is idempotent. Only **REFRESH** persisted recovery overrides that and keeps **live match shell** blocked.”
+
 ## Flagged ambiguities
 
 - **Empty dungeon pile at bidding end** vs **sim empty-pile forfeit**: **web game engine** gives an immediate successful **dungeon run** (see kernel test). **Python training sim** uses **sim empty-pile forfeit** (`EMPTY_DUNGEON_FORFEIT`, no winner)—an anti-pass-farming rule from early training that remains a sim **local minima**; runtime play follows web/table rules. See [`UBIQUITOUS_LANGUAGE.md`](../../../UBIQUITOUS_LANGUAGE.md).
@@ -357,3 +405,4 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - “Catalog” without qualifier may mean the neural **model catalog** or the **game data catalog** — use the full term.
 - In-match “history panel” was considered and rejected — **history** stays engine/replay data only.
 - Seat “role badges” during play were considered and rejected — **opponent** type belongs in **setup** only.
+- Play page shell split (#212) moves wiring only; **presentation motion registry** consolidation stays a separate slice (#216)—shells consume existing orchestrator/registry seams unchanged.

--- a/src/features/dungeon-runner/enterMatchFromSetupSnapshot.js
+++ b/src/features/dungeon-runner/enterMatchFromSetupSnapshot.js
@@ -1,0 +1,67 @@
+import { createMatchSeed } from './setup/seed.js'
+
+/**
+ * @param {Array<{ role?: { type?: string }, label?: string }>} seats
+ * @returns {string[]}
+ */
+export function collectPreservedBotLabelsFromMatchState(seats) {
+  return seats
+    .filter((seat) => seat.role?.type !== 'human' && seat.label)
+    .map((seat) => seat.label)
+}
+
+/**
+ * Shared page flow: neural load gate → setup terminal or fresh match envelope → kick automation.
+ *
+ * @param {{
+ *   setupSnapshot: object
+ *   preservedBotLabels?: string[]
+ *   presentationSpeedProfile: string
+ *   clearPersistedMatch?: boolean
+ *   storage?: Storage
+ *   runMatchEntryGate: (setupSnapshot: object) => Promise<{ kind: 'success' } | { kind: 'setup-terminal' }>
+ *   resetForSetupTerminal: () => void
+ *   resetForFreshMatchEntry: () => void
+ *   buildNewMatchEnvelope: (options: object) => object
+ *   kickMatchAutomation: () => void
+ *   setMatchNeuralLoadGateInFlight: (inFlight: boolean) => void
+ *   clearCurrentMatch?: (storage: Storage) => void
+ *   createMatchId?: () => string
+ *   createSeed?: () => number
+ * }} options
+ * @returns {Promise<{ kind: 'setup-terminal' } | { kind: 'entered', match: object }>}
+ */
+export async function enterMatchFromSetupSnapshot(options) {
+  const createMatchId = options.createMatchId ?? (() => `match-${Date.now()}`)
+  const createSeed = options.createSeed ?? createMatchSeed
+
+  options.setMatchNeuralLoadGateInFlight(true)
+  try {
+    const gateResult = await options.runMatchEntryGate(options.setupSnapshot)
+    if (gateResult.kind === 'setup-terminal') {
+      options.resetForSetupTerminal()
+      return { kind: 'setup-terminal' }
+    }
+
+    if (options.clearPersistedMatch) {
+      options.clearCurrentMatch?.(options.storage)
+    }
+
+    const envelopeOptions = {
+      setupSnapshot: options.setupSnapshot,
+      seed: createSeed(),
+      id: createMatchId(),
+      presentationSpeedProfile: options.presentationSpeedProfile,
+    }
+    if (options.preservedBotLabels?.length) {
+      envelopeOptions.preservedBotLabels = options.preservedBotLabels
+    }
+
+    options.resetForFreshMatchEntry()
+    const match = options.buildNewMatchEnvelope(envelopeOptions)
+    return { kind: 'entered', match }
+  } finally {
+    options.setMatchNeuralLoadGateInFlight(false)
+    options.kickMatchAutomation()
+  }
+}

--- a/src/features/dungeon-runner/enterMatchFromSetupSnapshot.test.js
+++ b/src/features/dungeon-runner/enterMatchFromSetupSnapshot.test.js
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  collectPreservedBotLabelsFromMatchState,
+  enterMatchFromSetupSnapshot,
+} from './enterMatchFromSetupSnapshot.js'
+
+const SETUP = {
+  totalSeats: 2,
+  opponents: [{ type: 'randombot' }],
+}
+
+function createDeps(overrides = {}) {
+  const calls = {
+    gate: [],
+    resetSetupTerminal: 0,
+    resetFreshEntry: 0,
+    buildEnvelope: [],
+    kickAutomation: 0,
+    inFlight: [],
+    clearPersisted: 0,
+  }
+
+  const deps = {
+    setupSnapshot: SETUP,
+    presentationSpeedProfile: 'cinematic',
+    runMatchEntryGate: async (setupSnapshot) => {
+      calls.gate.push(setupSnapshot)
+      return { kind: 'success' }
+    },
+    resetForSetupTerminal: () => {
+      calls.resetSetupTerminal += 1
+    },
+    resetForFreshMatchEntry: () => {
+      calls.resetFreshEntry += 1
+    },
+    buildNewMatchEnvelope: (options) => {
+      calls.buildEnvelope.push(options)
+      return { id: options.id, envelope: true, options }
+    },
+    kickMatchAutomation: () => {
+      calls.kickAutomation += 1
+    },
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      calls.inFlight.push(inFlight)
+    },
+    createMatchId: () => 'match-test-id',
+    createSeed: () => 12345,
+    ...overrides,
+  }
+
+  return { deps, calls }
+}
+
+test('enterMatchFromSetupSnapshot returns setup-terminal without building match', async () => {
+  const { deps, calls } = createDeps({
+    runMatchEntryGate: async () => ({ kind: 'setup-terminal' }),
+  })
+
+  const result = await enterMatchFromSetupSnapshot(deps)
+
+  assert.deepEqual(result, { kind: 'setup-terminal' })
+  assert.equal(calls.resetSetupTerminal, 1)
+  assert.equal(calls.resetFreshEntry, 0)
+  assert.equal(calls.buildEnvelope.length, 0)
+  assert.equal(calls.kickAutomation, 1)
+  assert.deepEqual(calls.inFlight, [true, false])
+})
+
+test('enterMatchFromSetupSnapshot builds envelope on successful gate', async () => {
+  const { deps, calls } = createDeps()
+
+  const result = await enterMatchFromSetupSnapshot(deps)
+
+  assert.equal(result.kind, 'entered')
+  assert.equal(result.match.id, 'match-test-id')
+  assert.equal(calls.resetFreshEntry, 1)
+  assert.equal(calls.resetSetupTerminal, 0)
+  assert.deepEqual(calls.buildEnvelope, [
+    {
+      setupSnapshot: SETUP,
+      seed: 12345,
+      id: 'match-test-id',
+      presentationSpeedProfile: 'cinematic',
+    },
+  ])
+  assert.equal(calls.kickAutomation, 1)
+  assert.deepEqual(calls.inFlight, [true, false])
+})
+
+test('enterMatchFromSetupSnapshot forwards preservedBotLabels for rematch', async () => {
+  const preservedBotLabels = ['Bot A', 'Bot B']
+  const { deps, calls } = createDeps({ preservedBotLabels })
+
+  const result = await enterMatchFromSetupSnapshot(deps)
+
+  assert.equal(result.kind, 'entered')
+  assert.deepEqual(calls.buildEnvelope[0].preservedBotLabels, preservedBotLabels)
+})
+
+test('enterMatchFromSetupSnapshot skips clearCurrentMatch on setup-terminal', async () => {
+  const { deps, calls } = createDeps({
+    clearPersistedMatch: true,
+    runMatchEntryGate: async () => ({ kind: 'setup-terminal' }),
+    clearCurrentMatch: () => {
+      calls.clearPersisted += 1
+    },
+  })
+
+  await enterMatchFromSetupSnapshot(deps)
+
+  assert.equal(calls.clearPersisted, 0)
+})
+
+test('enterMatchFromSetupSnapshot clears persisted match when requested', async () => {
+  const storage = { kind: 'memory-storage' }
+  const { deps, calls } = createDeps({
+    clearPersistedMatch: true,
+    storage,
+    clearCurrentMatch: (nextStorage) => {
+      calls.clearPersisted += 1
+      assert.equal(nextStorage, storage)
+    },
+  })
+
+  await enterMatchFromSetupSnapshot(deps)
+
+  assert.equal(calls.clearPersisted, 1)
+})
+
+test('enterMatchFromSetupSnapshot skips clearCurrentMatch when not requested', async () => {
+  const { deps, calls } = createDeps({
+    clearCurrentMatch: () => {
+      calls.clearPersisted += 1
+    },
+  })
+
+  await enterMatchFromSetupSnapshot(deps)
+
+  assert.equal(calls.clearPersisted, 0)
+})
+
+test('enterMatchFromSetupSnapshot kicks automation after gate failure', async () => {
+  const { deps, calls } = createDeps({
+    runMatchEntryGate: async () => {
+      throw new Error('gate failed')
+    },
+  })
+
+  await assert.rejects(() => enterMatchFromSetupSnapshot(deps), /gate failed/)
+  assert.equal(calls.kickAutomation, 1)
+  assert.deepEqual(calls.inFlight, [true, false])
+})
+
+test('collectPreservedBotLabelsFromMatchState keeps non-human seat labels', () => {
+  const labels = collectPreservedBotLabelsFromMatchState([
+    { id: 'human', role: { type: 'human' }, label: 'You' },
+    { id: 'bot-1', role: { type: 'randombot' }, label: 'Rook' },
+    { id: 'bot-2', role: { type: 'nn' }, label: 'Oracle' },
+    { id: 'bot-3', role: { type: 'randombot' } },
+  ])
+
+  assert.deepEqual(labels, ['Rook', 'Oracle'])
+})

--- a/src/features/dungeon-runner/ui/playSetupShell.js
+++ b/src/features/dungeon-runner/ui/playSetupShell.js
@@ -30,13 +30,6 @@ export function evaluatePlaySetupStart({ setup, modelOptions }) {
 }
 
 /**
- * @param {{ setup: { totalSeats: number, opponents: Array<{ type: string, modelId?: string }> }, modelOptions: Array<string | { value?: string }> }} inputs
- */
-export function isPlaySetupStartEnabled(inputs) {
-  return evaluatePlaySetupStart(inputs).ok
-}
-
-/**
  * @param {{ opponents: Array<{ type: string, modelId?: string }> }} setup
  * @param {Array<string | { value?: string }>} modelOptions
  */

--- a/src/features/dungeon-runner/ui/playSetupShell.js
+++ b/src/features/dungeon-runner/ui/playSetupShell.js
@@ -1,0 +1,51 @@
+import { pickDefaultModelId, validateSelectedModels } from '../models/discovery.js'
+import { validateSetupConfig } from '../setup/config.js'
+import { canStartMatchFromSetup, normalizeSetupState } from '../setup/state.js'
+
+export const PLAY_SETUP_SHELL_TEST_IDS = {
+  root: 'play-setup-shell',
+  neuralLoadGateTerminal: 'neural-load-gate-terminal',
+  neuralLoadGateTerminalDismiss: 'neural-load-gate-terminal-dismiss',
+  startMatch: 'play-setup-start-match',
+}
+
+/**
+ * @param {{ setup: { totalSeats: number, opponents: Array<{ type: string, modelId?: string }> }, modelOptions: Array<string | { value?: string }> }} inputs
+ * @returns {{ ok: true } | { ok: false, errorCode: string }}
+ */
+export function evaluatePlaySetupStart({ setup, modelOptions }) {
+  const normalized = normalizeSetupState(setup)
+  const configResult = validateSetupConfig(normalized)
+  if (!configResult.ok) {
+    return { ok: false, errorCode: configResult.errorCode }
+  }
+  if (!canStartMatchFromSetup(setup)) {
+    return { ok: false, errorCode: 'INVALID_SETUP' }
+  }
+  const modelResult = validateSelectedModels(setup.opponents, modelOptions)
+  if (!modelResult.ok) {
+    return { ok: false, errorCode: modelResult.errorCode }
+  }
+  return { ok: true }
+}
+
+/**
+ * @param {{ setup: { totalSeats: number, opponents: Array<{ type: string, modelId?: string }> }, modelOptions: Array<string | { value?: string }> }} inputs
+ */
+export function isPlaySetupStartEnabled(inputs) {
+  return evaluatePlaySetupStart(inputs).ok
+}
+
+/**
+ * @param {{ opponents: Array<{ type: string, modelId?: string }> }} setup
+ * @param {Array<string | { value?: string }>} modelOptions
+ */
+export function applyNnDefaultModelIds(setup, modelOptions) {
+  const defaultModel = pickDefaultModelId(modelOptions)
+  if (!defaultModel) return
+  for (const opponent of setup.opponents ?? []) {
+    if (opponent.type === 'nn' && !opponent.modelId) {
+      opponent.modelId = defaultModel
+    }
+  }
+}

--- a/src/features/dungeon-runner/ui/playSetupShell.test.js
+++ b/src/features/dungeon-runner/ui/playSetupShell.test.js
@@ -4,7 +4,6 @@ import {
   PLAY_SETUP_SHELL_TEST_IDS,
   applyNnDefaultModelIds,
   evaluatePlaySetupStart,
-  isPlaySetupStartEnabled,
 } from './playSetupShell.js'
 
 test('PLAY_SETUP_SHELL_TEST_IDS exposes stable setup-surface selectors', () => {
@@ -17,45 +16,45 @@ test('PLAY_SETUP_SHELL_TEST_IDS exposes stable setup-surface selectors', () => {
   assert.equal(PLAY_SETUP_SHELL_TEST_IDS.startMatch, 'play-setup-start-match')
 })
 
-test('isPlaySetupStartEnabled is false when setup has no opponents', () => {
+test('evaluatePlaySetupStart ok is false when setup has no opponents', () => {
   assert.equal(
-    isPlaySetupStartEnabled({
+    evaluatePlaySetupStart({
       setup: { totalSeats: 2, opponents: [] },
       modelOptions: ['latest'],
-    }),
+    }).ok,
     false,
   )
 })
 
-test('isPlaySetupStartEnabled is false when nn opponent lacks a selected model', () => {
+test('evaluatePlaySetupStart ok is false when nn opponent lacks a selected model', () => {
   const setup = { totalSeats: 2, opponents: [{ type: 'nn' }] }
   assert.equal(
-    isPlaySetupStartEnabled({
+    evaluatePlaySetupStart({
       setup,
       modelOptions: ['latest'],
-    }),
+    }).ok,
     false,
   )
 })
 
-test('isPlaySetupStartEnabled is true for valid nn setup with catalog model', () => {
+test('evaluatePlaySetupStart ok is true for valid nn setup with catalog model', () => {
   const setup = { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] }
   assert.equal(
-    isPlaySetupStartEnabled({
+    evaluatePlaySetupStart({
       setup,
       modelOptions: ['latest'],
-    }),
+    }).ok,
     true,
   )
 })
 
-test('isPlaySetupStartEnabled is true for randombot-only setup without models', () => {
+test('evaluatePlaySetupStart ok is true for randombot-only setup without models', () => {
   const setup = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
   assert.equal(
-    isPlaySetupStartEnabled({
+    evaluatePlaySetupStart({
       setup,
       modelOptions: [],
-    }),
+    }).ok,
     true,
   )
 })
@@ -68,14 +67,6 @@ test('evaluatePlaySetupStart reports INVALID_SETUP when opponents list is empty'
     }),
     { ok: false, errorCode: 'INVALID_SETUP' },
   )
-})
-
-test('isPlaySetupStartEnabled mirrors evaluatePlaySetupStart ok flag', () => {
-  const inputs = {
-    setup: { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
-    modelOptions: ['latest'],
-  }
-  assert.equal(isPlaySetupStartEnabled(inputs), evaluatePlaySetupStart(inputs).ok)
 })
 
 test('evaluatePlaySetupStart reports unavailable nn model when catalog is non-empty', () => {

--- a/src/features/dungeon-runner/ui/playSetupShell.test.js
+++ b/src/features/dungeon-runner/ui/playSetupShell.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  PLAY_SETUP_SHELL_TEST_IDS,
+  applyNnDefaultModelIds,
+  evaluatePlaySetupStart,
+  isPlaySetupStartEnabled,
+} from './playSetupShell.js'
+
+test('PLAY_SETUP_SHELL_TEST_IDS exposes stable setup-surface selectors', () => {
+  assert.equal(PLAY_SETUP_SHELL_TEST_IDS.root, 'play-setup-shell')
+  assert.equal(PLAY_SETUP_SHELL_TEST_IDS.neuralLoadGateTerminal, 'neural-load-gate-terminal')
+  assert.equal(
+    PLAY_SETUP_SHELL_TEST_IDS.neuralLoadGateTerminalDismiss,
+    'neural-load-gate-terminal-dismiss',
+  )
+  assert.equal(PLAY_SETUP_SHELL_TEST_IDS.startMatch, 'play-setup-start-match')
+})
+
+test('isPlaySetupStartEnabled is false when setup has no opponents', () => {
+  assert.equal(
+    isPlaySetupStartEnabled({
+      setup: { totalSeats: 2, opponents: [] },
+      modelOptions: ['latest'],
+    }),
+    false,
+  )
+})
+
+test('isPlaySetupStartEnabled is false when nn opponent lacks a selected model', () => {
+  const setup = { totalSeats: 2, opponents: [{ type: 'nn' }] }
+  assert.equal(
+    isPlaySetupStartEnabled({
+      setup,
+      modelOptions: ['latest'],
+    }),
+    false,
+  )
+})
+
+test('isPlaySetupStartEnabled is true for valid nn setup with catalog model', () => {
+  const setup = { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] }
+  assert.equal(
+    isPlaySetupStartEnabled({
+      setup,
+      modelOptions: ['latest'],
+    }),
+    true,
+  )
+})
+
+test('isPlaySetupStartEnabled is true for randombot-only setup without models', () => {
+  const setup = { totalSeats: 2, opponents: [{ type: 'randombot' }] }
+  assert.equal(
+    isPlaySetupStartEnabled({
+      setup,
+      modelOptions: [],
+    }),
+    true,
+  )
+})
+
+test('evaluatePlaySetupStart reports INVALID_SETUP when opponents list is empty', () => {
+  assert.deepEqual(
+    evaluatePlaySetupStart({
+      setup: { totalSeats: 2, opponents: [] },
+      modelOptions: [],
+    }),
+    { ok: false, errorCode: 'INVALID_SETUP' },
+  )
+})
+
+test('isPlaySetupStartEnabled mirrors evaluatePlaySetupStart ok flag', () => {
+  const inputs = {
+    setup: { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'latest' }] },
+    modelOptions: ['latest'],
+  }
+  assert.equal(isPlaySetupStartEnabled(inputs), evaluatePlaySetupStart(inputs).ok)
+})
+
+test('evaluatePlaySetupStart reports unavailable nn model when catalog is non-empty', () => {
+  const setup = { totalSeats: 2, opponents: [{ type: 'nn', modelId: 'missing' }] }
+  assert.deepEqual(
+    evaluatePlaySetupStart({
+      setup,
+      modelOptions: ['latest'],
+    }),
+    { ok: false, errorCode: 'MODEL_UNAVAILABLE' },
+  )
+})
+
+test('applyNnDefaultModelIds fills nn opponents without modelId', () => {
+  const setup = {
+    totalSeats: 3,
+    opponents: [{ type: 'nn' }, { type: 'randombot' }],
+  }
+  applyNnDefaultModelIds(setup, ['v1.0.0', 'latest'])
+  assert.equal(setup.opponents[0].modelId, 'latest')
+  assert.equal(setup.opponents[1].modelId, undefined)
+})
+
+test('applyNnDefaultModelIds leaves existing nn modelId unchanged', () => {
+  const setup = {
+    totalSeats: 2,
+    opponents: [{ type: 'nn', modelId: 'v1.0.0' }],
+  }
+  applyNnDefaultModelIds(setup, ['latest'])
+  assert.equal(setup.opponents[0].modelId, 'v1.0.0')
+})

--- a/src/features/dungeon-runner/ui/playShellResolver.js
+++ b/src/features/dungeon-runner/ui/playShellResolver.js
@@ -1,0 +1,61 @@
+import { MATCH_PHASES } from '../engine/kernel.js'
+
+export const PLAY_SHELL = {
+  PLAY_SETUP: 'play-setup',
+  LIVE_MATCH: 'live-match',
+  MATCH_OVER: 'match-over',
+}
+
+/**
+ * @param {{
+ *   match: { state?: { phase?: string } } | null
+ *   neuralRefreshTerminalSurfaced: boolean
+ *   matchNeuralLoadGateInFlight?: boolean
+ * }} inputs
+ * @returns {{
+ *   hasCurrentMatch: boolean
+ *   matchPhase: string | null
+ *   neuralRefreshTerminalSurfaced: boolean
+ *   matchNeuralLoadGateInFlight: boolean
+ * }}
+ */
+export function buildPlayShellSnapshot({
+  match,
+  neuralRefreshTerminalSurfaced,
+  matchNeuralLoadGateInFlight = false,
+}) {
+  return {
+    hasCurrentMatch: Boolean(match),
+    matchPhase: match?.state?.phase ?? null,
+    neuralRefreshTerminalSurfaced,
+    matchNeuralLoadGateInFlight,
+  }
+}
+
+/**
+ * @param {{
+ *   hasCurrentMatch: boolean
+ *   matchPhase: string | null
+ *   neuralRefreshTerminalSurfaced: boolean
+ *   matchNeuralLoadGateInFlight?: boolean
+ * }} snapshot
+ * @returns {typeof PLAY_SHELL[keyof typeof PLAY_SHELL]}
+ */
+export function resolveActivePlayShell(snapshot) {
+  if (!snapshot.hasCurrentMatch) {
+    return PLAY_SHELL.PLAY_SETUP
+  }
+  if (snapshot.neuralRefreshTerminalSurfaced) {
+    return PLAY_SHELL.LIVE_MATCH
+  }
+  if (snapshot.matchNeuralLoadGateInFlight) {
+    if (snapshot.matchPhase === MATCH_PHASES.MATCH_OVER) {
+      return PLAY_SHELL.MATCH_OVER
+    }
+    return PLAY_SHELL.LIVE_MATCH
+  }
+  if (snapshot.matchPhase === MATCH_PHASES.MATCH_OVER) {
+    return PLAY_SHELL.MATCH_OVER
+  }
+  return PLAY_SHELL.LIVE_MATCH
+}

--- a/src/features/dungeon-runner/ui/playShellResolver.js
+++ b/src/features/dungeon-runner/ui/playShellResolver.js
@@ -12,49 +12,27 @@ export const PLAY_SHELL = {
  *   neuralRefreshTerminalSurfaced: boolean
  *   matchNeuralLoadGateInFlight?: boolean
  * }} inputs
- * @returns {{
- *   hasCurrentMatch: boolean
- *   matchPhase: string | null
- *   neuralRefreshTerminalSurfaced: boolean
- *   matchNeuralLoadGateInFlight: boolean
- * }}
+ * @returns {typeof PLAY_SHELL[keyof typeof PLAY_SHELL]}
  */
-export function buildPlayShellSnapshot({
+export function resolveActivePlayShell({
   match,
   neuralRefreshTerminalSurfaced,
   matchNeuralLoadGateInFlight = false,
 }) {
-  return {
-    hasCurrentMatch: Boolean(match),
-    matchPhase: match?.state?.phase ?? null,
-    neuralRefreshTerminalSurfaced,
-    matchNeuralLoadGateInFlight,
-  }
-}
-
-/**
- * @param {{
- *   hasCurrentMatch: boolean
- *   matchPhase: string | null
- *   neuralRefreshTerminalSurfaced: boolean
- *   matchNeuralLoadGateInFlight?: boolean
- * }} snapshot
- * @returns {typeof PLAY_SHELL[keyof typeof PLAY_SHELL]}
- */
-export function resolveActivePlayShell(snapshot) {
-  if (!snapshot.hasCurrentMatch) {
+  if (!match) {
     return PLAY_SHELL.PLAY_SETUP
   }
-  if (snapshot.neuralRefreshTerminalSurfaced) {
+  if (neuralRefreshTerminalSurfaced) {
     return PLAY_SHELL.LIVE_MATCH
   }
-  if (snapshot.matchNeuralLoadGateInFlight) {
-    if (snapshot.matchPhase === MATCH_PHASES.MATCH_OVER) {
+  const matchPhase = match.state?.phase ?? null
+  if (matchNeuralLoadGateInFlight) {
+    if (matchPhase === MATCH_PHASES.MATCH_OVER) {
       return PLAY_SHELL.MATCH_OVER
     }
     return PLAY_SHELL.LIVE_MATCH
   }
-  if (snapshot.matchPhase === MATCH_PHASES.MATCH_OVER) {
+  if (matchPhase === MATCH_PHASES.MATCH_OVER) {
     return PLAY_SHELL.MATCH_OVER
   }
   return PLAY_SHELL.LIVE_MATCH

--- a/src/features/dungeon-runner/ui/playShellResolver.test.js
+++ b/src/features/dungeon-runner/ui/playShellResolver.test.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MATCH_PHASES } from '../engine/kernel.js'
+import {
+  PLAY_SHELL,
+  buildPlayShellSnapshot,
+  resolveActivePlayShell,
+} from './playShellResolver.js'
+
+const ACTIVATION_ROWS = [
+  {
+    label: 'no current match',
+    snapshot: {
+      hasCurrentMatch: false,
+      matchPhase: null,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: false,
+    },
+    expected: PLAY_SHELL.PLAY_SETUP,
+  },
+  {
+    label: 'rematch gate in flight keeps match-over shell',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.MATCH_OVER,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: true,
+    },
+    expected: PLAY_SHELL.MATCH_OVER,
+  },
+  {
+    label: 'fresh match entry gate in flight routes to live-match',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.BIDDING,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: true,
+    },
+    expected: PLAY_SHELL.LIVE_MATCH,
+  },
+  {
+    label: 'current match with REFRESH terminal surfaced',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.BIDDING,
+      neuralRefreshTerminalSurfaced: true,
+      matchNeuralLoadGateInFlight: false,
+    },
+    expected: PLAY_SHELL.LIVE_MATCH,
+  },
+  {
+    label: 'current match in progress',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.DUNGEON,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: false,
+    },
+    expected: PLAY_SHELL.LIVE_MATCH,
+  },
+  {
+    label: 'current match at match over',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.MATCH_OVER,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: false,
+    },
+    expected: PLAY_SHELL.MATCH_OVER,
+  },
+  {
+    label: 'REFRESH terminal takes precedence over match over',
+    snapshot: {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.MATCH_OVER,
+      neuralRefreshTerminalSurfaced: true,
+      matchNeuralLoadGateInFlight: false,
+    },
+    expected: PLAY_SHELL.LIVE_MATCH,
+  },
+]
+
+test('resolveActivePlayShell activation matrix', () => {
+  for (const row of ACTIVATION_ROWS) {
+    assert.equal(resolveActivePlayShell(row.snapshot), row.expected, row.label)
+  }
+})
+
+test('resolveActivePlayShell selects live-match for every in-progress match phase', () => {
+  for (const phase of [
+    MATCH_PHASES.BIDDING,
+    MATCH_PHASES.DUNGEON,
+    MATCH_PHASES.PICK_ADVENTURER,
+  ]) {
+    assert.equal(
+      resolveActivePlayShell({
+        hasCurrentMatch: true,
+        matchPhase: phase,
+        neuralRefreshTerminalSurfaced: false,
+        matchNeuralLoadGateInFlight: false,
+      }),
+      PLAY_SHELL.LIVE_MATCH,
+      phase,
+    )
+  }
+})
+
+test('buildPlayShellSnapshot maps play-route session inputs', () => {
+  assert.deepEqual(
+    buildPlayShellSnapshot({
+      match: null,
+      neuralRefreshTerminalSurfaced: false,
+    }),
+    {
+      hasCurrentMatch: false,
+      matchPhase: null,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: false,
+    },
+  )
+
+  assert.deepEqual(
+    buildPlayShellSnapshot({
+      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
+      neuralRefreshTerminalSurfaced: true,
+      matchNeuralLoadGateInFlight: true,
+    }),
+    {
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.MATCH_OVER,
+      neuralRefreshTerminalSurfaced: true,
+      matchNeuralLoadGateInFlight: true,
+    },
+  )
+})
+
+test('resolveActivePlayShell never selects play-setup while rematch gate runs with current match', () => {
+  assert.notEqual(
+    resolveActivePlayShell({
+      hasCurrentMatch: true,
+      matchPhase: MATCH_PHASES.MATCH_OVER,
+      neuralRefreshTerminalSurfaced: false,
+      matchNeuralLoadGateInFlight: true,
+    }),
+    PLAY_SHELL.PLAY_SETUP,
+  )
+})

--- a/src/features/dungeon-runner/ui/playShellResolver.test.js
+++ b/src/features/dungeon-runner/ui/playShellResolver.test.js
@@ -1,18 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { MATCH_PHASES } from '../engine/kernel.js'
-import {
-  PLAY_SHELL,
-  buildPlayShellSnapshot,
-  resolveActivePlayShell,
-} from './playShellResolver.js'
+import { PLAY_SHELL, resolveActivePlayShell } from './playShellResolver.js'
 
 const ACTIVATION_ROWS = [
   {
     label: 'no current match',
-    snapshot: {
-      hasCurrentMatch: false,
-      matchPhase: null,
+    inputs: {
+      match: null,
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: false,
     },
@@ -20,9 +15,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'rematch gate in flight keeps match-over shell',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.MATCH_OVER,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: true,
     },
@@ -30,9 +24,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'fresh match entry gate in flight routes to live-match',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.BIDDING,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.BIDDING } },
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: true,
     },
@@ -40,9 +33,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'current match with REFRESH terminal surfaced',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.BIDDING,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.BIDDING } },
       neuralRefreshTerminalSurfaced: true,
       matchNeuralLoadGateInFlight: false,
     },
@@ -50,9 +42,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'current match in progress',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.DUNGEON,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.DUNGEON } },
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: false,
     },
@@ -60,9 +51,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'current match at match over',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.MATCH_OVER,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: false,
     },
@@ -70,9 +60,8 @@ const ACTIVATION_ROWS = [
   },
   {
     label: 'REFRESH terminal takes precedence over match over',
-    snapshot: {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.MATCH_OVER,
+    inputs: {
+      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
       neuralRefreshTerminalSurfaced: true,
       matchNeuralLoadGateInFlight: false,
     },
@@ -82,7 +71,7 @@ const ACTIVATION_ROWS = [
 
 test('resolveActivePlayShell activation matrix', () => {
   for (const row of ACTIVATION_ROWS) {
-    assert.equal(resolveActivePlayShell(row.snapshot), row.expected, row.label)
+    assert.equal(resolveActivePlayShell(row.inputs), row.expected, row.label)
   }
 })
 
@@ -94,8 +83,7 @@ test('resolveActivePlayShell selects live-match for every in-progress match phas
   ]) {
     assert.equal(
       resolveActivePlayShell({
-        hasCurrentMatch: true,
-        matchPhase: phase,
+        match: { state: { phase } },
         neuralRefreshTerminalSurfaced: false,
         matchNeuralLoadGateInFlight: false,
       }),
@@ -105,40 +93,10 @@ test('resolveActivePlayShell selects live-match for every in-progress match phas
   }
 })
 
-test('buildPlayShellSnapshot maps play-route session inputs', () => {
-  assert.deepEqual(
-    buildPlayShellSnapshot({
-      match: null,
-      neuralRefreshTerminalSurfaced: false,
-    }),
-    {
-      hasCurrentMatch: false,
-      matchPhase: null,
-      neuralRefreshTerminalSurfaced: false,
-      matchNeuralLoadGateInFlight: false,
-    },
-  )
-
-  assert.deepEqual(
-    buildPlayShellSnapshot({
-      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
-      neuralRefreshTerminalSurfaced: true,
-      matchNeuralLoadGateInFlight: true,
-    }),
-    {
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.MATCH_OVER,
-      neuralRefreshTerminalSurfaced: true,
-      matchNeuralLoadGateInFlight: true,
-    },
-  )
-})
-
 test('resolveActivePlayShell never selects play-setup while rematch gate runs with current match', () => {
   assert.notEqual(
     resolveActivePlayShell({
-      hasCurrentMatch: true,
-      matchPhase: MATCH_PHASES.MATCH_OVER,
+      match: { state: { phase: MATCH_PHASES.MATCH_OVER } },
       neuralRefreshTerminalSurfaced: false,
       matchNeuralLoadGateInFlight: true,
     }),

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -1,0 +1,842 @@
+<template>
+  <div :data-testid="LIVE_MATCH_SHELL_TEST_IDS.root">
+    <div :ref="session.bindBoardShellRef" class="dr-board-shell">
+      <div
+        v-if="session.showDungeonStage && session.dungeonStageView.hpBar"
+        class="dr-dungeon-hp-bar q-mb-sm"
+        role="meter"
+        aria-label="Adventurer HP"
+        aria-valuemin="0"
+        :aria-valuemax="session.dungeonStageView.hpBar.displayMaxHp"
+        :aria-valuenow="session.dungeonStageView.hpBar.currentHp"
+      >
+        <div class="row items-center justify-between q-mb-xs">
+          <span class="text-caption text-weight-medium">HP</span>
+          <span class="text-caption">{{ session.dungeonStageView.hpBar.text }}</span>
+        </div>
+        <div class="dr-dungeon-hp-bar__track">
+          <div
+            class="dr-dungeon-hp-bar__fill"
+            :style="{ width: `${session.dungeonStageView.hpBar.percent}%` }"
+          />
+        </div>
+      </div>
+      <q-card
+        flat
+        bordered
+        class="q-pa-sm q-mb-sm dr-bidding-board"
+        :class="session.biddingBoard.heroCue.accentClass"
+      >
+      <div
+        v-if="session.seatRunTrackerRows.length"
+        class="dr-seat-strip q-mb-sm"
+      >
+        <div class="row q-col-gutter-xs">
+          <div v-for="row in session.seatRunTrackerRows" :key="`seat-${row.seatId}`" class="col dr-seat-stack">
+            <q-badge
+              :color="row.passed ? 'grey-9' : session.biddingBoard.heroCue.badgeColor"
+              text-color="white"
+              class="dr-seat-chip q-px-sm full-width"
+              :class="{ 'dr-token-glow': row.isActive }"
+            >
+              <span class="text-caption">{{ row.label }}</span>
+            </q-badge>
+            <div
+              v-if="row.recovering"
+              class="row items-center justify-center q-mt-xs"
+              :data-testid="row.recoveryTestId"
+            >
+              <q-spinner size="16px" color="primary" />
+            </div>
+            <div class="dr-seat-progress-cell text-caption" :aria-label="row.ariaLabel">
+              <span
+                v-for="index in row.successes"
+                :key="`success-${row.seatId}-${index}`"
+                class="dr-seat-progress-marker dr-seat-progress-marker--success"
+              >
+                ✓
+              </span>
+              <span
+                v-for="index in row.failures"
+                :key="`failure-${row.seatId}-${index}`"
+                class="dr-seat-progress-marker dr-seat-progress-marker--failure"
+              >
+                X
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <q-card-section class="q-pa-none q-mb-sm dr-board-primary">
+        <div
+          :ref="session.bindHeroCardSlotRef"
+          class="dr-hero-card-slot"
+          :class="{
+            'dr-dungeon-stage': session.showDungeonStage,
+            [session.dungeonStageAnimationClass]: session.showDungeonStage && session.dungeonStageAnimationClass,
+          }"
+        >
+          <div :ref="session.bindDungeonCardMotionWrapRef" class="dr-dungeon-card-motion-wrap">
+            <MonsterCardFace
+              :ref="session.bindDungeonCardFaceRef"
+              class="dr-hero-card-control"
+              :empty="session.monsterCardSlotEmpty"
+              :hide-empty-slot="session.showDungeonStage"
+              :species="session.showDungeonStage ? session.dungeonStageView.monster.frontFaceSpecies : session.biddingStageSpecies"
+              :face-down="
+                session.showDungeonStage
+                  ? session.dungeonStageView.monster.visibility === 'face-down'
+                  : session.biddingStageFaceDown
+              "
+            />
+          </div>
+          <q-badge
+            v-if="session.showDungeonStage && session.dungeonStageView.hpDelta"
+            class="dr-dungeon-stage__hp-chip"
+            :color="session.dungeonStageView.hpDelta.tone === 'damage' ? 'negative' : 'positive'"
+            text-color="white"
+          >
+            {{ session.dungeonStageView.hpDelta.text }}
+          </q-badge>
+        </div>
+      </q-card-section>
+      <div class="row q-col-gutter-xs items-start">
+        <div class="col-4">
+          <q-badge
+            :ref="session.bindDeckBadgeRef"
+            text-color="white"
+            class="full-width q-py-xs justify-between dr-deck-badge dr-pile-badge dr-pile-badge--deck"
+            :style="{ '--dr-pile': `url('${session.uiAssets.piles.deck.runtimePath}')` }"
+            :class="{
+              'dr-deck-badge--interactive': session.biddingBoard.memoryAid.deckTapEnabled,
+            }"
+            @click="session.onDeckTap"
+          >
+            <span>Deck</span>
+            <span>{{ session.biddingBoard.secondary.deckCount }}</span>
+          </q-badge>
+          <div v-if="session.biddingBoard.memoryAid.knownDeckCountHint !== null" class="text-caption text-grey-6 q-mt-xs">
+            Known to you: {{ session.biddingBoard.memoryAid.knownDeckCountHint }}
+          </div>
+        </div>
+        <div class="col-4">
+          <div :ref="session.bindDungeonPileMotionAnchorRef" class="full-width">
+            <q-badge
+              text-color="white"
+              class="full-width q-py-xs justify-between dr-pile-badge dr-pile-badge--dungeon"
+              :style="{ '--dr-pile': `url('${session.uiAssets.piles.dungeon.runtimePath}')` }"
+            >
+              <span>Dungeon</span>
+              <span>{{ session.biddingBoard.secondary.dungeonCount }}</span>
+            </q-badge>
+          </div>
+        </div>
+        <div class="col-4">
+          <div class="row no-wrap items-center full-width dr-turn-hero-row">
+            <q-chip
+              :color="session.biddingBoard.heroCue.badgeColor"
+              text-color="white"
+              dense
+              :aria-label="session.biddingBoard.heroCue.shortLabel"
+            >
+              {{ session.biddingBoard.heroCue.shortLabel }}
+            </q-chip>
+          </div>
+        </div>
+      </div>
+      <div class="row q-mt-none">
+        <div
+          v-for="token in session.boardEquipmentTokens"
+          :key="token.equipmentId"
+          class="col-4 flex flex-center"
+        >
+          <div
+            :ref="(el) => session.bindBiddingEquipmentBadgeRef(token.equipmentId, el)"
+            class="dr-equip-token"
+            :class="{
+              'dr-equip-token--spent': token.removed,
+              'dr-token-glow': token.glow,
+              'dr-token-pulse': token.pulse,
+              'dr-equip-token--deemphasized': token.deemphasized,
+              'dr-equip-token--interactive': token.hasModal,
+            }"
+            :tabindex="token.hasModal ? 0 : -1"
+            :role="token.hasModal ? 'button' : 'img'"
+            :aria-disabled="token.hasModal ? undefined : 'true'"
+            :aria-label="token.ariaLabel"
+            @click="session.openEquipmentModal(token)"
+            @keydown.enter.prevent="session.openEquipmentModal(token)"
+            @keydown.space.prevent="session.openEquipmentModal(token)"
+          >
+            <img
+              class="dr-equip-token__plate"
+              :src="session.uiAssets.equipment.plate.runtimePath"
+              alt=""
+              draggable="false"
+            />
+            <img
+              class="dr-equip-token__symbol"
+              :src="token.symbolRuntimePath"
+              alt=""
+              draggable="false"
+            />
+            <span v-if="token.equipmentOverlay != null" class="dr-equip-token__overlay" aria-hidden="true">
+              +{{ token.equipmentOverlay }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </q-card>
+    
+    <q-card v-if="session.showActionPane" flat bordered class="q-pa-sm q-mb-md">
+      <div v-if="session.activePresentationLabel" class="text-body2 text-grey-6 q-mb-xs">{{ session.activePresentationLabel }}</div>
+      <div v-if="session.isHumanTurn" class="row q-col-gutter-sm q-gutter-y-sm">
+        <template v-if="session.match?.state?.phase === 'bidding' && session.biddingSacrificeActions.length > 1">
+          <q-btn
+            v-for="action in session.biddingNonSacrificeActions"
+            :key="session.actionKey(action)"
+            :color="session.biddingBoard.heroCue.buttonColor"
+            unelevated
+            no-caps
+            size="lg"
+            class="col-12 col-sm-auto"
+            :label="session.actionLabel(action)"
+            :disable="session.humanGameplayBlocked"
+            @click="session.takeHumanAction(action)"
+          />
+          <q-btn-dropdown
+            :color="session.biddingBoard.heroCue.buttonColor"
+            unelevated
+            no-caps
+            dense
+            size="lg"
+            class="col-12 col-sm-auto"
+            label="Sacrifice equipment"
+            :disable="session.humanGameplayBlocked"
+          >
+            <q-list dense>
+              <q-item
+                v-for="action in session.biddingSacrificeActions"
+                :key="session.actionKey(action)"
+                v-close-popup
+                clickable
+                @click="session.takeHumanAction(action)"
+              >
+                <q-item-section>{{ session.actionLabel(action) }}</q-item-section>
+              </q-item>
+            </q-list>
+          </q-btn-dropdown>
+        </template>
+        <template v-else>
+          <template v-if="session.showHeroPickActionGrid">
+            <div class="col-12 text-h5 text-weight-medium text-grey-5 q-mb-xs" style="text-align: center;">Select Adventurer</div>
+            <div class="dr-hero-pick-grid col-12">
+              <q-btn
+                v-for="action in session.heroPickActionsOrdered"
+                :key="session.actionKey(action)"
+                :color="session.getHeroIdentity(action.hero).buttonColor"
+                unelevated
+                no-caps
+                dense
+                size="lg"
+                class="dr-hero-pick-grid__btn full-width"
+                :label="session.getHeroIdentity(action.hero).shortLabel"
+                :aria-label="session.actionLabel(action)"
+                :disable="session.humanGameplayBlocked"
+                @click="session.takeHumanAction(action)"
+              />
+            </div>
+          </template>
+          <template v-else>
+            <q-btn
+              v-for="action in session.visiblePrimaryActions"
+              :key="session.actionKey(action)"
+              :color="session.biddingBoard.heroCue.buttonColor"
+              unelevated
+              no-caps
+              dense
+              size="lg"
+              class="col-12 col-sm-auto"
+              :label="session.actionLabel(action)"
+              :disable="session.humanGameplayBlocked"
+              @click="session.takeHumanAction(action)"
+            />
+          </template>
+        </template>
+      </div>
+      <div v-if="session.isHumanTurn && session.dungeonOutcomeTransitionControls.length" class="row q-col-gutter-sm q-gutter-y-sm q-mt-xs">
+        <q-btn
+          v-for="control in session.dungeonOutcomeTransitionControls"
+          :key="control.key"
+          :color="session.biddingBoard.heroCue.buttonColor"
+          unelevated
+          no-caps
+          dense
+          size="md"
+          class="col-12 col-sm-auto"
+          :label="control.label"
+          :disable="session.gameplayInputLocked || session.dungeonOutcomeDialogOpen"
+          @click="session.takeHumanAction(control.action)"
+        />
+      </div>
+    </q-card>
+    
+    <q-card v-if="session.debugMode" flat bordered class="q-pa-md q-mb-md">
+      <div class="text-subtitle2 q-mb-sm">Debug replay</div>
+      <div v-if="session.nnDebugTraceHistory.length" class="q-mb-sm">
+        <div class="text-caption text-grey-5 q-mb-xs">NN trace history</div>
+        <div v-for="(entry, index) in session.nnDebugTraceHistory" :key="`nn-trace-${index}`" class="text-caption">
+          {{ entry.at }} | {{ entry.modelId }} | {{ entry.trace.kind }} |
+          {{ entry.trace.fallbackReason ?? entry.trace.mode ?? 'sample' }}
+        </div>
+      </div>
+      <div class="row q-gutter-sm q-mb-sm">
+        <q-btn color="primary" flat label="Export replay" @click="session.exportReplay" />
+        <q-btn color="primary" flat label="Import replay" @click="session.importReplay" />
+      </div>
+      <q-input
+        v-model="session.replayExportText"
+        type="textarea"
+        autogrow
+        readonly
+        label="Export payload"
+        outlined
+        dense
+        class="q-mb-sm"
+      />
+      <q-input v-model="session.replayImportText" type="textarea" autogrow label="Import payload" outlined dense />
+      <q-input
+        v-model="session.nnDebugTraceText"
+        type="textarea"
+        autogrow
+        readonly
+        label="NN trace (features/mask/logits)"
+        outlined
+        dense
+        class="q-mt-sm"
+      />
+    </q-card>
+    
+      <div
+        :ref="session.bindPresentationFlightLayerRef"
+        class="dr-presentation-flight-layer"
+        aria-hidden="true"
+      />
+    </div>
+
+    <button
+      v-if="session.activePresentation?.kind === 'HERO_CHANGE_INTERSTITIAL' && session.heroChangeInterstitialView"
+      :ref="session.bindHeroChangeInterstitialOverlayRef"
+      type="button"
+      class="dr-hero-interstitial"
+      :aria-label="session.heroChangeInterstitialAriaLabel"
+      @click="session.skipActivePresentation"
+    >
+      <p class="dr-hero-interstitial__headline">{{ session.heroChangeInterstitialView.headline }}</p>
+      <q-avatar
+        :color="session.heroChangeInterstitialView.chosen.badgeColor"
+        text-color="white"
+        size="56px"
+        font-size="1.25rem"
+        class="dr-hero-interstitial__avatar"
+      >
+        {{ session.heroChangeInterstitialView.chosen.badgeGlyph }}
+      </q-avatar>
+    </button>
+    
+    <q-dialog v-model="session.dungeonOutcomeDialogOpen" persistent transition-show="scale" transition-hide="scale">
+      <q-card class="q-pa-md dr-dungeon-outcome-dialog" :class="session.dungeonOutcomeToneClass" style="min-width: 340px">
+        <div class="text-overline dr-outcome-kicker">Dungeon run resolved</div>
+        <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">
+          {{ session.dungeonOutcomeSummary?.resultLabel }}
+        </div>
+        <div class="text-body1 q-mb-xs">
+          Runner: <span class="text-weight-bold">{{ session.dungeonOutcomeSummary?.runnerLabel }}</span>
+        </div>
+        <div class="text-body2 q-mb-md dr-outcome-message">{{ session.dungeonOutcomeMessage }}</div>
+        <div class="row justify-end">
+          <q-btn color="primary" unelevated label="Continue" class="dr-outcome-btn" @click="session.continueFromDungeonOutcome" />
+        </div>
+      </q-card>
+    </q-dialog>
+    
+    <q-dialog v-model="session.equipmentModalOpen" class="dr-equipment-dialog">
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">{{ session.selectedEquipmentModalView?.title }}</div>
+        <div class="text-body2 q-mb-md">{{ session.selectedEquipmentModalView?.details }}</div>
+        <div class="row justify-end q-gutter-sm">
+          <q-btn
+            v-if="session.selectedEquipmentModalView?.showUseButton"
+            color="primary"
+            unelevated
+            label="Use"
+            :disable="session.equipmentModalActionsDisabled"
+            @click="session.takeEquipmentUseAction"
+          />
+          <q-btn flat color="primary" label="Continue" @click="session.continueFromEquipmentModal" />
+        </div>
+      </q-card>
+    </q-dialog>
+    
+    <q-dialog v-model="session.confirmationDialogOpen" persistent>
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">{{ session.confirmationDialogTitle }}</div>
+        <div class="text-body2 q-mb-md">{{ session.confirmationDialogMessage }}</div>
+        <div class="row justify-end q-gutter-sm">
+          <q-btn flat color="primary" :label="session.confirmationDialogCancelLabel" @click="session.onConfirmationDialogCancel" />
+          <q-btn color="primary" unelevated :label="session.confirmationDialogOkLabel" @click="session.onConfirmationDialogOk" />
+        </div>
+      </q-card>
+    </q-dialog>
+    
+    <q-dialog v-model="session.neuralRefreshTerminalOpen" persistent :data-testid="LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminal">
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
+        <div class="text-body2 q-mb-md">
+          Inference could not recover. Refresh the page to reload the neural runtime; your match stays saved.
+        </div>
+        <div class="row justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Refresh page"
+            :data-testid="LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminalReload"
+            @click="session.reloadPageForNeuralRefreshTerminal"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+    
+    <q-dialog v-model="session.vorpalDialogOpen" persistent>
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">Vorpal target</div>
+        <div class="text-body2 q-mb-md">Choose a species before entering the dungeon.</div>
+        <q-select
+          v-model="session.selectedVorpalSpecies"
+          :options="session.vorpalSelectOptions"
+          emit-value
+          map-options
+          option-value="value"
+          option-label="label"
+          label="Species"
+          behavior="menu"
+          outlined
+          dense
+          class="q-mb-md"
+        />
+        <div class="row justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Confirm"
+            :disable="!session.selectedVorpalSpecies || session.humanGameplayBlocked"
+            @click="session.confirmVorpalDeclaration"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+    <q-dialog v-model="session.deckSplayOpen" maximized>
+      <q-card class="dr-deck-splay-panel">
+        <div class="row items-center q-px-md q-pt-md q-pb-sm">
+          <div class="text-subtitle1">Deck splay</div>
+          <q-space />
+          <q-btn flat dense icon="close" aria-label="Close deck splay" @click="session.onCloseDeckSplay" />
+        </div>
+        <q-separator />
+        <div class="q-pa-md dr-deck-splay-scroll">
+          <div class="row q-col-gutter-sm q-row-gutter-sm">
+            <div
+              v-for="(slot, index) in session.biddingBoard.memoryAid.deckSplayCards"
+              :key="`deck-card-${index}`"
+              class="col-6 col-sm-4 col-md-3"
+            >
+              <MonsterCardFace
+                class="dr-card-preview"
+                :species="slot.visibility === 'face' ? slot.species : null"
+                :face-down="slot.visibility !== 'face'"
+              />
+            </div>
+          </div>
+        </div>
+      </q-card>
+    </q-dialog>
+    
+    <q-inner-loading
+      :showing="session.headlessCompletionInFlight"
+      :data-testid="LIVE_MATCH_SHELL_TEST_IDS.finishingMatchOverlay"
+      class="dr-finishing-match-overlay"
+    >
+      <q-spinner size="50px" color="primary" />
+    </q-inner-loading>
+  </div>
+</template>
+
+<script setup>
+import { inject } from 'vue'
+import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
+import { LIVE_MATCH_SHELL_SESSION_KEY } from './liveMatchShellSessionKey.js'
+import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
+
+const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
+</script>
+
+<style scoped>
+
+.dr-board-shell {
+  position: relative;
+}
+
+.dr-presentation-flight-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.dr-hero-pick-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.dr-hero-pick-grid__btn {
+  min-height: 3rem;
+}
+
+.dr-bidding-board {
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.dr-dungeon-hp-bar {
+  border: 1px solid rgba(244, 67, 54, 0.35);
+  border-radius: 10px;
+  padding: 8px 10px;
+  background: rgba(31, 13, 13, 0.86);
+}
+
+.dr-dungeon-hp-bar__track {
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.dr-dungeon-hp-bar__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #b71c1c, #f44336);
+  transition: width 180ms ease;
+}
+
+.dr-pile-badge {
+  background-image: linear-gradient(180deg, rgba(42, 42, 42, 0.92), rgba(58, 58, 58, 0.9)), var(--dr-pile);
+  background-size: auto, 150% auto;
+  background-position: center, 50% 45%;
+  background-repeat: no-repeat;
+}
+
+.dr-equip-token {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  outline: none;
+}
+
+.dr-equip-token__plate,
+.dr-equip-token__symbol {
+  position: absolute;
+  pointer-events: none;
+  user-select: none;
+}
+
+.dr-equip-token__plate {
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.dr-equip-token__symbol {
+  width: 72%;
+  height: 72%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  object-fit: contain;
+  filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.35));
+}
+
+.dr-equip-token__overlay {
+  position: absolute;
+  right: 0;
+  bottom: 2px;
+  font-size: 18px;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  -webkit-text-stroke: 0.85px rgba(18, 18, 18, 0.92);
+  paint-order: stroke fill;
+  color: rgba(18, 18, 18, 0.92);
+  text-shadow:
+    0 0 12px rgba(255, 255, 255, 0.98),
+    0 0 6px rgba(255, 255, 255, 0.95);
+  pointer-events: none;
+}
+
+.dr-equip-token--spent {
+  opacity: 0.55;
+}
+
+.dr-equip-token--interactive {
+  cursor: pointer;
+}
+
+.dr-board-primary {
+  width: 100%;
+  isolation: isolate;
+}
+
+.dr-hero-card-slot {
+  width: 100%;
+  position: relative;
+}
+
+.dr-hero-card-control {
+  width: 100%;
+  display: block;
+}
+
+.dr-dungeon-card-motion-wrap {
+  width: 100%;
+  display: block;
+}
+
+.dr-hero-card-control :deep(.dr-monster-card) {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
+
+.dr-seat-strip {
+  width: 100%;
+}
+
+.dr-seat-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.dr-seat-progress-cell {
+  min-height: 1.25rem;
+  padding: 0 4px;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.dr-seat-progress-marker {
+  font-weight: 700;
+  margin-right: 2px;
+}
+
+.dr-seat-progress-marker--success {
+  color: #66bb6a;
+}
+
+.dr-seat-progress-marker--failure {
+  color: #ef5350;
+}
+
+@keyframes dr-token-pulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.03);
+  }
+}
+
+.dr-card-preview {
+  width: 100%;
+  max-width: 140px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+}
+
+.dr-token-glow {
+  box-shadow:
+    0 0 0 2px rgba(255, 193, 7, 0.95),
+    0 0 0 4px rgba(255, 152, 0, 0.45),
+    0 0 22px rgba(255, 193, 7, 0.75),
+    0 0 40px rgba(255, 160, 0, 0.35);
+}
+
+.dr-token-pulse {
+  animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
+}
+
+.dr-equip-token--deemphasized {
+  opacity: 0.5;
+  filter: saturate(0.7);
+}
+
+.dr-dungeon-stage .dr-hero-card-control {
+  transform-origin: center;
+}
+
+.dr-dungeon-stage__hp-chip {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 2;
+}
+
+.dr-token-icon {
+  flex-shrink: 0;
+  object-fit: contain;
+  filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.5));
+}
+
+.dr-deck-badge {
+  user-select: none;
+}
+
+.dr-deck-badge--interactive {
+  cursor: pointer;
+}
+
+.dr-deck-splay-panel {
+  width: min(960px, 100vw);
+  height: 100dvh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.dr-deck-splay-scroll {
+  overflow-y: auto;
+}
+
+.dr-hero--warrior {
+  box-shadow: inset 0 0 0 2px rgba(63, 81, 181, 0.45);
+}
+
+.dr-hero--barbarian {
+  box-shadow: inset 0 0 0 2px rgba(255, 87, 34, 0.5);
+}
+
+.dr-hero--mage {
+  box-shadow: inset 0 0 0 2px rgba(103, 58, 183, 0.5);
+}
+
+.dr-hero--rogue {
+  box-shadow: inset 0 0 0 2px rgba(46, 125, 50, 0.5);
+}
+
+.dr-turn-hero-row {
+  gap: 6px;
+}
+
+.dr-hero-interstitial {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  width: 100%;
+  background: rgba(12, 12, 18, 0.9);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  z-index: 20;
+  cursor: pointer;
+}
+
+.dr-hero-interstitial__headline {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 500;
+  text-align: center;
+}
+
+.dr-hero-interstitial__avatar {
+  animation: dr-hero-interstitial-pop 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes dr-hero-interstitial-pop {
+  from {
+    transform: scale(0.72);
+    opacity: 0.35;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.dr-hero-interstitial__hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.dr-dungeon-outcome-dialog,
+.dr-match-over-dialog {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  box-shadow:
+    0 12px 34px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+}
+
+.dr-outcome--success {
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(102, 187, 106, 0.22), rgba(102, 187, 106, 0) 60%),
+    radial-gradient(120% 120% at 100% 100%, rgba(41, 182, 246, 0.2), rgba(41, 182, 246, 0) 62%),
+    #171b1f;
+}
+
+.dr-outcome--failure {
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(239, 83, 80, 0.24), rgba(239, 83, 80, 0) 58%),
+    radial-gradient(120% 120% at 100% 100%, rgba(171, 71, 188, 0.2), rgba(171, 71, 188, 0) 62%),
+    #1b161c;
+}
+
+.dr-outcome-kicker {
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.dr-outcome-title {
+  text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
+}
+
+.dr-outcome-message {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.dr-outcome-btn {
+  letter-spacing: 0.03em;
+}
+
+.dr-outcome-btn-secondary {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+</style>
+
+<style>
+/* Quasar portals dialogs outside scoped tree; above presentation ghost flights (z-index 10050) */
+.dr-equipment-dialog .q-dialog__inner {
+  z-index: 10100 !important;
+}
+</style>

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -1,23 +1,23 @@
 <template>
   <div :data-testid="LIVE_MATCH_SHELL_TEST_IDS.root">
-    <div :ref="session.bindBoardShellRef" class="dr-board-shell">
+    <div :ref="session.board.bindBoardShellRef" class="dr-board-shell">
       <div
-        v-if="session.showDungeonStage && session.dungeonStageView.hpBar"
+        v-if="session.board.showDungeonStage && session.board.dungeonStageView.hpBar"
         class="dr-dungeon-hp-bar q-mb-sm"
         role="meter"
         aria-label="Adventurer HP"
         aria-valuemin="0"
-        :aria-valuemax="session.dungeonStageView.hpBar.displayMaxHp"
-        :aria-valuenow="session.dungeonStageView.hpBar.currentHp"
+        :aria-valuemax="session.board.dungeonStageView.hpBar.displayMaxHp"
+        :aria-valuenow="session.board.dungeonStageView.hpBar.currentHp"
       >
         <div class="row items-center justify-between q-mb-xs">
           <span class="text-caption text-weight-medium">HP</span>
-          <span class="text-caption">{{ session.dungeonStageView.hpBar.text }}</span>
+          <span class="text-caption">{{ session.board.dungeonStageView.hpBar.text }}</span>
         </div>
         <div class="dr-dungeon-hp-bar__track">
           <div
             class="dr-dungeon-hp-bar__fill"
-            :style="{ width: `${session.dungeonStageView.hpBar.percent}%` }"
+            :style="{ width: `${session.board.dungeonStageView.hpBar.percent}%` }"
           />
         </div>
       </div>
@@ -25,16 +25,16 @@
         flat
         bordered
         class="q-pa-sm q-mb-sm dr-bidding-board"
-        :class="session.biddingBoard.heroCue.accentClass"
+        :class="session.board.biddingBoard.heroCue.accentClass"
       >
       <div
-        v-if="session.seatRunTrackerRows.length"
+        v-if="session.board.seatRunTrackerRows.length"
         class="dr-seat-strip q-mb-sm"
       >
         <div class="row q-col-gutter-xs">
-          <div v-for="row in session.seatRunTrackerRows" :key="`seat-${row.seatId}`" class="col dr-seat-stack">
+          <div v-for="row in session.board.seatRunTrackerRows" :key="`seat-${row.seatId}`" class="col dr-seat-stack">
             <q-badge
-              :color="row.passed ? 'grey-9' : session.biddingBoard.heroCue.badgeColor"
+              :color="row.passed ? 'grey-9' : session.board.biddingBoard.heroCue.badgeColor"
               text-color="white"
               class="dr-seat-chip q-px-sm full-width"
               :class="{ 'dr-token-glow': row.isActive }"
@@ -69,89 +69,89 @@
       </div>
       <q-card-section class="q-pa-none q-mb-sm dr-board-primary">
         <div
-          :ref="session.bindHeroCardSlotRef"
+          :ref="session.board.bindHeroCardSlotRef"
           class="dr-hero-card-slot"
           :class="{
-            'dr-dungeon-stage': session.showDungeonStage,
-            [session.dungeonStageAnimationClass]: session.showDungeonStage && session.dungeonStageAnimationClass,
+            'dr-dungeon-stage': session.board.showDungeonStage,
+            [session.board.dungeonStageAnimationClass]: session.board.showDungeonStage && session.board.dungeonStageAnimationClass,
           }"
         >
-          <div :ref="session.bindDungeonCardMotionWrapRef" class="dr-dungeon-card-motion-wrap">
+          <div :ref="session.board.bindDungeonCardMotionWrapRef" class="dr-dungeon-card-motion-wrap">
             <MonsterCardFace
-              :ref="session.bindDungeonCardFaceRef"
+              :ref="session.board.bindDungeonCardFaceRef"
               class="dr-hero-card-control"
-              :empty="session.monsterCardSlotEmpty"
-              :hide-empty-slot="session.showDungeonStage"
-              :species="session.showDungeonStage ? session.dungeonStageView.monster.frontFaceSpecies : session.biddingStageSpecies"
+              :empty="session.board.monsterCardSlotEmpty"
+              :hide-empty-slot="session.board.showDungeonStage"
+              :species="session.board.showDungeonStage ? session.board.dungeonStageView.monster.frontFaceSpecies : session.board.biddingStageSpecies"
               :face-down="
-                session.showDungeonStage
-                  ? session.dungeonStageView.monster.visibility === 'face-down'
-                  : session.biddingStageFaceDown
+                session.board.showDungeonStage
+                  ? session.board.dungeonStageView.monster.visibility === 'face-down'
+                  : session.board.biddingStageFaceDown
               "
             />
           </div>
           <q-badge
-            v-if="session.showDungeonStage && session.dungeonStageView.hpDelta"
+            v-if="session.board.showDungeonStage && session.board.dungeonStageView.hpDelta"
             class="dr-dungeon-stage__hp-chip"
-            :color="session.dungeonStageView.hpDelta.tone === 'damage' ? 'negative' : 'positive'"
+            :color="session.board.dungeonStageView.hpDelta.tone === 'damage' ? 'negative' : 'positive'"
             text-color="white"
           >
-            {{ session.dungeonStageView.hpDelta.text }}
+            {{ session.board.dungeonStageView.hpDelta.text }}
           </q-badge>
         </div>
       </q-card-section>
       <div class="row q-col-gutter-xs items-start">
         <div class="col-4">
           <q-badge
-            :ref="session.bindDeckBadgeRef"
+            :ref="session.board.bindDeckBadgeRef"
             text-color="white"
             class="full-width q-py-xs justify-between dr-deck-badge dr-pile-badge dr-pile-badge--deck"
-            :style="{ '--dr-pile': `url('${session.uiAssets.piles.deck.runtimePath}')` }"
+            :style="{ '--dr-pile': `url('${session.board.uiAssets.piles.deck.runtimePath}')` }"
             :class="{
-              'dr-deck-badge--interactive': session.biddingBoard.memoryAid.deckTapEnabled,
+              'dr-deck-badge--interactive': session.board.biddingBoard.memoryAid.deckTapEnabled,
             }"
-            @click="session.onDeckTap"
+            @click="session.board.onDeckTap"
           >
             <span>Deck</span>
-            <span>{{ session.biddingBoard.secondary.deckCount }}</span>
+            <span>{{ session.board.biddingBoard.secondary.deckCount }}</span>
           </q-badge>
-          <div v-if="session.biddingBoard.memoryAid.knownDeckCountHint !== null" class="text-caption text-grey-6 q-mt-xs">
-            Known to you: {{ session.biddingBoard.memoryAid.knownDeckCountHint }}
+          <div v-if="session.board.biddingBoard.memoryAid.knownDeckCountHint !== null" class="text-caption text-grey-6 q-mt-xs">
+            Known to you: {{ session.board.biddingBoard.memoryAid.knownDeckCountHint }}
           </div>
         </div>
         <div class="col-4">
-          <div :ref="session.bindDungeonPileMotionAnchorRef" class="full-width">
+          <div :ref="session.board.bindDungeonPileMotionAnchorRef" class="full-width">
             <q-badge
               text-color="white"
               class="full-width q-py-xs justify-between dr-pile-badge dr-pile-badge--dungeon"
-              :style="{ '--dr-pile': `url('${session.uiAssets.piles.dungeon.runtimePath}')` }"
+              :style="{ '--dr-pile': `url('${session.board.uiAssets.piles.dungeon.runtimePath}')` }"
             >
               <span>Dungeon</span>
-              <span>{{ session.biddingBoard.secondary.dungeonCount }}</span>
+              <span>{{ session.board.biddingBoard.secondary.dungeonCount }}</span>
             </q-badge>
           </div>
         </div>
         <div class="col-4">
           <div class="row no-wrap items-center full-width dr-turn-hero-row">
             <q-chip
-              :color="session.biddingBoard.heroCue.badgeColor"
+              :color="session.board.biddingBoard.heroCue.badgeColor"
               text-color="white"
               dense
-              :aria-label="session.biddingBoard.heroCue.shortLabel"
+              :aria-label="session.board.biddingBoard.heroCue.shortLabel"
             >
-              {{ session.biddingBoard.heroCue.shortLabel }}
+              {{ session.board.biddingBoard.heroCue.shortLabel }}
             </q-chip>
           </div>
         </div>
       </div>
       <div class="row q-mt-none">
         <div
-          v-for="token in session.boardEquipmentTokens"
+          v-for="token in session.board.boardEquipmentTokens"
           :key="token.equipmentId"
           class="col-4 flex flex-center"
         >
           <div
-            :ref="(el) => session.bindBiddingEquipmentBadgeRef(token.equipmentId, el)"
+            :ref="(el) => session.board.bindBiddingEquipmentBadgeRef(token.equipmentId, el)"
             class="dr-equip-token"
             :class="{
               'dr-equip-token--spent': token.removed,
@@ -164,13 +164,13 @@
             :role="token.hasModal ? 'button' : 'img'"
             :aria-disabled="token.hasModal ? undefined : 'true'"
             :aria-label="token.ariaLabel"
-            @click="session.openEquipmentModal(token)"
-            @keydown.enter.prevent="session.openEquipmentModal(token)"
-            @keydown.space.prevent="session.openEquipmentModal(token)"
+            @click="session.board.openEquipmentModal(token)"
+            @keydown.enter.prevent="session.board.openEquipmentModal(token)"
+            @keydown.space.prevent="session.board.openEquipmentModal(token)"
           >
             <img
               class="dr-equip-token__plate"
-              :src="session.uiAssets.equipment.plate.runtimePath"
+              :src="session.board.uiAssets.equipment.plate.runtimePath"
               alt=""
               draggable="false"
             />
@@ -188,114 +188,114 @@
       </div>
     </q-card>
     
-    <q-card v-if="session.showActionPane" flat bordered class="q-pa-sm q-mb-md">
-      <div v-if="session.activePresentationLabel" class="text-body2 text-grey-6 q-mb-xs">{{ session.activePresentationLabel }}</div>
-      <div v-if="session.isHumanTurn" class="row q-col-gutter-sm q-gutter-y-sm">
-        <template v-if="session.match?.state?.phase === 'bidding' && session.biddingSacrificeActions.length > 1">
+    <q-card v-if="session.board.showActionPane" flat bordered class="q-pa-sm q-mb-md">
+      <div v-if="session.board.activePresentationLabel" class="text-body2 text-grey-6 q-mb-xs">{{ session.board.activePresentationLabel }}</div>
+      <div v-if="session.board.isHumanTurn" class="row q-col-gutter-sm q-gutter-y-sm">
+        <template v-if="session.board.match?.state?.phase === 'bidding' && session.board.biddingSacrificeActions.length > 1">
           <q-btn
-            v-for="action in session.biddingNonSacrificeActions"
-            :key="session.actionKey(action)"
-            :color="session.biddingBoard.heroCue.buttonColor"
+            v-for="action in session.board.biddingNonSacrificeActions"
+            :key="session.board.actionKey(action)"
+            :color="session.board.biddingBoard.heroCue.buttonColor"
             unelevated
             no-caps
             size="lg"
             class="col-12 col-sm-auto"
-            :label="session.actionLabel(action)"
-            :disable="session.humanGameplayBlocked"
-            @click="session.takeHumanAction(action)"
+            :label="session.board.actionLabel(action)"
+            :disable="session.board.humanGameplayBlocked"
+            @click="session.board.takeHumanAction(action)"
           />
           <q-btn-dropdown
-            :color="session.biddingBoard.heroCue.buttonColor"
+            :color="session.board.biddingBoard.heroCue.buttonColor"
             unelevated
             no-caps
             dense
             size="lg"
             class="col-12 col-sm-auto"
             label="Sacrifice equipment"
-            :disable="session.humanGameplayBlocked"
+            :disable="session.board.humanGameplayBlocked"
           >
             <q-list dense>
               <q-item
-                v-for="action in session.biddingSacrificeActions"
-                :key="session.actionKey(action)"
+                v-for="action in session.board.biddingSacrificeActions"
+                :key="session.board.actionKey(action)"
                 v-close-popup
                 clickable
-                @click="session.takeHumanAction(action)"
+                @click="session.board.takeHumanAction(action)"
               >
-                <q-item-section>{{ session.actionLabel(action) }}</q-item-section>
+                <q-item-section>{{ session.board.actionLabel(action) }}</q-item-section>
               </q-item>
             </q-list>
           </q-btn-dropdown>
         </template>
         <template v-else>
-          <template v-if="session.showHeroPickActionGrid">
+          <template v-if="session.board.showHeroPickActionGrid">
             <div class="col-12 text-h5 text-weight-medium text-grey-5 q-mb-xs" style="text-align: center;">Select Adventurer</div>
             <div class="dr-hero-pick-grid col-12">
               <q-btn
-                v-for="action in session.heroPickActionsOrdered"
-                :key="session.actionKey(action)"
-                :color="session.getHeroIdentity(action.hero).buttonColor"
+                v-for="action in session.board.heroPickActionsOrdered"
+                :key="session.board.actionKey(action)"
+                :color="session.board.getHeroIdentity(action.hero).buttonColor"
                 unelevated
                 no-caps
                 dense
                 size="lg"
                 class="dr-hero-pick-grid__btn full-width"
-                :label="session.getHeroIdentity(action.hero).shortLabel"
-                :aria-label="session.actionLabel(action)"
-                :disable="session.humanGameplayBlocked"
-                @click="session.takeHumanAction(action)"
+                :label="session.board.getHeroIdentity(action.hero).shortLabel"
+                :aria-label="session.board.actionLabel(action)"
+                :disable="session.board.humanGameplayBlocked"
+                @click="session.board.takeHumanAction(action)"
               />
             </div>
           </template>
           <template v-else>
             <q-btn
-              v-for="action in session.visiblePrimaryActions"
-              :key="session.actionKey(action)"
-              :color="session.biddingBoard.heroCue.buttonColor"
+              v-for="action in session.board.visiblePrimaryActions"
+              :key="session.board.actionKey(action)"
+              :color="session.board.biddingBoard.heroCue.buttonColor"
               unelevated
               no-caps
               dense
               size="lg"
               class="col-12 col-sm-auto"
-              :label="session.actionLabel(action)"
-              :disable="session.humanGameplayBlocked"
-              @click="session.takeHumanAction(action)"
+              :label="session.board.actionLabel(action)"
+              :disable="session.board.humanGameplayBlocked"
+              @click="session.board.takeHumanAction(action)"
             />
           </template>
         </template>
       </div>
-      <div v-if="session.isHumanTurn && session.dungeonOutcomeTransitionControls.length" class="row q-col-gutter-sm q-gutter-y-sm q-mt-xs">
+      <div v-if="session.board.isHumanTurn && session.board.dungeonOutcomeTransitionControls.length" class="row q-col-gutter-sm q-gutter-y-sm q-mt-xs">
         <q-btn
-          v-for="control in session.dungeonOutcomeTransitionControls"
+          v-for="control in session.board.dungeonOutcomeTransitionControls"
           :key="control.key"
-          :color="session.biddingBoard.heroCue.buttonColor"
+          :color="session.board.biddingBoard.heroCue.buttonColor"
           unelevated
           no-caps
           dense
           size="md"
           class="col-12 col-sm-auto"
           :label="control.label"
-          :disable="session.gameplayInputLocked || session.dungeonOutcomeDialogOpen"
-          @click="session.takeHumanAction(control.action)"
+          :disable="session.board.gameplayInputLocked || session.dialogs.dungeonOutcomeDialogOpen"
+          @click="session.board.takeHumanAction(control.action)"
         />
       </div>
     </q-card>
     
-    <q-card v-if="session.debugMode" flat bordered class="q-pa-md q-mb-md">
+    <q-card v-if="session.debug.debugMode" flat bordered class="q-pa-md q-mb-md">
       <div class="text-subtitle2 q-mb-sm">Debug replay</div>
-      <div v-if="session.nnDebugTraceHistory.length" class="q-mb-sm">
+      <div v-if="session.debug.nnDebugTraceHistory.length" class="q-mb-sm">
         <div class="text-caption text-grey-5 q-mb-xs">NN trace history</div>
-        <div v-for="(entry, index) in session.nnDebugTraceHistory" :key="`nn-trace-${index}`" class="text-caption">
+        <div v-for="(entry, index) in session.debug.nnDebugTraceHistory" :key="`nn-trace-${index}`" class="text-caption">
           {{ entry.at }} | {{ entry.modelId }} | {{ entry.trace.kind }} |
           {{ entry.trace.fallbackReason ?? entry.trace.mode ?? 'sample' }}
         </div>
       </div>
       <div class="row q-gutter-sm q-mb-sm">
-        <q-btn color="primary" flat label="Export replay" @click="session.exportReplay" />
-        <q-btn color="primary" flat label="Import replay" @click="session.importReplay" />
+        <q-btn color="primary" flat label="Export replay" @click="session.debug.exportReplay" />
+        <q-btn color="primary" flat label="Import replay" @click="session.debug.importReplay" />
       </div>
       <q-input
-        v-model="session.replayExportText"
+        v-model="session.debug.replayExportText"
         type="textarea"
         autogrow
         readonly
@@ -304,9 +304,9 @@
         dense
         class="q-mb-sm"
       />
-      <q-input v-model="session.replayImportText" type="textarea" autogrow label="Import payload" outlined dense />
+      <q-input v-model="session.debug.replayImportText" type="textarea" autogrow label="Import payload" outlined dense />
       <q-input
-        v-model="session.nnDebugTraceText"
+        v-model="session.debug.nnDebugTraceText"
         type="textarea"
         autogrow
         readonly
@@ -318,78 +318,78 @@
     </q-card>
     
       <div
-        :ref="session.bindPresentationFlightLayerRef"
+        :ref="session.board.bindPresentationFlightLayerRef"
         class="dr-presentation-flight-layer"
         aria-hidden="true"
       />
     </div>
 
     <button
-      v-if="session.activePresentation?.kind === 'HERO_CHANGE_INTERSTITIAL' && session.heroChangeInterstitialView"
-      :ref="session.bindHeroChangeInterstitialOverlayRef"
+      v-if="session.board.activePresentation?.kind === 'HERO_CHANGE_INTERSTITIAL' && session.board.heroChangeInterstitialView"
+      :ref="session.board.bindHeroChangeInterstitialOverlayRef"
       type="button"
       class="dr-hero-interstitial"
-      :aria-label="session.heroChangeInterstitialAriaLabel"
-      @click="session.skipActivePresentation"
+      :aria-label="session.board.heroChangeInterstitialAriaLabel"
+      @click="session.board.skipActivePresentation"
     >
-      <p class="dr-hero-interstitial__headline">{{ session.heroChangeInterstitialView.headline }}</p>
+      <p class="dr-hero-interstitial__headline">{{ session.board.heroChangeInterstitialView.headline }}</p>
       <q-avatar
-        :color="session.heroChangeInterstitialView.chosen.badgeColor"
+        :color="session.board.heroChangeInterstitialView.chosen.badgeColor"
         text-color="white"
         size="56px"
         font-size="1.25rem"
         class="dr-hero-interstitial__avatar"
       >
-        {{ session.heroChangeInterstitialView.chosen.badgeGlyph }}
+        {{ session.board.heroChangeInterstitialView.chosen.badgeGlyph }}
       </q-avatar>
     </button>
     
-    <q-dialog v-model="session.dungeonOutcomeDialogOpen" persistent transition-show="scale" transition-hide="scale">
-      <q-card class="q-pa-md dr-dungeon-outcome-dialog" :class="session.dungeonOutcomeToneClass" style="min-width: 340px">
+    <q-dialog v-model="session.dialogs.dungeonOutcomeDialogOpen" persistent transition-show="scale" transition-hide="scale">
+      <q-card class="q-pa-md dr-dungeon-outcome-dialog" :class="session.dialogs.dungeonOutcomeToneClass" style="min-width: 340px">
         <div class="text-overline dr-outcome-kicker">Dungeon run resolved</div>
         <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">
-          {{ session.dungeonOutcomeSummary?.resultLabel }}
+          {{ session.dialogs.dungeonOutcomeSummary?.resultLabel }}
         </div>
         <div class="text-body1 q-mb-xs">
-          Runner: <span class="text-weight-bold">{{ session.dungeonOutcomeSummary?.runnerLabel }}</span>
+          Runner: <span class="text-weight-bold">{{ session.dialogs.dungeonOutcomeSummary?.runnerLabel }}</span>
         </div>
-        <div class="text-body2 q-mb-md dr-outcome-message">{{ session.dungeonOutcomeMessage }}</div>
+        <div class="text-body2 q-mb-md dr-outcome-message">{{ session.dialogs.dungeonOutcomeMessage }}</div>
         <div class="row justify-end">
-          <q-btn color="primary" unelevated label="Continue" class="dr-outcome-btn" @click="session.continueFromDungeonOutcome" />
+          <q-btn color="primary" unelevated label="Continue" class="dr-outcome-btn" @click="session.dialogs.continueFromDungeonOutcome" />
         </div>
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.equipmentModalOpen" class="dr-equipment-dialog">
+    <q-dialog v-model="session.dialogs.equipmentModalOpen" class="dr-equipment-dialog">
       <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">{{ session.selectedEquipmentModalView?.title }}</div>
-        <div class="text-body2 q-mb-md">{{ session.selectedEquipmentModalView?.details }}</div>
+        <div class="text-subtitle1 q-mb-xs">{{ session.dialogs.selectedEquipmentModalView?.title }}</div>
+        <div class="text-body2 q-mb-md">{{ session.dialogs.selectedEquipmentModalView?.details }}</div>
         <div class="row justify-end q-gutter-sm">
           <q-btn
-            v-if="session.selectedEquipmentModalView?.showUseButton"
+            v-if="session.dialogs.selectedEquipmentModalView?.showUseButton"
             color="primary"
             unelevated
             label="Use"
-            :disable="session.equipmentModalActionsDisabled"
-            @click="session.takeEquipmentUseAction"
+            :disable="session.dialogs.equipmentModalActionsDisabled"
+            @click="session.dialogs.takeEquipmentUseAction"
           />
-          <q-btn flat color="primary" label="Continue" @click="session.continueFromEquipmentModal" />
+          <q-btn flat color="primary" label="Continue" @click="session.dialogs.continueFromEquipmentModal" />
         </div>
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.confirmationDialogOpen" persistent>
+    <q-dialog v-model="session.dialogs.confirmationDialogOpen" persistent>
       <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">{{ session.confirmationDialogTitle }}</div>
-        <div class="text-body2 q-mb-md">{{ session.confirmationDialogMessage }}</div>
+        <div class="text-subtitle1 q-mb-xs">{{ session.dialogs.confirmationDialogTitle }}</div>
+        <div class="text-body2 q-mb-md">{{ session.dialogs.confirmationDialogMessage }}</div>
         <div class="row justify-end q-gutter-sm">
-          <q-btn flat color="primary" :label="session.confirmationDialogCancelLabel" @click="session.onConfirmationDialogCancel" />
-          <q-btn color="primary" unelevated :label="session.confirmationDialogOkLabel" @click="session.onConfirmationDialogOk" />
+          <q-btn flat color="primary" :label="session.dialogs.confirmationDialogCancelLabel" @click="session.dialogs.onConfirmationDialogCancel" />
+          <q-btn color="primary" unelevated :label="session.dialogs.confirmationDialogOkLabel" @click="session.dialogs.onConfirmationDialogOk" />
         </div>
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.neuralRefreshTerminalOpen" persistent :data-testid="LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminal">
+    <q-dialog v-model="session.dialogs.neuralRefreshTerminalOpen" persistent :data-testid="LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminal">
       <q-card class="q-pa-md" style="min-width: 320px">
         <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
         <div class="text-body2 q-mb-md">
@@ -401,19 +401,19 @@
             unelevated
             label="Refresh page"
             :data-testid="LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminalReload"
-            @click="session.reloadPageForNeuralRefreshTerminal"
+            @click="session.dialogs.reloadPageForNeuralRefreshTerminal"
           />
         </div>
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.vorpalDialogOpen" persistent>
+    <q-dialog v-model="session.dialogs.vorpalDialogOpen" persistent>
       <q-card class="q-pa-md" style="min-width: 320px">
         <div class="text-subtitle1 q-mb-xs">Vorpal target</div>
         <div class="text-body2 q-mb-md">Choose a species before entering the dungeon.</div>
         <q-select
-          v-model="session.selectedVorpalSpecies"
-          :options="session.vorpalSelectOptions"
+          v-model="session.dialogs.selectedVorpalSpecies"
+          :options="session.dialogs.vorpalSelectOptions"
           emit-value
           map-options
           option-value="value"
@@ -429,24 +429,24 @@
             color="primary"
             unelevated
             label="Confirm"
-            :disable="!session.selectedVorpalSpecies || session.humanGameplayBlocked"
-            @click="session.confirmVorpalDeclaration"
+            :disable="!session.dialogs.selectedVorpalSpecies || session.board.humanGameplayBlocked"
+            @click="session.dialogs.confirmVorpalDeclaration"
           />
         </div>
       </q-card>
     </q-dialog>
-    <q-dialog v-model="session.deckSplayOpen" maximized>
+    <q-dialog v-model="session.dialogs.deckSplayOpen" maximized>
       <q-card class="dr-deck-splay-panel">
         <div class="row items-center q-px-md q-pt-md q-pb-sm">
           <div class="text-subtitle1">Deck splay</div>
           <q-space />
-          <q-btn flat dense icon="close" aria-label="Close deck splay" @click="session.onCloseDeckSplay" />
+          <q-btn flat dense icon="close" aria-label="Close deck splay" @click="session.dialogs.onCloseDeckSplay" />
         </div>
         <q-separator />
         <div class="q-pa-md dr-deck-splay-scroll">
           <div class="row q-col-gutter-sm q-row-gutter-sm">
             <div
-              v-for="(slot, index) in session.biddingBoard.memoryAid.deckSplayCards"
+              v-for="(slot, index) in session.board.biddingBoard.memoryAid.deckSplayCards"
               :key="`deck-card-${index}`"
               class="col-6 col-sm-4 col-md-3"
             >
@@ -462,7 +462,7 @@
     </q-dialog>
     
     <q-inner-loading
-      :showing="session.headlessCompletionInFlight"
+      :showing="session.board.headlessCompletionInFlight"
       :data-testid="LIVE_MATCH_SHELL_TEST_IDS.finishingMatchOverlay"
       class="dr-finishing-match-overlay"
     >

--- a/src/features/dungeon-runner/ui/shells/MatchOverShell.vue
+++ b/src/features/dungeon-runner/ui/shells/MatchOverShell.vue
@@ -1,0 +1,182 @@
+<template>
+  <div :data-testid="MATCH_OVER_SHELL_TEST_IDS.root">
+    <q-dialog :model-value="true" persistent transition-show="scale" transition-hide="scale">
+      <q-card class="q-pa-md dr-match-over-dialog" :class="toneClass" style="min-width: 340px">
+        <div class="text-overline dr-outcome-kicker">Match complete</div>
+        <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">{{ summary.title }}</div>
+        <div class="text-body1 q-mb-xs">{{ summary.message }}</div>
+        <div v-if="summary.showWinner" class="text-body2 q-mb-md">
+          Winner: {{ summary.winnerLabel }}
+        </div>
+        <div class="row q-gutter-sm justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Rematch"
+            class="dr-outcome-btn"
+            :data-testid="MATCH_OVER_SHELL_TEST_IDS.rematch"
+            @click="emit('rematch')"
+          />
+          <q-btn
+            flat
+            color="primary"
+            label="Back to setup"
+            class="dr-outcome-btn-secondary"
+            :data-testid="MATCH_OVER_SHELL_TEST_IDS.backToSetup"
+            @click="emit('back-to-setup')"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+
+    <q-card v-if="debugMode" flat bordered class="q-pa-md q-mt-md">
+      <div class="text-subtitle2 q-mb-sm">Debug replay</div>
+      <div v-if="nnDebugTraceHistory.length" class="q-mb-sm">
+        <div class="text-caption text-grey-5 q-mb-xs">NN trace history</div>
+        <div v-for="(entry, index) in nnDebugTraceHistory" :key="`nn-trace-${index}`" class="text-caption">
+          {{ entry.at }} | {{ entry.modelId }} | {{ entry.trace.kind }} |
+          {{ entry.trace.fallbackReason ?? entry.trace.mode ?? 'sample' }}
+        </div>
+      </div>
+      <div class="row q-gutter-sm q-mb-sm">
+        <q-btn
+          color="primary"
+          flat
+          label="Export replay"
+          :data-testid="MATCH_OVER_SHELL_TEST_IDS.exportReplay"
+          @click="emit('export-replay')"
+        />
+      </div>
+      <q-input
+        :model-value="replayExportText"
+        type="textarea"
+        autogrow
+        readonly
+        label="Export payload"
+        outlined
+        dense
+        class="q-mb-sm"
+      />
+      <q-input
+        :model-value="nnDebugTraceText"
+        type="textarea"
+        autogrow
+        readonly
+        label="NN trace (features/mask/logits)"
+        outlined
+        dense
+      />
+    </q-card>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import { buildMatchOverSummary } from '../matchOverSummaryBuilder.js'
+import { MATCH_OVER_END_VARIANTS } from '../humanEliminationCompletionPolicy.js'
+import { runMatchOverShellActivation } from './matchOverShellActivation.js'
+import { MATCH_OVER_SHELL_TEST_IDS } from './matchOverShellTestIds.js'
+
+const props = defineProps({
+  match: {
+    type: Object,
+    default: null,
+  },
+  humanSeatId: {
+    type: String,
+    default: null,
+  },
+  debugMode: {
+    type: Boolean,
+    default: false,
+  },
+  replayExportText: {
+    type: String,
+    default: '',
+  },
+  nnDebugTraceText: {
+    type: String,
+    default: '',
+  },
+  nnDebugTraceHistory: {
+    type: Array,
+    default: () => [],
+  },
+  uploadTracker: {
+    type: Object,
+    default: null,
+  },
+})
+
+const emit = defineEmits(['rematch', 'back-to-setup', 'export-replay'])
+
+const summary = computed(() =>
+  buildMatchOverSummary({
+    state: props.match?.state ?? null,
+    humanPlayerSeatId: props.humanSeatId,
+    seats: props.match?.state?.seats ?? [],
+  }),
+)
+
+const toneClass = computed(() =>
+  summary.value.variant === MATCH_OVER_END_VARIANTS.VICTORY
+    ? 'dr-outcome--success'
+    : 'dr-outcome--failure',
+)
+
+function activateShell() {
+  runMatchOverShellActivation({
+    match: props.match,
+    uploadTracker: props.uploadTracker,
+  })
+}
+
+watch(
+  () => props.match?.id,
+  () => {
+    activateShell()
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.dr-match-over-dialog {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  box-shadow:
+    0 12px 34px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+}
+
+.dr-outcome--success {
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(102, 187, 106, 0.22), rgba(102, 187, 106, 0) 60%),
+    radial-gradient(120% 120% at 100% 100%, rgba(41, 182, 246, 0.2), rgba(41, 182, 246, 0) 62%),
+    #171b1f;
+}
+
+.dr-outcome--failure {
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(239, 83, 80, 0.24), rgba(239, 83, 80, 0) 58%),
+    radial-gradient(120% 120% at 100% 100%, rgba(171, 71, 188, 0.2), rgba(171, 71, 188, 0) 62%),
+    #1b161c;
+}
+
+.dr-outcome-kicker {
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.dr-outcome-title {
+  text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
+}
+
+.dr-outcome-btn {
+  letter-spacing: 0.03em;
+}
+
+.dr-outcome-btn-secondary {
+  color: rgba(255, 255, 255, 0.86);
+}
+</style>

--- a/src/features/dungeon-runner/ui/shells/PlaySetupShell.vue
+++ b/src/features/dungeon-runner/ui/shells/PlaySetupShell.vue
@@ -1,0 +1,155 @@
+<template>
+  <div :data-testid="PLAY_SETUP_SHELL_TEST_IDS.root">
+    <q-card flat bordered class="q-pa-md">
+      <div class="text-subtitle1 q-mb-sm">Setup</div>
+      <div class="row q-col-gutter-md q-mb-md">
+        <div class="col-12 col-sm-6">
+          <div class="text-body2 q-mb-sm">Total players</div>
+          <q-slider
+            v-model="setup.totalSeats"
+            :min="totalSeatSlider.min"
+            :max="totalSeatSlider.max"
+            :step="totalSeatSlider.step"
+            snap
+            markers
+            marker-labels
+            color="primary"
+            aria-label="Total players"
+            class="dr-total-seats-slider q-px-sm"
+          />
+        </div>
+      </div>
+
+      <div class="q-gutter-y-sm">
+        <div
+          v-for="(opponent, index) in setup.opponents"
+          :key="`opponent-${index}`"
+          class="row items-center q-col-gutter-sm"
+        >
+          <div class="col-7">
+            <q-select
+              v-model="opponent.type"
+              :options="opponentTypeOptions"
+              option-value="value"
+              option-label="label"
+              emit-value
+              map-options
+              behavior="menu"
+              outlined
+              dense
+              :label="`Opponent ${index + 1}`"
+            />
+          </div>
+          <div class="col-5" v-if="opponent.type === 'nn'">
+            <q-select
+              v-if="modelOptions.length"
+              v-model="opponent.modelId"
+              :options="modelOptions"
+              label="Model"
+              behavior="menu"
+              outlined
+              dense
+            />
+            <q-input v-else v-model="opponent.modelId" label="Model" outlined dense />
+          </div>
+        </div>
+      </div>
+
+      <div class="q-mt-md">
+        <q-btn
+          unelevated
+          color="primary"
+          label="Start match"
+          :disable="!setupIsValid"
+          :data-testid="PLAY_SETUP_SHELL_TEST_IDS.startMatch"
+          @click="emit('start-match')"
+        />
+      </div>
+    </q-card>
+
+    <q-dialog
+      :model-value="neuralLoadGateTerminalOpen"
+      persistent
+      :data-testid="PLAY_SETUP_SHELL_TEST_IDS.neuralLoadGateTerminal"
+      @update:model-value="onNeuralLoadGateTerminalModelValue"
+    >
+      <q-card class="q-pa-md" style="min-width: 320px">
+        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
+        <div class="text-body2 q-mb-md">
+          A selected neural model could not load. Adjust setup and start a new match.
+        </div>
+        <div class="row justify-end">
+          <q-btn
+            color="primary"
+            unelevated
+            label="Back to setup"
+            :data-testid="PLAY_SETUP_SHELL_TEST_IDS.neuralLoadGateTerminalDismiss"
+            @click="emit('update:neuralLoadGateTerminalOpen', false)"
+          />
+        </div>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import { normalizeSetupState } from '../../setup/state.js'
+import {
+  PLAY_SETUP_SHELL_TEST_IDS,
+  applyNnDefaultModelIds,
+  isPlaySetupStartEnabled,
+} from '../playSetupShell.js'
+
+const setup = defineModel('setup', { type: Object, required: true })
+
+const props = defineProps({
+  modelOptions: {
+    type: Array,
+    required: true,
+  },
+  totalSeatSlider: {
+    type: Object,
+    required: true,
+  },
+  opponentTypeOptions: {
+    type: Array,
+    required: true,
+  },
+  neuralLoadGateTerminalOpen: {
+    type: Boolean,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['start-match', 'update:neuralLoadGateTerminalOpen'])
+
+const setupIsValid = computed(() =>
+  isPlaySetupStartEnabled({
+    setup: setup.value,
+    modelOptions: props.modelOptions,
+  }),
+)
+
+watch(
+  () => setup.value.totalSeats,
+  (totalSeats) => {
+    const normalized = normalizeSetupState({ totalSeats, opponents: setup.value.opponents })
+    setup.value.totalSeats = normalized.totalSeats
+    setup.value.opponents.splice(0, setup.value.opponents.length, ...normalized.opponents)
+  },
+)
+
+watch(
+  () => setup.value.opponents.map((opponent) => opponent.type),
+  () => {
+    applyNnDefaultModelIds(setup.value, props.modelOptions)
+  },
+)
+
+function onNeuralLoadGateTerminalModelValue(open) {
+  if (!open) {
+    emit('update:neuralLoadGateTerminalOpen', false)
+  }
+}
+</script>

--- a/src/features/dungeon-runner/ui/shells/PlaySetupShell.vue
+++ b/src/features/dungeon-runner/ui/shells/PlaySetupShell.vue
@@ -98,7 +98,7 @@ import { normalizeSetupState } from '../../setup/state.js'
 import {
   PLAY_SETUP_SHELL_TEST_IDS,
   applyNnDefaultModelIds,
-  isPlaySetupStartEnabled,
+  evaluatePlaySetupStart,
 } from '../playSetupShell.js'
 
 const setup = defineModel('setup', { type: Object, required: true })
@@ -124,11 +124,12 @@ const props = defineProps({
 
 const emit = defineEmits(['start-match', 'update:neuralLoadGateTerminalOpen'])
 
-const setupIsValid = computed(() =>
-  isPlaySetupStartEnabled({
-    setup: setup.value,
-    modelOptions: props.modelOptions,
-  }),
+const setupIsValid = computed(
+  () =>
+    evaluatePlaySetupStart({
+      setup: setup.value,
+      modelOptions: props.modelOptions,
+    }).ok,
 )
 
 watch(

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellLifecycle.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellLifecycle.js
@@ -1,0 +1,63 @@
+import {
+  DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS,
+  runPresentationIntervalTick,
+} from '../dungeonRunnerPresentationInterval.js'
+
+/**
+ * @param {{
+ *   recovery: { subscribe: (listener: () => void) => () => void }
+ *   onRecoveryChanged: () => void
+ *   presentationOrchestrator: Parameters<typeof runPresentationIntervalTick>[0]
+ *   tickCallbacks: Parameters<typeof runPresentationIntervalTick>[2]
+ *   setInterval?: typeof globalThis.setInterval
+ *   clearInterval?: typeof globalThis.clearInterval
+ * }} deps
+ * @returns {{ unsubscribe: () => void, presentationTimerId: ReturnType<typeof setInterval> }}
+ */
+export function activateLiveMatchShellLifecycle({
+  recovery,
+  onRecoveryChanged,
+  presentationOrchestrator,
+  tickCallbacks,
+  setInterval = globalThis.setInterval,
+  clearInterval = globalThis.clearInterval,
+}) {
+  const unsubscribe = recovery.subscribe(onRecoveryChanged)
+  const presentationTimerId = setInterval(() => {
+    runPresentationIntervalTick(
+      presentationOrchestrator,
+      DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS,
+      tickCallbacks,
+    )
+  }, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS)
+  return { unsubscribe, presentationTimerId, clearInterval }
+}
+
+/**
+ * @param {{
+ *   unsubscribe?: (() => void) | null
+ *   presentationTimerId?: ReturnType<typeof setInterval> | null
+ *   aiTurnTimerId?: ReturnType<typeof setTimeout> | null
+ *   autoResolveTimerId?: ReturnType<typeof setTimeout> | null
+ *   confirmationDialogResolve?: ((value: boolean) => void) | null
+ *   clearInterval?: typeof globalThis.clearInterval
+ *   clearTimeout?: typeof globalThis.clearTimeout
+ * }} state
+ */
+export function deactivateLiveMatchShellLifecycle({
+  unsubscribe = null,
+  presentationTimerId = null,
+  aiTurnTimerId = null,
+  autoResolveTimerId = null,
+  confirmationDialogResolve = null,
+  clearInterval = globalThis.clearInterval,
+  clearTimeout = globalThis.clearTimeout,
+}) {
+  unsubscribe?.()
+  if (presentationTimerId != null) clearInterval(presentationTimerId)
+  if (aiTurnTimerId != null) clearTimeout(aiTurnTimerId)
+  if (autoResolveTimerId != null) clearTimeout(autoResolveTimerId)
+  if (typeof confirmationDialogResolve === 'function') {
+    confirmationDialogResolve(false)
+  }
+}

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellLifecycle.test.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellLifecycle.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  activateLiveMatchShellLifecycle,
+  deactivateLiveMatchShellLifecycle,
+} from './liveMatchShellLifecycle.js'
+
+test('activateLiveMatchShellLifecycle subscribes to recovery and starts presentation interval', () => {
+  let subscribed = false
+  let intervalCallback = null
+  const recovery = {
+    subscribe(listener) {
+      subscribed = true
+      listener()
+      return () => {
+        subscribed = false
+      }
+    },
+  }
+  const presentationOrchestrator = { tick: true }
+  const tickCallbacks = { syncPresentationLabel: () => {} }
+
+  const { unsubscribe, presentationTimerId } = activateLiveMatchShellLifecycle({
+    recovery,
+    onRecoveryChanged: () => {},
+    presentationOrchestrator,
+    tickCallbacks,
+    setInterval: (cb) => {
+      intervalCallback = cb
+      return 42
+    },
+  })
+
+  assert.equal(subscribed, true)
+  assert.equal(presentationTimerId, 42)
+  assert.equal(typeof intervalCallback, 'function')
+  unsubscribe()
+  assert.equal(subscribed, false)
+})
+
+test('deactivateLiveMatchShellLifecycle clears timers and settles confirmation', () => {
+  let intervalCleared = false
+  let aiTurnCleared = false
+  let autoResolveCleared = false
+  let confirmationResult = null
+
+  deactivateLiveMatchShellLifecycle({
+    unsubscribe: () => {},
+    presentationTimerId: 1,
+    aiTurnTimerId: 2,
+    autoResolveTimerId: 3,
+    confirmationDialogResolve: (value) => {
+      confirmationResult = value
+    },
+    clearInterval: (id) => {
+      if (id === 1) intervalCleared = true
+    },
+    clearTimeout: (id) => {
+      if (id === 2) aiTurnCleared = true
+      if (id === 3) autoResolveCleared = true
+    },
+  })
+
+  assert.equal(intervalCleared, true)
+  assert.equal(aiTurnCleared, true)
+  assert.equal(autoResolveCleared, true)
+  assert.equal(confirmationResult, false)
+})

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellSessionGroups.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellSessionGroups.js
@@ -1,0 +1,8 @@
+/** @typedef {'board' | 'dialogs' | 'debug' | 'page'} LiveMatchShellSessionGroup */
+
+export const LIVE_MATCH_SHELL_SESSION_GROUPS = /** @type {const} */ ([
+  'board',
+  'dialogs',
+  'debug',
+  'page',
+])

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellSessionKey.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellSessionKey.js
@@ -1,0 +1,1 @@
+export const LIVE_MATCH_SHELL_SESSION_KEY = Symbol('liveMatchShellSession')

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.js
@@ -1,0 +1,6 @@
+export const LIVE_MATCH_SHELL_TEST_IDS = {
+  root: 'live-match-shell',
+  finishingMatchOverlay: 'finishing-match-overlay',
+  neuralRefreshTerminal: 'neural-refresh-terminal',
+  neuralRefreshTerminalReload: 'neural-refresh-terminal-reload',
+}

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.test.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.test.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
+
+test('LIVE_MATCH_SHELL_TEST_IDS exposes stable live-match selectors', () => {
+  assert.equal(LIVE_MATCH_SHELL_TEST_IDS.root, 'live-match-shell')
+  assert.equal(LIVE_MATCH_SHELL_TEST_IDS.finishingMatchOverlay, 'finishing-match-overlay')
+  assert.equal(LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminal, 'neural-refresh-terminal')
+  assert.equal(LIVE_MATCH_SHELL_TEST_IDS.neuralRefreshTerminalReload, 'neural-refresh-terminal-reload')
+})

--- a/src/features/dungeon-runner/ui/shells/matchOverShellActivation.js
+++ b/src/features/dungeon-runner/ui/shells/matchOverShellActivation.js
@@ -1,0 +1,11 @@
+/**
+ * Side effects when the match-over shell becomes active (replay + outcome upload).
+ *
+ * @param {{
+ *   match: import('../../engine/kernel.js').Match | null | undefined
+ *   uploadTracker: { maybeUpload: (match: unknown) => void } | null | undefined
+ * }} inputs
+ */
+export function runMatchOverShellActivation({ match, uploadTracker }) {
+  uploadTracker?.maybeUpload(match ?? null)
+}

--- a/src/features/dungeon-runner/ui/shells/matchOverShellActivation.test.js
+++ b/src/features/dungeon-runner/ui/shells/matchOverShellActivation.test.js
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MATCH_PHASES } from '../../engine/kernel.js'
+import {
+  UPLOADED_MATCH_IDS_STORAGE_KEY,
+  maybeUploadCompletedMatchReplay,
+} from '../../firebase/completedMatchReplayUpload.js'
+import { runMatchOverShellActivation } from './matchOverShellActivation.js'
+
+function createMemoryStorage() {
+  /** @type {Map<string, string>} */
+  const map = new Map()
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value)
+    },
+  }
+}
+
+/** @param {Partial<import('../../firebase/completedMatchReplayUpload.js').CompletedMatchReplayUploadDeps>} overrides */
+function createUploadDeps(overrides = {}) {
+  const storage = createMemoryStorage()
+  const uploadedIds = new Set()
+  /** @type {Array<{ matchId: string, envelope: { createdAt: string } }>} */
+  const setCalls = []
+  return {
+    storage,
+    setCalls,
+    deps: {
+      storage,
+      uploadedIds,
+      isConfigured: () => true,
+      exportEnvelope: (payload) => ({
+        version: 1,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        ...payload,
+      }),
+      setCompletedMatch: async (matchId, envelope) => {
+        setCalls.push({ matchId, envelope })
+      },
+      createOutcome: async () => {},
+      ...overrides,
+    },
+  }
+}
+
+function matchOverMatch(matchId = 'match-activation-1') {
+  return {
+    id: matchId,
+    setup: { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    state: {
+      phase: MATCH_PHASES.MATCH_OVER,
+      rng: { seed: 1 },
+      history: [],
+    },
+    presentationSpeedProfile: 'cinematic',
+  }
+}
+
+test('runMatchOverShellActivation uploads completed match replay once', async () => {
+  const { deps, setCalls } = createUploadDeps()
+  const tracker = { maybeUpload: (match) => maybeUploadCompletedMatchReplay(match, deps) }
+  const match = matchOverMatch()
+
+  runMatchOverShellActivation({ match, uploadTracker: tracker })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(setCalls.length, 1)
+  assert.equal(setCalls[0].matchId, 'match-activation-1')
+})
+
+test('runMatchOverShellActivation pairs outcome upload with replay envelope', async () => {
+  /** @type {Array<{ match: unknown, createdAt: string }>} */
+  const outcomeCalls = []
+  const { deps, setCalls } = createUploadDeps({
+    createOutcome: async (uploadMatch, createdAt) => {
+      outcomeCalls.push({ match: uploadMatch, createdAt })
+    },
+  })
+  const tracker = { maybeUpload: (match) => maybeUploadCompletedMatchReplay(match, deps) }
+  const match = matchOverMatch()
+
+  runMatchOverShellActivation({ match, uploadTracker: tracker })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(outcomeCalls.length, 1)
+  assert.equal(outcomeCalls[0].match, match)
+  assert.equal(outcomeCalls[0].createdAt, setCalls[0].envelope.createdAt)
+})
+
+test('runMatchOverShellActivation is idempotent for the same match id', () => {
+  const { deps, setCalls, storage } = createUploadDeps()
+  const tracker = { maybeUpload: (match) => maybeUploadCompletedMatchReplay(match, deps) }
+  const match = matchOverMatch()
+
+  runMatchOverShellActivation({ match, uploadTracker: tracker })
+  runMatchOverShellActivation({ match, uploadTracker: tracker })
+
+  assert.equal(setCalls.length, 1)
+  assert.ok(storage.getItem(UPLOADED_MATCH_IDS_STORAGE_KEY)?.includes('match-activation-1'))
+})
+
+test('runMatchOverShellActivation no-ops without match', () => {
+  const { deps, setCalls } = createUploadDeps()
+  const tracker = { maybeUpload: (match) => maybeUploadCompletedMatchReplay(match, deps) }
+
+  runMatchOverShellActivation({ match: null, uploadTracker: tracker })
+
+  assert.equal(setCalls.length, 0)
+})
+
+test('runMatchOverShellActivation no-ops without upload tracker', () => {
+  assert.doesNotThrow(() => {
+    runMatchOverShellActivation({ match: matchOverMatch(), uploadTracker: null })
+  })
+})

--- a/src/features/dungeon-runner/ui/shells/matchOverShellTestIds.js
+++ b/src/features/dungeon-runner/ui/shells/matchOverShellTestIds.js
@@ -1,0 +1,6 @@
+export const MATCH_OVER_SHELL_TEST_IDS = {
+  root: 'match-over-shell',
+  rematch: 'match-over-rematch',
+  backToSetup: 'match-over-back-to-setup',
+  exportReplay: 'match-over-export-replay',
+}

--- a/src/features/dungeon-runner/ui/shells/matchOverShellTestIds.test.js
+++ b/src/features/dungeon-runner/ui/shells/matchOverShellTestIds.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MATCH_OVER_SHELL_TEST_IDS } from './matchOverShellTestIds.js'
+
+test('MATCH_OVER_SHELL_TEST_IDS exposes stable match-over selectors', () => {
+  assert.equal(MATCH_OVER_SHELL_TEST_IDS.root, 'match-over-shell')
+  assert.equal(MATCH_OVER_SHELL_TEST_IDS.rematch, 'match-over-rematch')
+  assert.equal(MATCH_OVER_SHELL_TEST_IDS.backToSetup, 'match-over-back-to-setup')
+  assert.equal(MATCH_OVER_SHELL_TEST_IDS.exportReplay, 'match-over-export-replay')
+})
+
+test('match-over shell debug surface is export-only', () => {
+  assert.equal('importReplay' in MATCH_OVER_SHELL_TEST_IDS, false)
+})

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -1,10 +1,5 @@
 import { computed, reactive, ref, triggerRef, unref, watch } from 'vue'
-import {
-  MATCH_PHASES,
-  applyAction,
-  getLegalActions,
-  getPlayerView,
-} from '../../engine/kernel.js'
+import { MATCH_PHASES, applyAction, getLegalActions, getPlayerView } from '../../engine/kernel.js'
 import {
   CURRENT_MATCH_SCHEMA_VERSION,
   clearCurrentMatch,
@@ -14,15 +9,9 @@ import { applySetupSnapshot } from '../../setup/state.js'
 import { isNnAdventurerPickEnabled } from '../../setup/nnAdventurerPick.js'
 import { buildStateFromReplayEnvelope } from '../../debug/replaySession.js'
 import { exportReplayEnvelope, importReplayEnvelope } from '../../debug/replay.js'
-import {
-  abandonScheduledInferenceQueue,
-  loadNnModel,
-} from '../../nn/runtime.js'
+import { abandonScheduledInferenceQueue, loadNnModel } from '../../nn/runtime.js'
 import { createChooseNnActionWithRecovery } from '../../nn/chooseWithRecovery.js'
-import {
-  createPresentationOrchestrator,
-  SPEED_PROFILES,
-} from '../presentationOrchestrator.js'
+import { createPresentationOrchestrator, SPEED_PROFILES } from '../presentationOrchestrator.js'
 import { buildAiTurnRunToken } from '../dungeonRunnerAiTurnToken.js'
 import {
   cancelAiTurnPrefetch,
@@ -31,16 +20,10 @@ import {
   startAiTurnPrefetch,
 } from '../dungeonRunnerAiTurnPrefetch.js'
 import { createPipelineStepLogger } from '../../nn/nnPipelineTrace.js'
-import {
-  dungeonRunnerAssetPack,
-  dungeonRunnerEquipmentSymbolRuntimePath,
-} from '../assetPack.js'
+import { dungeonRunnerAssetPack, dungeonRunnerEquipmentSymbolRuntimePath } from '../assetPack.js'
 import { equipmentTokenAppearance } from '../../equipmentTokenAppearance.js'
 import { equipmentShortName } from '../../data/gameDataCatalog.js'
-import {
-  adventurerChoiceHeadline,
-  legalActionBoardLabel,
-} from '../dungeonRunnerPlayerPhrasing.js'
+import { adventurerChoiceHeadline, legalActionBoardLabel } from '../dungeonRunnerPlayerPhrasing.js'
 import {
   buildDungeonEquipmentTokenView,
   createDungeonEquipmentModalView,
@@ -82,7 +65,12 @@ import { createMatchPageOrchestrationContext } from '../../createMatchPageOrches
 import { createLiveMatchPageSessionSink } from '../../createLiveMatchPageSessionSink.js'
 import { resetLiveMatchPageState } from '../../resetLiveMatchPageState.js'
 import { createLivePlayActionChooser } from '../livePlayActionChooser.js'
-import { closeDeckSplay, createMemoryAidState, setMemoryAidEnabled, tapDeck } from '../memoryAidState.js'
+import {
+  closeDeckSplay,
+  createMemoryAidState,
+  setMemoryAidEnabled,
+  tapDeck,
+} from '../memoryAidState.js'
 import { isDungeonPresentationTraceEnabled } from '../dungeonPresentationTrace.js'
 import { isDungeonOrchestratorPresentationKind } from '../orchestratorPresentationKinds.js'
 import { usePresentationMotion } from '../usePresentationMotion.js'
@@ -92,15 +80,14 @@ import {
   buildAiTurnRunSkipTrace,
   buildAiTurnScheduleSkipTrace,
 } from '../liveAiTurnPipelineGateTrace.js'
-import {
-  buildSeatRecoveryIndicators,
-  isActiveNnSeatRecovering,
-} from '../neuralSeatRecoveryView.js'
+import { buildSeatRecoveryIndicators, isActiveNnSeatRecovering } from '../neuralSeatRecoveryView.js'
 import { handleLivePlayNeuralRecoveryTerminalError } from '../livePlayNeuralRecoveryTerminal.js'
 import {
   activateLiveMatchShellLifecycle,
   deactivateLiveMatchShellLifecycle,
 } from './liveMatchShellLifecycle.js'
+
+export { LIVE_MATCH_SHELL_SESSION_GROUPS } from './liveMatchShellSessionGroups.js'
 
 /**
  * Live-match session: board, mid-match dialogs, AI pipeline, presentation motion.
@@ -129,1497 +116,1586 @@ export function useLiveMatchShell(deps) {
   function presentationTraceEnabled() {
     return isDungeonPresentationTraceEnabled()
   }
-const nnRecovery = deps.nnRecovery
-const seatRecoveryIndicators = ref([])
-/** @type {(() => void) | null} */
-let unsubscribeNnRecovery = null
-let activeSeatRecoveryBlocking = false
+  const nnRecovery = deps.nnRecovery
+  const seatRecoveryIndicators = ref([])
+  /** @type {(() => void) | null} */
+  let unsubscribeNnRecovery = null
+  let activeSeatRecoveryBlocking = false
 
-function syncSeatRecoveryIndicators() {
-  const seats = match.value?.state?.seats ?? []
-  seatRecoveryIndicators.value = buildSeatRecoveryIndicators({ seats, recovery: nnRecovery })
-}
-
-function resolveActiveSeatRecoveryBlocking() {
-  return match.value?.state
-    ? isActiveNnSeatRecovering({ state: match.value.state, recovery: nnRecovery })
-    : false
-}
-
-function applySeatRecoveryBlockingTransition(blocking) {
-  if (!activeSeatRecoveryBlocking && blocking) {
-    cancelAiTurnPrefetch()
+  function syncSeatRecoveryIndicators() {
+    const seats = match.value?.state?.seats ?? []
+    seatRecoveryIndicators.value = buildSeatRecoveryIndicators({ seats, recovery: nnRecovery })
   }
-  activeSeatRecoveryBlocking = blocking
-}
 
-function onNnRecoveryChanged() {
-  syncSeatRecoveryIndicators()
-  applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
-  if (!liveMatchShellLifecycleActive) return
-  scheduleAiTurnIfReady()
-}
-
-function logNnRecoveryTrace(modelId, step, detail = {}) {
-  if (!debugMode.value) return
-  aiTurnTrace({ modelId })(`recovery.${step}`, {
-    loadAttempts: nnRecovery.getLoadAttempts(modelId),
-    inferAttempts: nnRecovery.getInferAttempts(modelId),
-    loadBackend: nnRecovery.getBackendPreference(modelId, 'load'),
-    inferBackend: nnRecovery.getBackendPreference(modelId, 'infer'),
-    ...detail,
-  })
-}
-
-const chooseNnActionWithRecovery = createChooseNnActionWithRecovery({
-  recovery: nnRecovery,
-  onRecoveryBegin: (modelId) => logNnRecoveryTrace(modelId, 'begin'),
-  onRecoveryAttempt: (detail) => logNnRecoveryTrace(detail.modelId, 'attempt', detail),
-  onRecoverySettled: (modelId) => logNnRecoveryTrace(modelId, 'settled'),
-})
-
-function buildLivePlayChooserDeps(extra = {}) {
-  return {
-    nnRecovery,
-    ensureNnModelsReady,
-    nnRuntimeOptions,
-    chooseNnActionWithRecovery,
-    ...extra,
+  function resolveActiveSeatRecoveryBlocking() {
+    return match.value?.state
+      ? isActiveNnSeatRecovering({ state: match.value.state, recovery: nnRecovery })
+      : false
   }
-}
 
-function evaluatePageAiTurnPipelineGate({ runToken = '', timerPending = false } = {}) {
-  return evaluateLiveAiTurnPipelineGateForContext({
-    matchState: match.value?.state ?? null,
-    humanSeatId: humanSeatId.value,
-    isHumanTurn: isHumanTurn.value,
-    hasMatch: !!match.value,
-    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
-    matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
-    aiTurnInFlight,
-    headlessCompletionInFlight: headlessCompletionInFlight.value,
-    deferredPostDungeonState: deferredPostDungeonState.value,
-    gameplayInputLocked: gameplayInputLocked.value,
-    recovery: nnRecovery,
-    runToken,
-    lastAppliedAiTurnToken,
-    timerPending,
-    pickAdventurerNnEnabled: isNnAdventurerPickEnabled(),
-  })
-}
-const replayImportText = deps.replayImportText
-const replayExportText = deps.replayExportText
-const nnDebugTraceText = deps.nnDebugTraceText
-const nnDebugTraceHistory = deps.nnDebugTraceHistory
-const presentationOrchestrator = createPresentationOrchestrator()
-const dungeonRunnerSettingsStore = deps.dungeonRunnerSettingsStore
-
-const presentationSpeedProfile = deps.presentationSpeedProfile
-const activePresentation = ref(null)
-const boardShellRef = ref(null)
-const heroCardSlotRef = ref(null)
-const dungeonCardMotionWrap = ref(null)
-const dungeonCardFaceRef = ref(null)
-const deckBadgeRef = ref(null)
-const dungeonPileMotionAnchorRef = ref(null)
-const heroChangeInterstitialOverlayRef = ref(null)
-const presentationFlightLayerRef = ref(null)
-const biddingEquipmentBadgeRefs = reactive({})
-
-function domEl(componentOrEl) {
-  if (!componentOrEl) return null
-  if (componentOrEl.nodeType === 1) return componentOrEl
-  const inner = componentOrEl.$el
-  return inner?.nodeType === 1 ? inner : null
-}
-
-/** `defineExpose`d Refs from child components; QBadge roots via {@link domEl}. */
-function unwrapMotionDom(exposedMaybeRef) {
-  if (exposedMaybeRef == null) return null
-  const el = unref(exposedMaybeRef)
-  return el?.nodeType === 1 ? el : null
-}
-
-function bindBiddingEquipmentBadgeRef(equipmentId, componentOrEl) {
-  const node = domEl(componentOrEl)
-  if (node) biddingEquipmentBadgeRefs[equipmentId] = node
-  else delete biddingEquipmentBadgeRefs[equipmentId]
-}
-
-// GSAP: most beats tween `boardShell` (shared placeholder) plus kind-specific refs — `DUNGEON_REVEAL` tweens `dungeonCardWrap` (opacity / y / scale) and `dungeonCardFlipAxis` (`rotationY` flip); damage / neutralize / continue use `dungeonCardWrap` + shell; `DUNGEON_OUTCOME` tweens the wrap only (no shell tween); teardown clears wrap + shell after that beat for neutral baseline (#66).
-// `HERO_CHANGE_INTERSTITIAL` → overlay only; bot bidding → `dungeonCardWrap` / `deckBadge` / equipment; neutralize + sacrifice use `presentationFlightLayer` + `equipment_*` (see presentationMotionRegistry.js).
-// Window resize during fragile motion (ghost flight #68, or dungeon reveal flip) swaps to shell+card-only tweens for the rest of that beat (#71); orchestrator `remainingMs` is not recomputed on resize (#68).
-usePresentationMotion({
-  activePresentation,
-  getMotionRefs: (head) => {
-    if (head?.kind === 'HERO_CHANGE_INTERSTITIAL') {
-      return {
-        heroChangeInterstitialOverlay: heroChangeInterstitialOverlayRef.value,
-        boardShell: boardShellRef.value,
-      }
+  function applySeatRecoveryBlockingTransition(blocking) {
+    if (!activeSeatRecoveryBlocking && blocking) {
+      cancelAiTurnPrefetch()
     }
-    const base = {
-      boardShell: boardShellRef.value,
-      dungeonCardWrap: dungeonCardMotionWrap.value,
-      dungeonCardFlipAxis: unwrapMotionDom(dungeonCardFaceRef.value?.dungeonCardFlipAxis),
-      deckBadge: domEl(deckBadgeRef.value),
-      dungeonPileBadge: dungeonPileMotionAnchorRef.value,
-      presentationFlightLayer: presentationFlightLayerRef.value,
-      presentationGhostTarget: heroCardSlotRef.value,
-    }
-    if (
-      presentationTraceEnabled() &&
-      (head?.kind === 'DUNGEON_REVEAL' || head?.kind === 'BIDDING_DRAW')
-    ) {
-      const snapEl = (el) => {
-        if (!el || typeof el.getBoundingClientRect !== 'function') return { present: false }
-        const r = el.getBoundingClientRect()
-        return {
-          present: true,
-          tag: el.tagName,
-          w: Math.round(r.width * 100) / 100,
-          h: Math.round(r.height * 100) / 100,
-          cx: Math.round((r.left + r.width / 2) * 100) / 100,
-          cy: Math.round((r.top + r.height / 2) * 100) / 100,
-        }
-      }
-      const deckNode = domEl(deckBadgeRef.value)
-      console.log('[DungeonRunner][card-flight][refs]', {
-        kind: head.kind,
-        id: head.id,
-        durationMs: head.durationMs,
-        dungeonCardWrap: snapEl(base.dungeonCardWrap),
-        dungeonPileAnchor: snapEl(base.dungeonPileBadge),
-        deckBadgeResolved: snapEl(base.deckBadge),
-        dungeonCardFlipAxis: snapEl(base.dungeonCardFlipAxis),
-        deckBadgeRawDomEl: snapEl(deckNode),
-        refsBound: {
-          dungeonPileMotionAnchorRef: !!dungeonPileMotionAnchorRef.value,
-          deckBadgeRef: !!deckBadgeRef.value,
-          dungeonCardMotionWrap: !!dungeonCardMotionWrap.value,
-          dungeonCardFaceRef: !!dungeonCardFaceRef.value,
-        },
-      })
-    }
-    if (head?.kind !== 'BIDDING_SACRIFICE' && head?.kind !== 'DUNGEON_NEUTRALIZE') return base
-    const ids = head?.payload?.responsibleEquipmentIds ?? head?.payload?.consumedEquipmentIds ?? []
-    const extra = {}
-    for (const id of ids) {
-      const node = biddingEquipmentBadgeRefs[id]
-      if (node?.nodeType === 1) extra[`equipment_${id}`] = node
-    }
-    return { ...base, ...extra }
-  },
-})
-const activePresentationLabel = ref('')
-const equipmentModalOpen = ref(false)
-const selectedEquipmentTokenId = ref(null)
-const neuralLoadGateTerminalOpen = deps.neuralLoadGateTerminalOpen
-const neuralRefreshTerminalOpen = ref(false)
-const matchNeuralLoadGateInFlight = deps.matchNeuralLoadGateInFlight
-const confirmationDialogOpen = ref(false)
-const confirmationDialogTitle = ref('Confirm')
-const confirmationDialogMessage = ref('')
-const confirmationDialogOkLabel = ref('OK')
-const confirmationDialogCancelLabel = ref('Cancel')
-let confirmationDialogResolve = null
-const vorpalDialogOpen = ref(false)
-const selectedVorpalSpecies = ref(null)
-const memoryAidState = ref(createMemoryAidState({ enabled: dungeonRunnerSettingsStore.memoryAidEnabled }))
-const previousVisibleState = ref(null)
-const dismissedDungeonRun = ref(null)
-const equipmentRemainingAtResolution = ref(null)
-const deferredPostDungeonState = ref(null)
-let presentationTimerId = null
-let aiTurnTimerId = null
-let liveMatchShellLifecycleActive = false
-let autoResolveTimerId = null
-let aiTurnInFlight = false
-let lastAppliedAiTurnToken = null
-let presentationInputWasLocked = false
-let lastPresentationTraceKey = null
-let lastScheduleSkipKey = ''
-let lastPrimeSkipTraceKey = ''
-/** @type {Promise<void> | null} */
-let nnModelsWarmPromise = null
-
-const liveMatchPageSessionSink = createLiveMatchPageSessionSink({
-  match,
-  setNnModelsWarmPromise: (promise) => {
-    nnModelsWarmPromise = promise
-  },
-  resetAiTurnPrefetch,
-  setLastAppliedAiTurnTokenNull: () => {
-    lastAppliedAiTurnToken = null
-  },
-  setPresentationInputWasLockedFalse: () => {
-    presentationInputWasLocked = false
-  },
-  deferredPostDungeonState,
-  nnDebugTraceText,
-  nnDebugTraceHistory,
-  presentationOrchestrator,
-  syncPresentationLabel,
-  neuralLoadGateTerminalOpen,
-  clearCurrentMatch,
-  storage: window.localStorage,
-})
-
-const AI_TURN_SCHEDULE_DELAY_MS = 300
-
-function aiTurnTrace(baseContext = {}) {
-  return createPipelineStepLogger('AITurn', debugMode.value, {
-    matchId: match.value?.id ?? null,
-    ...baseContext,
-  })
-}
-
-const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
-  'gameplay-locked',
-  'timer-pending',
-  'in-flight',
-  'already-applied-token',
-  'deferred-post-dungeon',
-  'headless-completion',
-])
-
-function logAiTurnScheduleSkip(reason, detail = {}) {
-  if (!debugMode.value) return
-  const key = `${reason}:${detail.runToken ?? detail.activeKind ?? ''}`
-  if (SCHEDULE_SKIP_THROTTLE_REASONS.has(reason) && key === lastScheduleSkipKey) return
-  lastScheduleSkipKey = key
-  console.warn('[DungeonRunner][AITurn][Schedule] skip', reason, detail)
-}
-
-function logAiTurnPrimeSkip(reason, detail = {}) {
-  if (!debugMode.value) return
-  const key = `${reason}:${detail.runToken ?? detail.phase ?? detail.seatId ?? detail.roleType ?? ''}`
-  if (key === lastPrimeSkipTraceKey) return
-  lastPrimeSkipTraceKey = key
-  aiTurnTrace()('prefetch.prime.skip', { reason, ...detail })
-}
-
-function scheduleAiTurnOnPresentationTick() {
-  if (!liveMatchShellLifecycleActive) return
-  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value || headlessCompletionInFlight.value) {
-    return
+    activeSeatRecoveryBlocking = blocking
   }
-  scheduleAiTurnIfReady()
-}
-const uiAssets = dungeonRunnerAssetPack
 
-watch(presentationSpeedProfile, (next) => {
-  presentationOrchestrator.setSpeedProfile(next)
-  syncPresentationLabel()
-  triggerRef(activePresentation)
-  if (match.value) {
-    match.value = { ...match.value, presentationSpeedProfile: next }
-    persistCurrentMatch(window.localStorage, match.value)
-  }
-})
-
-watch(
-  () => dungeonRunnerSettingsStore.memoryAidEnabled,
-  (enabled) => {
-    memoryAidState.value = setMemoryAidEnabled(memoryAidState.value, enabled)
-  },
-  { immediate: true },
-)
-
-const humanSeatId = computed(() => match.value?.state.seats.find((seat) => seat.role.type === 'human')?.id ?? null)
-const isHumanTurn = computed(
-  () => !!match.value && humanSeatId.value != null && match.value.state.turn.activeSeatId === humanSeatId.value,
-)
-const legalActions = computed(() => {
-  if (!match.value || !isHumanTurn.value) return []
-  return getLegalActions(match.value.state, { seatId: humanSeatId.value })
-})
-const visibleLegalActions = computed(() =>
-  filterVisibleLegalActions({
-    phase: match.value?.state?.phase ?? null,
-    legalActions: legalActions.value,
-  }),
-)
-const visiblePrimaryActions = computed(() =>
-  visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE'),
-)
-/** Matches engine pick-adventurer legal action order. */
-const HERO_CHOICE_ACTION_ORDER = ['WARRIOR', 'BARBARIAN', 'MAGE', 'ROGUE']
-const showHeroPickActionGrid = computed(() => {
-  const actions = visiblePrimaryActions.value
-  if (actions.length !== HERO_CHOICE_ACTION_ORDER.length) return false
-  return actions.every((a) => a.type === 'CHOOSE_NEXT_ADVENTURER')
-})
-const heroPickActionsOrdered = computed(() => {
-  if (!showHeroPickActionGrid.value) return []
-  const byHero = new Map(visiblePrimaryActions.value.map((a) => [a.hero, a]))
-  return HERO_CHOICE_ACTION_ORDER.map((hero) => byHero.get(hero)).filter(Boolean)
-})
-const showActionPane = computed(
-  () =>
-    !!activePresentationLabel.value ||
-    (isHumanTurn.value &&
-      (visiblePrimaryActions.value.length > 0 || dungeonOutcomeTransitionControls.value.length > 0)),
-)
-const biddingSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'))
-const biddingNonSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'))
-const gameplayInputLocked = ref(false)
-const headlessCompletionInFlight = ref(false)
-const visibleState = computed(() => {
-  if (!match.value || !humanSeatId.value) return null
-  return getPlayerView(match.value.state, { seatId: humanSeatId.value })
-})
-const dungeonOutcomeAckPending = computed(() =>
-  isDungeonOutcomeDialogOpen({
-    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-    dismissedDungeonRun: dismissedDungeonRun.value,
-  }),
-)
-const dungeonEquipmentTokens = computed(() =>
-  buildDungeonEquipmentTokenView({
-    inPlayEquipmentIds: visibleState.value?.dungeon?.inPlayEquipmentIds ?? [],
-    legalActions: legalActions.value,
-  }),
-)
-const dungeonResolutionView = computed(() =>
-  createDungeonResolutionViewModel({
-    visibleState: visibleState.value ?? {},
-    previousVisibleState: previousVisibleState.value ?? {},
-    legalActions: legalActions.value,
-    activeAnimation: activePresentation.value,
-  }),
-)
-const showDungeonStage = computed(() => {
-  if (match.value?.state?.phase === 'dungeon') return true
-  if (isDungeonOrchestratorPresentationKind(activePresentation.value?.kind ?? null)) return true
-  return dungeonOutcomeAckPending.value
-})
-const dungeonStageView = computed(() =>
-  createDungeonResolutionViewModel({
-    visibleState: visibleState.value ?? {},
-    previousVisibleState: previousVisibleState.value ?? {},
-    legalActions: legalActions.value,
-    activeAnimation: activePresentation.value,
-    preserveMonsterCardUntilRunAck: dungeonOutcomeAckPending.value,
-  }),
-)
-const dungeonStageAnimationClass = computed(() => dungeonStageClassForKind(activePresentation.value?.kind ?? null))
-const dungeonOutcomeTransitionControls = computed(() =>
-  buildDungeonOutcomeTransitionControls({
-    phase: match.value?.state?.phase ?? null,
-    gameplayInputLocked: gameplayInputLocked.value,
-    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
-    autoAdvanceAction: dungeonResolutionView.value.autoAdvanceAction,
-  }),
-)
-const actionableEquipmentIds = computed(() => new Set(dungeonResolutionView.value.highlightedEquipmentIds))
-const boardEquipmentTokens = computed(() => {
-  const dungeonTokenById = new Map(dungeonEquipmentTokens.value.map((token) => [token.equipmentId, token]))
-  const isDungeonPhase = match.value?.state?.phase === 'dungeon'
-  const hasActionable = actionableEquipmentIds.value.size > 0
-  return biddingBoard.value.secondary.equipment.map((equipment) => {
-    const dungeonToken = dungeonTokenById.get(equipment.equipmentId)
-    const removed =
-      equipment.removed ||
-      equipment.consumed ||
-      (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
-    const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
-    const appearance = equipmentTokenAppearance(equipment.equipmentId)
-    return {
-      equipmentId: equipment.equipmentId,
-      ariaLabel: equipmentShortName(equipment.equipmentId),
-      symbolRuntimePath: dungeonRunnerEquipmentSymbolRuntimePath(appearance.symbolKey),
-      equipmentOverlay: appearance.overlay,
-      removed,
-      glow: isDungeonPhase ? (dungeonToken?.glow ?? false) : false,
-      pulse: actionable,
-      deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
-      canUseNow: dungeonToken?.canUseNow ?? false,
-      hasModal: true,
-    }
-  })
-})
-const selectedEquipmentModalView = computed(() => {
-  if (!selectedEquipmentTokenId.value) return null
-  return createDungeonEquipmentModalView({
-    equipmentId: selectedEquipmentTokenId.value,
-    legalActions: legalActions.value,
-  })
-})
-const vorpalPromptView = computed(() =>
-  createVorpalDeclarationPromptView({
-    isHumanTurn: isHumanTurn.value,
-    gameplayInputLocked: gameplayInputLocked.value,
-    phase: match.value?.state?.phase ?? null,
-    subphase: match.value?.state?.dungeon?.subphase ?? null,
-    legalActions: legalActions.value,
-    memoryAidEnabled: memoryAidState.value.enabled,
-    viewerOwnPileAdds: visibleState.value?.playerOwnPileAdds?.[humanSeatId.value ?? ''] ?? [],
-  }),
-)
-const vorpalSelectOptions = computed(() => {
-  const pv = vorpalPromptView.value
-  const counts = pv.vorpalSpeciesOwnPileCounts
-  return pv.speciesOptions.map((species) => {
-    const n = counts?.[species] ?? 0
-    const label = n > 0 ? `${species} (${n})` : species
-    return { label, value: species }
-  })
-})
-const biddingBoard = computed(() =>
-  createBiddingBoardViewModel({
-    state: match.value?.state ?? null,
-    visibleState: visibleState.value,
-    activeAnimation: activePresentation.value,
-    viewerSeatId: humanSeatId.value,
-    settings: {
-      memoryAidEnabled: memoryAidState.value.enabled,
-    },
-  }),
-)
-const seatRunTrackerRows = computed(() => {
-  const recoveryBySeatId = new Map(
-    seatRecoveryIndicators.value.map((entry) => [entry.seatId, entry]),
-  )
-  return biddingBoard.value.secondary.seats.map((row) => {
-    const scoreboard = match.value?.state?.scoreboard ?? {}
-    const score = scoreboard[row.seatId] ?? {}
-    const successes = Math.max(0, Number(score.successes ?? 0))
-    const failures = Math.max(0, 2 - Number(score.lives ?? 2))
-    const recovery = recoveryBySeatId.get(row.seatId)
-    return {
-      seatId: row.seatId,
-      label: row.label,
-      passed: row.passed,
-      isActive: row.isActive,
-      successes,
-      failures,
-      recovering: recovery?.recovering ?? false,
-      recoveryTestId: recovery?.testId ?? null,
-      ariaLabel: `${row.label}: ${successes} successful run${successes === 1 ? '' : 's'}, ${failures} failed run${failures === 1 ? '' : 's'}`,
-    }
-  })
-})
-const biddingCardEmpty = computed(
-  () =>
-    match.value?.state?.phase === 'bidding' &&
-    !showDungeonStage.value &&
-    biddingBoard.value.primaryCard.variant === 'empty',
-)
-const monsterCardSlotEmpty = computed(() => {
-  if (showDungeonStage.value) return dungeonStageView.value.monster.visibility === 'empty'
-  return biddingCardEmpty.value
-})
-const biddingStageSpecies = computed(() => {
-  if (showDungeonStage.value) return null
-  if (match.value?.state?.phase !== 'bidding') return null
-  if (activePresentation.value?.kind === 'BIDDING_DRAW') return null
-  return biddingBoard.value.primaryCard.variant === 'revealed' ? biddingBoard.value.primaryCard.monsterCard : null
-})
-const biddingStageFaceDown = computed(() => {
-  if (showDungeonStage.value) return true
-  if (match.value?.state?.phase !== 'bidding') return true
-  if (activePresentation.value?.kind === 'BIDDING_DRAW') return true
-  return biddingBoard.value.primaryCard.variant !== 'revealed'
-})
-const heroChangeInterstitialView = computed(() => {
-  if (activePresentation.value?.kind !== 'HERO_CHANGE_INTERSTITIAL') return null
-  const payload = activePresentation.value?.payload
-  if (!payload?.heroAfter) return null
-  const seats = match.value?.state?.seats ?? []
-  const actorSeatId = payload.actorSeatId ?? null
-  const actorLabel =
-    seats.find((seat) => seat.id === actorSeatId)?.label ?? actorSeatId ?? 'Unknown'
-  const chosen = getHeroIdentity(payload.heroAfter)
-  return {
-    headline: adventurerChoiceHeadline(actorLabel, payload.heroAfter),
-    chosen,
-  }
-})
-const heroChangeInterstitialAriaLabel = computed(() => heroChangeInterstitialView.value?.headline ?? '')
-const deckSplayOpen = computed({
-  get() {
-    return memoryAidState.value.deckSplayOpen
-  },
-  set(open) {
-    memoryAidState.value = open ? tapDeck(memoryAidState.value) : closeDeckSplay(memoryAidState.value)
-  },
-})
-const dungeonOutcomeSummary = computed(() =>
-  buildDungeonOutcomeSummary({
-    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-    seats: match.value?.state?.seats ?? [],
-    equipmentRemainingAtResolution: equipmentRemainingAtResolution.value,
-  }),
-)
-const dungeonOutcomeToneClass = computed(() =>
-  dungeonOutcomeSummary.value?.resultLabel === 'Success' ? 'dr-outcome--success' : 'dr-outcome--failure',
-)
-const dungeonOutcomeMessage = computed(() =>
-  dungeonOutcomeSummary.value?.resultLabel === 'Success'
-    ? 'Clean run. The dungeon is cleared.'
-    : 'The run failed.',
-)
-const dungeonOutcomeDialogOpen = computed({
-  get() {
-    return shouldShowDungeonOutcomeDialog({
-      headlessCompletionInFlight: headlessCompletionInFlight.value,
-      gameplayInputLocked: gameplayInputLocked.value,
-      lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-      dismissedDungeonRun: dismissedDungeonRun.value,
-    })
-  },
-  set(open) {
-    if (open) return
-    continueFromDungeonOutcome()
-  },
-})
-const humanGameplayBlocked = computed(() =>
-  isHumanGameplayBlocked({
-    gameplayInputLocked: gameplayInputLocked.value,
-    dungeonOutcomeDialogOpen: dungeonOutcomeDialogOpen.value,
-    headlessCompletionInFlight: headlessCompletionInFlight.value,
-    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
-  }),
-)
-const equipmentModalActionsDisabled = computed(() =>
-  isEquipmentModalActionsDisabled({
-    humanGameplayBlocked: humanGameplayBlocked.value,
-    isHumanTurn: isHumanTurn.value,
-  }),
-)
-function applyBootstrappedMatchSession(matchEnvelope, pace) {
-  dungeonRunnerSettingsStore.setAnimationPace(pace)
-  match.value = matchEnvelope
-  syncSeatRecoveryIndicators()
-  activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
-  deferredPostDungeonState.value = null
-  presentationOrchestrator.clear()
-  presentationSpeedProfile.value = pace
-  presentationOrchestrator.setSpeedProfile(pace)
-  nnModelsWarmPromise = Promise.resolve()
-  syncPresentationLabel()
-}
-
-/**
- * @param {Awaited<ReturnType<typeof import('../../matchPageOrchestration.js').bootstrapCurrentMatchFromStorage>>} result
- */
-function processBootstrappedSession(result) {
-  if (result.kind === 'no-saved-match') return
-  if (result.kind === 'setup-terminal') {
-    resetForSetupTerminal()
-    return
-  }
-  applyBootstrappedMatchSession(result.match, result.presentationSpeedProfile)
-  if (result.kind === 'refresh-terminal') {
-    neuralRefreshTerminalOpen.value = true
-    return
-  }
-  void maybeRunHeadlessMatchCompletion()
-}
-
-function kickMatchAutomation() {
-  if (!liveMatchShellLifecycleActive) return
-  scheduleAiTurnIfReady()
-  scheduleHumanAutoResolveIfReady()
-}
-
-watch(
-  () => match.value?.state,
-  (state) => {
-    if (!match.value || !state) return
+  function onNnRecoveryChanged() {
     syncSeatRecoveryIndicators()
     applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
-    persistCurrentMatch(window.localStorage, match.value)
+    if (!liveMatchShellLifecycleActive) return
+    scheduleAiTurnIfReady()
+  }
+
+  function logNnRecoveryTrace(modelId, step, detail = {}) {
+    if (!debugMode.value) return
+    aiTurnTrace({ modelId })(`recovery.${step}`, {
+      loadAttempts: nnRecovery.getLoadAttempts(modelId),
+      inferAttempts: nnRecovery.getInferAttempts(modelId),
+      loadBackend: nnRecovery.getBackendPreference(modelId, 'load'),
+      inferBackend: nnRecovery.getBackendPreference(modelId, 'infer'),
+      ...detail,
+    })
+  }
+
+  const chooseNnActionWithRecovery = createChooseNnActionWithRecovery({
+    recovery: nnRecovery,
+    onRecoveryBegin: (modelId) => logNnRecoveryTrace(modelId, 'begin'),
+    onRecoveryAttempt: (detail) => logNnRecoveryTrace(detail.modelId, 'attempt', detail),
+    onRecoverySettled: (modelId) => logNnRecoveryTrace(modelId, 'settled'),
+  })
+
+  function buildLivePlayChooserDeps(extra = {}) {
+    return {
+      nnRecovery,
+      ensureNnModelsReady,
+      nnRuntimeOptions,
+      chooseNnActionWithRecovery,
+      ...extra,
+    }
+  }
+
+  function evaluatePageAiTurnPipelineGate({ runToken = '', timerPending = false } = {}) {
+    return evaluateLiveAiTurnPipelineGateForContext({
+      matchState: match.value?.state ?? null,
+      humanSeatId: humanSeatId.value,
+      isHumanTurn: isHumanTurn.value,
+      hasMatch: !!match.value,
+      neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
+      matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
+      aiTurnInFlight,
+      headlessCompletionInFlight: headlessCompletionInFlight.value,
+      deferredPostDungeonState: deferredPostDungeonState.value,
+      gameplayInputLocked: gameplayInputLocked.value,
+      recovery: nnRecovery,
+      runToken,
+      lastAppliedAiTurnToken,
+      timerPending,
+      pickAdventurerNnEnabled: isNnAdventurerPickEnabled(),
+    })
+  }
+  const replayImportText = deps.replayImportText
+  const replayExportText = deps.replayExportText
+  const nnDebugTraceText = deps.nnDebugTraceText
+  const nnDebugTraceHistory = deps.nnDebugTraceHistory
+  const presentationOrchestrator = createPresentationOrchestrator()
+  const dungeonRunnerSettingsStore = deps.dungeonRunnerSettingsStore
+
+  const presentationSpeedProfile = deps.presentationSpeedProfile
+  const activePresentation = ref(null)
+  const boardShellRef = ref(null)
+  const heroCardSlotRef = ref(null)
+  const dungeonCardMotionWrap = ref(null)
+  const dungeonCardFaceRef = ref(null)
+  const deckBadgeRef = ref(null)
+  const dungeonPileMotionAnchorRef = ref(null)
+  const heroChangeInterstitialOverlayRef = ref(null)
+  const presentationFlightLayerRef = ref(null)
+  const biddingEquipmentBadgeRefs = reactive({})
+
+  function domEl(componentOrEl) {
+    if (!componentOrEl) return null
+    if (componentOrEl.nodeType === 1) return componentOrEl
+    const inner = componentOrEl.$el
+    return inner?.nodeType === 1 ? inner : null
+  }
+
+  /** `defineExpose`d Refs from child components; QBadge roots via {@link domEl}. */
+  function unwrapMotionDom(exposedMaybeRef) {
+    if (exposedMaybeRef == null) return null
+    const el = unref(exposedMaybeRef)
+    return el?.nodeType === 1 ? el : null
+  }
+
+  function bindBiddingEquipmentBadgeRef(equipmentId, componentOrEl) {
+    const node = domEl(componentOrEl)
+    if (node) biddingEquipmentBadgeRefs[equipmentId] = node
+    else delete biddingEquipmentBadgeRefs[equipmentId]
+  }
+
+  // GSAP: most beats tween `boardShell` (shared placeholder) plus kind-specific refs — `DUNGEON_REVEAL` tweens `dungeonCardWrap` (opacity / y / scale) and `dungeonCardFlipAxis` (`rotationY` flip); damage / neutralize / continue use `dungeonCardWrap` + shell; `DUNGEON_OUTCOME` tweens the wrap only (no shell tween); teardown clears wrap + shell after that beat for neutral baseline (#66).
+  // `HERO_CHANGE_INTERSTITIAL` → overlay only; bot bidding → `dungeonCardWrap` / `deckBadge` / equipment; neutralize + sacrifice use `presentationFlightLayer` + `equipment_*` (see presentationMotionRegistry.js).
+  // Window resize during fragile motion (ghost flight #68, or dungeon reveal flip) swaps to shell+card-only tweens for the rest of that beat (#71); orchestrator `remainingMs` is not recomputed on resize (#68).
+  usePresentationMotion({
+    activePresentation,
+    getMotionRefs: (head) => {
+      if (head?.kind === 'HERO_CHANGE_INTERSTITIAL') {
+        return {
+          heroChangeInterstitialOverlay: heroChangeInterstitialOverlayRef.value,
+          boardShell: boardShellRef.value,
+        }
+      }
+      const base = {
+        boardShell: boardShellRef.value,
+        dungeonCardWrap: dungeonCardMotionWrap.value,
+        dungeonCardFlipAxis: unwrapMotionDom(dungeonCardFaceRef.value?.dungeonCardFlipAxis),
+        deckBadge: domEl(deckBadgeRef.value),
+        dungeonPileBadge: dungeonPileMotionAnchorRef.value,
+        presentationFlightLayer: presentationFlightLayerRef.value,
+        presentationGhostTarget: heroCardSlotRef.value,
+      }
+      if (
+        presentationTraceEnabled() &&
+        (head?.kind === 'DUNGEON_REVEAL' || head?.kind === 'BIDDING_DRAW')
+      ) {
+        const snapEl = (el) => {
+          if (!el || typeof el.getBoundingClientRect !== 'function') return { present: false }
+          const r = el.getBoundingClientRect()
+          return {
+            present: true,
+            tag: el.tagName,
+            w: Math.round(r.width * 100) / 100,
+            h: Math.round(r.height * 100) / 100,
+            cx: Math.round((r.left + r.width / 2) * 100) / 100,
+            cy: Math.round((r.top + r.height / 2) * 100) / 100,
+          }
+        }
+        const deckNode = domEl(deckBadgeRef.value)
+        console.log('[DungeonRunner][card-flight][refs]', {
+          kind: head.kind,
+          id: head.id,
+          durationMs: head.durationMs,
+          dungeonCardWrap: snapEl(base.dungeonCardWrap),
+          dungeonPileAnchor: snapEl(base.dungeonPileBadge),
+          deckBadgeResolved: snapEl(base.deckBadge),
+          dungeonCardFlipAxis: snapEl(base.dungeonCardFlipAxis),
+          deckBadgeRawDomEl: snapEl(deckNode),
+          refsBound: {
+            dungeonPileMotionAnchorRef: !!dungeonPileMotionAnchorRef.value,
+            deckBadgeRef: !!deckBadgeRef.value,
+            dungeonCardMotionWrap: !!dungeonCardMotionWrap.value,
+            dungeonCardFaceRef: !!dungeonCardFaceRef.value,
+          },
+        })
+      }
+      if (head?.kind !== 'BIDDING_SACRIFICE' && head?.kind !== 'DUNGEON_NEUTRALIZE') return base
+      const ids =
+        head?.payload?.responsibleEquipmentIds ?? head?.payload?.consumedEquipmentIds ?? []
+      const extra = {}
+      for (const id of ids) {
+        const node = biddingEquipmentBadgeRefs[id]
+        if (node?.nodeType === 1) extra[`equipment_${id}`] = node
+      }
+      return { ...base, ...extra }
+    },
+  })
+  const activePresentationLabel = ref('')
+  const equipmentModalOpen = ref(false)
+  const selectedEquipmentTokenId = ref(null)
+  const neuralLoadGateTerminalOpen = deps.neuralLoadGateTerminalOpen
+  const neuralRefreshTerminalOpen = ref(false)
+  const matchNeuralLoadGateInFlight = deps.matchNeuralLoadGateInFlight
+  const confirmationDialogOpen = ref(false)
+  const confirmationDialogTitle = ref('Confirm')
+  const confirmationDialogMessage = ref('')
+  const confirmationDialogOkLabel = ref('OK')
+  const confirmationDialogCancelLabel = ref('Cancel')
+  let confirmationDialogResolve = null
+  const vorpalDialogOpen = ref(false)
+  const selectedVorpalSpecies = ref(null)
+  const memoryAidState = ref(
+    createMemoryAidState({ enabled: dungeonRunnerSettingsStore.memoryAidEnabled }),
+  )
+  const previousVisibleState = ref(null)
+  const dismissedDungeonRun = ref(null)
+  const equipmentRemainingAtResolution = ref(null)
+  const deferredPostDungeonState = ref(null)
+  let presentationTimerId = null
+  let aiTurnTimerId = null
+  let liveMatchShellLifecycleActive = false
+  let autoResolveTimerId = null
+  let aiTurnInFlight = false
+  let lastAppliedAiTurnToken = null
+  let presentationInputWasLocked = false
+  let lastPresentationTraceKey = null
+  let lastScheduleSkipKey = ''
+  let lastPrimeSkipTraceKey = ''
+  /** @type {Promise<void> | null} */
+  let nnModelsWarmPromise = null
+
+  const liveMatchPageSessionSink = createLiveMatchPageSessionSink({
+    match,
+    setNnModelsWarmPromise: (promise) => {
+      nnModelsWarmPromise = promise
+    },
+    resetAiTurnPrefetch,
+    setLastAppliedAiTurnTokenNull: () => {
+      lastAppliedAiTurnToken = null
+    },
+    setPresentationInputWasLockedFalse: () => {
+      presentationInputWasLocked = false
+    },
+    deferredPostDungeonState,
+    nnDebugTraceText,
+    nnDebugTraceHistory,
+    presentationOrchestrator,
+    syncPresentationLabel,
+    neuralLoadGateTerminalOpen,
+    clearCurrentMatch,
+    storage: window.localStorage,
+  })
+
+  const AI_TURN_SCHEDULE_DELAY_MS = 300
+
+  function aiTurnTrace(baseContext = {}) {
+    return createPipelineStepLogger('AITurn', debugMode.value, {
+      matchId: match.value?.id ?? null,
+      ...baseContext,
+    })
+  }
+
+  const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
+    'gameplay-locked',
+    'timer-pending',
+    'in-flight',
+    'already-applied-token',
+    'deferred-post-dungeon',
+    'headless-completion',
+  ])
+
+  function logAiTurnScheduleSkip(reason, detail = {}) {
+    if (!debugMode.value) return
+    const key = `${reason}:${detail.runToken ?? detail.activeKind ?? ''}`
+    if (SCHEDULE_SKIP_THROTTLE_REASONS.has(reason) && key === lastScheduleSkipKey) return
+    lastScheduleSkipKey = key
+    console.warn('[DungeonRunner][AITurn][Schedule] skip', reason, detail)
+  }
+
+  function logAiTurnPrimeSkip(reason, detail = {}) {
+    if (!debugMode.value) return
+    const key = `${reason}:${detail.runToken ?? detail.phase ?? detail.seatId ?? detail.roleType ?? ''}`
+    if (key === lastPrimeSkipTraceKey) return
+    lastPrimeSkipTraceKey = key
+    aiTurnTrace()('prefetch.prime.skip', { reason, ...detail })
+  }
+
+  function scheduleAiTurnOnPresentationTick() {
+    if (!liveMatchShellLifecycleActive) return
+    if (
+      !match.value ||
+      isHumanTurn.value ||
+      deferredPostDungeonState.value ||
+      headlessCompletionInFlight.value
+    ) {
+      return
+    }
+    scheduleAiTurnIfReady()
+  }
+  const uiAssets = dungeonRunnerAssetPack
+
+  watch(presentationSpeedProfile, (next) => {
+    presentationOrchestrator.setSpeedProfile(next)
+    syncPresentationLabel()
+    triggerRef(activePresentation)
+    if (match.value) {
+      match.value = { ...match.value, presentationSpeedProfile: next }
+      persistCurrentMatch(window.localStorage, match.value)
+    }
+  })
+
+  watch(
+    () => dungeonRunnerSettingsStore.memoryAidEnabled,
+    (enabled) => {
+      memoryAidState.value = setMemoryAidEnabled(memoryAidState.value, enabled)
+    },
+    { immediate: true },
+  )
+
+  const humanSeatId = computed(
+    () => match.value?.state.seats.find((seat) => seat.role.type === 'human')?.id ?? null,
+  )
+  const isHumanTurn = computed(
+    () =>
+      !!match.value &&
+      humanSeatId.value != null &&
+      match.value.state.turn.activeSeatId === humanSeatId.value,
+  )
+  const legalActions = computed(() => {
+    if (!match.value || !isHumanTurn.value) return []
+    return getLegalActions(match.value.state, { seatId: humanSeatId.value })
+  })
+  const visibleLegalActions = computed(() =>
+    filterVisibleLegalActions({
+      phase: match.value?.state?.phase ?? null,
+      legalActions: legalActions.value,
+    }),
+  )
+  const visiblePrimaryActions = computed(() =>
+    visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE'),
+  )
+  /** Matches engine pick-adventurer legal action order. */
+  const HERO_CHOICE_ACTION_ORDER = ['WARRIOR', 'BARBARIAN', 'MAGE', 'ROGUE']
+  const showHeroPickActionGrid = computed(() => {
+    const actions = visiblePrimaryActions.value
+    if (actions.length !== HERO_CHOICE_ACTION_ORDER.length) return false
+    return actions.every((a) => a.type === 'CHOOSE_NEXT_ADVENTURER')
+  })
+  const heroPickActionsOrdered = computed(() => {
+    if (!showHeroPickActionGrid.value) return []
+    const byHero = new Map(visiblePrimaryActions.value.map((a) => [a.hero, a]))
+    return HERO_CHOICE_ACTION_ORDER.map((hero) => byHero.get(hero)).filter(Boolean)
+  })
+  const showActionPane = computed(
+    () =>
+      !!activePresentationLabel.value ||
+      (isHumanTurn.value &&
+        (visiblePrimaryActions.value.length > 0 ||
+          dungeonOutcomeTransitionControls.value.length > 0)),
+  )
+  const biddingSacrificeActions = computed(() =>
+    visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'),
+  )
+  const biddingNonSacrificeActions = computed(() =>
+    visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'),
+  )
+  const gameplayInputLocked = ref(false)
+  const headlessCompletionInFlight = ref(false)
+  const visibleState = computed(() => {
+    if (!match.value || !humanSeatId.value) return null
+    return getPlayerView(match.value.state, { seatId: humanSeatId.value })
+  })
+  const dungeonOutcomeAckPending = computed(() =>
+    isDungeonOutcomeDialogOpen({
+      lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+      dismissedDungeonRun: dismissedDungeonRun.value,
+    }),
+  )
+  const dungeonEquipmentTokens = computed(() =>
+    buildDungeonEquipmentTokenView({
+      inPlayEquipmentIds: visibleState.value?.dungeon?.inPlayEquipmentIds ?? [],
+      legalActions: legalActions.value,
+    }),
+  )
+  const dungeonResolutionView = computed(() =>
+    createDungeonResolutionViewModel({
+      visibleState: visibleState.value ?? {},
+      previousVisibleState: previousVisibleState.value ?? {},
+      legalActions: legalActions.value,
+      activeAnimation: activePresentation.value,
+    }),
+  )
+  const showDungeonStage = computed(() => {
+    if (match.value?.state?.phase === 'dungeon') return true
+    if (isDungeonOrchestratorPresentationKind(activePresentation.value?.kind ?? null)) return true
+    return dungeonOutcomeAckPending.value
+  })
+  const dungeonStageView = computed(() =>
+    createDungeonResolutionViewModel({
+      visibleState: visibleState.value ?? {},
+      previousVisibleState: previousVisibleState.value ?? {},
+      legalActions: legalActions.value,
+      activeAnimation: activePresentation.value,
+      preserveMonsterCardUntilRunAck: dungeonOutcomeAckPending.value,
+    }),
+  )
+  const dungeonStageAnimationClass = computed(() =>
+    dungeonStageClassForKind(activePresentation.value?.kind ?? null),
+  )
+  const dungeonOutcomeTransitionControls = computed(() =>
+    buildDungeonOutcomeTransitionControls({
+      phase: match.value?.state?.phase ?? null,
+      gameplayInputLocked: gameplayInputLocked.value,
+      resolutionStatus: dungeonResolutionView.value.resolutionStatus,
+      autoAdvanceAction: dungeonResolutionView.value.autoAdvanceAction,
+    }),
+  )
+  const actionableEquipmentIds = computed(
+    () => new Set(dungeonResolutionView.value.highlightedEquipmentIds),
+  )
+  const boardEquipmentTokens = computed(() => {
+    const dungeonTokenById = new Map(
+      dungeonEquipmentTokens.value.map((token) => [token.equipmentId, token]),
+    )
+    const isDungeonPhase = match.value?.state?.phase === 'dungeon'
+    const hasActionable = actionableEquipmentIds.value.size > 0
+    return biddingBoard.value.secondary.equipment.map((equipment) => {
+      const dungeonToken = dungeonTokenById.get(equipment.equipmentId)
+      const removed =
+        equipment.removed ||
+        equipment.consumed ||
+        (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
+      const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
+      const appearance = equipmentTokenAppearance(equipment.equipmentId)
+      return {
+        equipmentId: equipment.equipmentId,
+        ariaLabel: equipmentShortName(equipment.equipmentId),
+        symbolRuntimePath: dungeonRunnerEquipmentSymbolRuntimePath(appearance.symbolKey),
+        equipmentOverlay: appearance.overlay,
+        removed,
+        glow: isDungeonPhase ? (dungeonToken?.glow ?? false) : false,
+        pulse: actionable,
+        deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
+        canUseNow: dungeonToken?.canUseNow ?? false,
+        hasModal: true,
+      }
+    })
+  })
+  const selectedEquipmentModalView = computed(() => {
+    if (!selectedEquipmentTokenId.value) return null
+    return createDungeonEquipmentModalView({
+      equipmentId: selectedEquipmentTokenId.value,
+      legalActions: legalActions.value,
+    })
+  })
+  const vorpalPromptView = computed(() =>
+    createVorpalDeclarationPromptView({
+      isHumanTurn: isHumanTurn.value,
+      gameplayInputLocked: gameplayInputLocked.value,
+      phase: match.value?.state?.phase ?? null,
+      subphase: match.value?.state?.dungeon?.subphase ?? null,
+      legalActions: legalActions.value,
+      memoryAidEnabled: memoryAidState.value.enabled,
+      viewerOwnPileAdds: visibleState.value?.playerOwnPileAdds?.[humanSeatId.value ?? ''] ?? [],
+    }),
+  )
+  const vorpalSelectOptions = computed(() => {
+    const pv = vorpalPromptView.value
+    const counts = pv.vorpalSpeciesOwnPileCounts
+    return pv.speciesOptions.map((species) => {
+      const n = counts?.[species] ?? 0
+      const label = n > 0 ? `${species} (${n})` : species
+      return { label, value: species }
+    })
+  })
+  const biddingBoard = computed(() =>
+    createBiddingBoardViewModel({
+      state: match.value?.state ?? null,
+      visibleState: visibleState.value,
+      activeAnimation: activePresentation.value,
+      viewerSeatId: humanSeatId.value,
+      settings: {
+        memoryAidEnabled: memoryAidState.value.enabled,
+      },
+    }),
+  )
+  const seatRunTrackerRows = computed(() => {
+    const recoveryBySeatId = new Map(
+      seatRecoveryIndicators.value.map((entry) => [entry.seatId, entry]),
+    )
+    return biddingBoard.value.secondary.seats.map((row) => {
+      const scoreboard = match.value?.state?.scoreboard ?? {}
+      const score = scoreboard[row.seatId] ?? {}
+      const successes = Math.max(0, Number(score.successes ?? 0))
+      const failures = Math.max(0, 2 - Number(score.lives ?? 2))
+      const recovery = recoveryBySeatId.get(row.seatId)
+      return {
+        seatId: row.seatId,
+        label: row.label,
+        passed: row.passed,
+        isActive: row.isActive,
+        successes,
+        failures,
+        recovering: recovery?.recovering ?? false,
+        recoveryTestId: recovery?.testId ?? null,
+        ariaLabel: `${row.label}: ${successes} successful run${successes === 1 ? '' : 's'}, ${failures} failed run${failures === 1 ? '' : 's'}`,
+      }
+    })
+  })
+  const biddingCardEmpty = computed(
+    () =>
+      match.value?.state?.phase === 'bidding' &&
+      !showDungeonStage.value &&
+      biddingBoard.value.primaryCard.variant === 'empty',
+  )
+  const monsterCardSlotEmpty = computed(() => {
+    if (showDungeonStage.value) return dungeonStageView.value.monster.visibility === 'empty'
+    return biddingCardEmpty.value
+  })
+  const biddingStageSpecies = computed(() => {
+    if (showDungeonStage.value) return null
+    if (match.value?.state?.phase !== 'bidding') return null
+    if (activePresentation.value?.kind === 'BIDDING_DRAW') return null
+    return biddingBoard.value.primaryCard.variant === 'revealed'
+      ? biddingBoard.value.primaryCard.monsterCard
+      : null
+  })
+  const biddingStageFaceDown = computed(() => {
+    if (showDungeonStage.value) return true
+    if (match.value?.state?.phase !== 'bidding') return true
+    if (activePresentation.value?.kind === 'BIDDING_DRAW') return true
+    return biddingBoard.value.primaryCard.variant !== 'revealed'
+  })
+  const heroChangeInterstitialView = computed(() => {
+    if (activePresentation.value?.kind !== 'HERO_CHANGE_INTERSTITIAL') return null
+    const payload = activePresentation.value?.payload
+    if (!payload?.heroAfter) return null
+    const seats = match.value?.state?.seats ?? []
+    const actorSeatId = payload.actorSeatId ?? null
+    const actorLabel =
+      seats.find((seat) => seat.id === actorSeatId)?.label ?? actorSeatId ?? 'Unknown'
+    const chosen = getHeroIdentity(payload.heroAfter)
+    return {
+      headline: adventurerChoiceHeadline(actorLabel, payload.heroAfter),
+      chosen,
+    }
+  })
+  const heroChangeInterstitialAriaLabel = computed(
+    () => heroChangeInterstitialView.value?.headline ?? '',
+  )
+  const deckSplayOpen = computed({
+    get() {
+      return memoryAidState.value.deckSplayOpen
+    },
+    set(open) {
+      memoryAidState.value = open
+        ? tapDeck(memoryAidState.value)
+        : closeDeckSplay(memoryAidState.value)
+    },
+  })
+  const dungeonOutcomeSummary = computed(() =>
+    buildDungeonOutcomeSummary({
+      lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+      seats: match.value?.state?.seats ?? [],
+      equipmentRemainingAtResolution: equipmentRemainingAtResolution.value,
+    }),
+  )
+  const dungeonOutcomeToneClass = computed(() =>
+    dungeonOutcomeSummary.value?.resultLabel === 'Success'
+      ? 'dr-outcome--success'
+      : 'dr-outcome--failure',
+  )
+  const dungeonOutcomeMessage = computed(() =>
+    dungeonOutcomeSummary.value?.resultLabel === 'Success'
+      ? 'Clean run. The dungeon is cleared.'
+      : 'The run failed.',
+  )
+  const dungeonOutcomeDialogOpen = computed({
+    get() {
+      return shouldShowDungeonOutcomeDialog({
+        headlessCompletionInFlight: headlessCompletionInFlight.value,
+        gameplayInputLocked: gameplayInputLocked.value,
+        lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+        dismissedDungeonRun: dismissedDungeonRun.value,
+      })
+    },
+    set(open) {
+      if (open) return
+      continueFromDungeonOutcome()
+    },
+  })
+  const humanGameplayBlocked = computed(() =>
+    isHumanGameplayBlocked({
+      gameplayInputLocked: gameplayInputLocked.value,
+      dungeonOutcomeDialogOpen: dungeonOutcomeDialogOpen.value,
+      headlessCompletionInFlight: headlessCompletionInFlight.value,
+      neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
+    }),
+  )
+  const equipmentModalActionsDisabled = computed(() =>
+    isEquipmentModalActionsDisabled({
+      humanGameplayBlocked: humanGameplayBlocked.value,
+      isHumanTurn: isHumanTurn.value,
+    }),
+  )
+  function applyBootstrappedMatchSession(matchEnvelope, pace) {
+    dungeonRunnerSettingsStore.setAnimationPace(pace)
+    match.value = matchEnvelope
+    syncSeatRecoveryIndicators()
+    activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
+    deferredPostDungeonState.value = null
+    presentationOrchestrator.clear()
+    presentationSpeedProfile.value = pace
+    presentationOrchestrator.setSpeedProfile(pace)
+    nnModelsWarmPromise = Promise.resolve()
+    syncPresentationLabel()
+  }
+
+  /**
+   * @param {Awaited<ReturnType<typeof import('../../matchPageOrchestration.js').bootstrapCurrentMatchFromStorage>>} result
+   */
+  function processBootstrappedSession(result) {
+    if (result.kind === 'no-saved-match') return
+    if (result.kind === 'setup-terminal') {
+      resetForSetupTerminal()
+      return
+    }
+    applyBootstrappedMatchSession(result.match, result.presentationSpeedProfile)
+    if (result.kind === 'refresh-terminal') {
+      neuralRefreshTerminalOpen.value = true
+      return
+    }
+    void maybeRunHeadlessMatchCompletion()
+  }
+
+  function kickMatchAutomation() {
     if (!liveMatchShellLifecycleActive) return
     scheduleAiTurnIfReady()
     scheduleHumanAutoResolveIfReady()
-  },
-  { deep: true },
-)
-
-watch(
-  () => match.value?.state?.lastDungeonRun ?? null,
-  (run) => {
-    const update = resolveLastDungeonRunWatcherUpdate(run, match.value?.state?.centerEquipment)
-    if ('dismissedDungeonRun' in update) {
-      dismissedDungeonRun.value = update.dismissedDungeonRun
-      equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
-      return
-    }
-    equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
-  },
-  { immediate: true },
-)
-
-watch(
-  () => vorpalPromptView.value.open,
-  (open) => {
-    if (!open) {
-      vorpalDialogOpen.value = false
-      selectedVorpalSpecies.value = null
-      return
-    }
-    vorpalDialogOpen.value = true
-    const firstSpecies = vorpalPromptView.value.speciesOptions[0] ?? null
-    if (!selectedVorpalSpecies.value || !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)) {
-      selectedVorpalSpecies.value = firstSpecies
-    }
-  },
-)
-
-function resetForSetupTerminal() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    clearMatch: true,
-    openNeuralLoadGateTerminal: true,
-  })
-}
-
-function resetForFreshMatchEntry() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    warmModelsResolved: true,
-  })
-}
-
-function resetForBackToSetup() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    clearMatch: true,
-    clearPersistedMatch: true,
-  })
-}
-
-const matchPageOrchestrationCtx = createMatchPageOrchestrationContext({
-  storage: window.localStorage,
-  recovery: nnRecovery,
-  loadModel: loadNnModel,
-  setMatchNeuralLoadGateInFlight: (inFlight) => {
-    matchNeuralLoadGateInFlight.value = inFlight
-  },
-  clearCurrentMatch,
-  persistCurrentMatch,
-  applySetupSnapshot,
-  setupTarget: deps.setup,
-  cloneSetup: deps.cloneSetup,
-  onSetupTerminal: () => {
-    resetForSetupTerminal()
-  },
-})
-
-async function runLivePageMatchEntryGate(setupSnapshot) {
-  return runMatchEntryNeuralLoadGateForPage(matchPageOrchestrationCtx, {
-    setupSnapshot,
-    releaseInFlightAfterGate: false,
-  })
-}
-
-async function ensureNnModelsReady() {
-  await nnModelsWarmPromise?.catch(() => {})
-}
-
-function reloadPageForNeuralRefreshTerminal() {
-  window.location.reload()
-}
-
-function handleNeuralRecoveryTerminalError(error) {
-  const result = handleLivePlayNeuralRecoveryTerminalError({
-    error,
-    match: match.value,
-    recovery: nnRecovery,
-    storage: window.localStorage,
-    persistCurrentMatch,
-    restoreSetup: (setupSnapshot) => {
-      matchPageOrchestrationCtx.applySetupTerminal(deps.cloneSetup(setupSnapshot))
-    },
-  })
-  if (!result.handled) return false
-  if (result.action === 'refresh-dialog') {
-    match.value = result.match
-    neuralRefreshTerminalOpen.value = true
-    logNnRecoveryTrace(result.trace.modelId, 'terminal', {
-      terminal: result.trace.terminal,
-      failureKind: result.trace.failureKind,
-    })
   }
-  return true
-}
 
-function takeHumanAction(action) {
-  if (!match.value || !humanSeatId.value) {
-    return
-  }
-  resetAiTurnPrefetch()
-  if (humanGameplayBlocked.value) {
-    return
-  }
-  if (autoResolveTimerId) {
-    window.clearTimeout(autoResolveTimerId)
-    autoResolveTimerId = null
-  }
-  if (equipmentModalOpen.value) equipmentModalOpen.value = false
-  const prevState = match.value.state
-  previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
-  const result = applyAction(prevState, action, { seatId: humanSeatId.value })
-  if (!result.ok) {
-    return
-  }
-  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
-  if (deferExit) {
-    deferredPostDungeonState.value = result.state
-    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
-  } else {
-    deferredPostDungeonState.value = null
-    match.value = { ...match.value, state: result.state }
-  }
-  enqueuePresentationTransition(prevState, result.state, action, humanSeatId.value, 'human')
-}
-
-function onDeckTap() {
-  memoryAidState.value = tapDeck(memoryAidState.value)
-}
-
-function onCloseDeckSplay() {
-  memoryAidState.value = closeDeckSplay(memoryAidState.value)
-}
-
-function settleConfirmationDialog(result) {
-  confirmationDialogOpen.value = false
-  const resolve = confirmationDialogResolve
-  confirmationDialogResolve = null
-  if (typeof resolve === 'function') resolve(result)
-}
-
-function requestConfirmation({ title = 'Confirm', message, okLabel = 'OK', cancelLabel = 'Cancel' }) {
-  if (typeof confirmationDialogResolve === 'function') {
-    confirmationDialogResolve(false)
-    confirmationDialogResolve = null
-  }
-  confirmationDialogTitle.value = title
-  confirmationDialogMessage.value = message
-  confirmationDialogOkLabel.value = okLabel
-  confirmationDialogCancelLabel.value = cancelLabel
-  confirmationDialogOpen.value = true
-  return new Promise((resolve) => {
-    confirmationDialogResolve = resolve
-  })
-}
-
-function onConfirmationDialogOk() {
-  settleConfirmationDialog(true)
-}
-
-function onConfirmationDialogCancel() {
-  settleConfirmationDialog(false)
-}
-
-function openEquipmentModal(token) {
-  if (shouldRejectEquipmentTokenTap({ hasModal: token?.hasModal, humanGameplayBlocked: humanGameplayBlocked.value })) return
-  selectedEquipmentTokenId.value = token.equipmentId
-  equipmentModalOpen.value = true
-}
-
-function takeEquipmentUseAction() {
-  if (equipmentModalActionsDisabled.value || !selectedEquipmentModalView.value?.useAction) return
-  takeHumanAction(selectedEquipmentModalView.value.useAction)
-}
-
-function continueFromEquipmentModal() {
-  if (!equipmentModalActionsDisabled.value && selectedEquipmentModalView.value?.continueAction) {
-    takeHumanAction(selectedEquipmentModalView.value.continueAction)
-    return
-  }
-  equipmentModalOpen.value = false
-}
-
-async function continueFromDungeonOutcome() {
-  const run = match.value?.state?.lastDungeonRun
-  if (!run) return
-  dismissedDungeonRun.value = dismissDungeonRunForOutcomeDialog(run)
-  if (deferredPostDungeonState.value) {
-    match.value = { ...match.value, state: deferredPostDungeonState.value }
-    deferredPostDungeonState.value = null
-  }
-  presentationOrchestrator.flushPostDungeonOutcomeAnimations()
-  syncPresentationLabel()
-  await maybeRunHeadlessMatchCompletion()
-}
-
-function teardownForHeadlessMatchCompletion() {
-  if (aiTurnTimerId) {
-    window.clearTimeout(aiTurnTimerId)
-    aiTurnTimerId = null
-  }
-  if (autoResolveTimerId) {
-    window.clearTimeout(autoResolveTimerId)
-    autoResolveTimerId = null
-  }
-  resetAiTurnPrefetch()
-  abandonScheduledInferenceQueue()
-  presentationOrchestrator.clear()
-  deferredPostDungeonState.value = null
-  lastAppliedAiTurnToken = null
-  const run = match.value?.state?.lastDungeonRun
-  if (run) dismissedDungeonRun.value = run
-}
-
-function createPageHeadlessCompletionFlightGate() {
-  return {
-    get inFlight() {
-      return headlessCompletionInFlight.value
-    },
-    tryStart() {
-      if (headlessCompletionInFlight.value) return false
-      headlessCompletionInFlight.value = true
-      return true
-    },
-    finish() {
-      headlessCompletionInFlight.value = false
-    },
-  }
-}
-
-async function maybeRunHeadlessMatchCompletion() {
-  try {
-    const result = await runHeadlessMatchCompletionForPage(matchPageOrchestrationCtx, {
-      match: match.value,
-      humanPlayerSeatId: humanSeatId.value,
-      chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
-      gate: createPageHeadlessCompletionFlightGate(),
-      teardown: teardownForHeadlessMatchCompletion,
-    })
-
-    if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
-      match.value = result.match
-    }
-    if (result.kind === 'refresh-terminal') {
-      neuralRefreshTerminalOpen.value = true
-      logNnRecoveryTrace(result.modelId, 'terminal', {
-        terminal: result.terminal,
-        failureKind: result.failureKind ?? null,
-      })
-    } else if (result.kind === 'setup-terminal') {
-      // applySetupTerminal already ran inside runHeadlessMatchCompletionForPage
-    } else if (result.kind === 'failed' && debugMode.value) {
-      console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
-    }
-  } finally {
-    syncPresentationLabel()
-  }
-}
-
-function confirmVorpalDeclaration() {
-  if (!selectedVorpalSpecies.value) return
-  takeHumanAction({
-    type: 'DECLARE_VORPAL',
-    species: selectedVorpalSpecies.value,
-  })
-}
-
-async function runAiTurn() {
-  const trace = aiTurnTrace()
-  const seatId = match.value?.state?.turn?.activeSeatId ?? null
-  const runToken = match.value
-    ? buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-    : ''
-  const gate = evaluatePageAiTurnPipelineGate({ runToken })
-  if (!gate.mayRunTurn) {
-    const presentationQueueSnapshot = presentationOrchestrator.getQueueSnapshot()
-    const skipTrace = buildAiTurnRunSkipTrace(gate, {
-      runToken,
-      seatId,
-      humanSeatId: humanSeatId.value,
-      phase: match.value?.state?.phase ?? null,
-      activePresentationKind: activePresentation.value?.kind ?? null,
-      queueMs: presentationQueueSnapshot.reduce((sum, item) => sum + item.remainingMs, 0),
-      lastAppliedAiTurnToken,
-    })
-    if (skipTrace) {
-      trace(skipTrace.step, skipTrace.detail)
-    }
-    return
-  }
-  aiTurnInFlight = true
-  try {
-  trace('run.begin', {
-    runToken,
-    phase: match.value.state.phase,
-    seatId,
-    turnNumber: match.value.state.turn.turnNumber,
-    biddingSubphase: match.value.state.bidding?.subphase ?? null,
-    revealedMonsterCard: match.value.state.bidding?.revealedMonsterCard ?? null,
-    dungeonSubphase: match.value.state.dungeon?.subphase ?? null,
-  })
-  const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
-  const roleType = seat?.role?.type
-  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps({
-    tryConsumePrefetch: async ({ runToken: consumeRunToken }) => {
-      const prefetchGate = evaluatePageAiTurnPipelineGate({ runToken: consumeRunToken ?? runToken })
-      return consumeAiTurnPrefetch({
-        runToken: consumeRunToken ?? runToken,
-        mayPrefetch: prefetchGate.mayPrefetch,
-        prefetchSkipReason: prefetchGate.prefetchSkipReason,
-        trace: (step, detail) => trace(step, detail),
-      })
-    },
-  }))
-  let action
-  try {
-    action = await chooseAction({ state: match.value.state, seatId, runToken })
-  } catch (error) {
-    if (handleNeuralRecoveryTerminalError(error)) {
-      trace('run.abort', {
-        reason: 'nn-recovery-terminal',
-        terminal: error.terminal,
-        modelId: error.modelId,
-      })
-      return
-    }
-    throw error
-  }
-  if (!action) {
-    trace('run.abort', { reason: 'no-action' })
-    return
-  }
-  if (!match.value) {
-    trace('run.abort', { reason: 'match-cleared' })
-    return
-  }
-  const currentToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-  if (runToken !== currentToken) {
-    trace('run.abort', { reason: 'stale-token', runToken, currentToken })
-    return
-  }
-  const prevState = match.value.state
-  if (humanSeatId.value) {
-    previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
-  }
-  const result = applyAction(prevState, action, { seatId })
-  if (!result.ok) {
-    trace('run.abort', { reason: 'apply-failed', actionType: action.type })
-    return
-  }
-  lastAppliedAiTurnToken = runToken
-  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
-  if (deferExit) {
-    deferredPostDungeonState.value = result.state
-    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
-  } else {
-    deferredPostDungeonState.value = null
-    match.value = { ...match.value, state: result.state }
-  }
-  trace('run.applied', {
-    actionType: action.type,
-    nextRunToken: buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state }),
-    phaseAfter: match.value.state.phase,
-    turnAfterSeatId: match.value.state.turn.activeSeatId,
-    deferExit,
-  })
-  enqueuePresentationTransition(prevState, result.state, action, seatId, roleType ?? 'randombot')
-  if (debugMode.value) {
-    const snap = presentationOrchestrator.getQueueSnapshot()
-    trace('presentation.enqueued', {
-      queue: snap.map((item) => item.kind),
-      queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
-    })
-  }
-  primeAiTurnPrefetch()
-  } finally {
-    aiTurnInFlight = false
-    trace('run.finally', { inFlight: false })
-  }
-}
-
-function primeAiTurnPrefetch(precomputedGate = null) {
-  const trace = aiTurnTrace()
-  const state = match.value?.state
-  const seatId = state?.turn?.activeSeatId ?? null
-  const seat = state?.seats?.find((candidate) => candidate.id === seatId)
-  const runToken = match.value ? buildAiTurnRunToken({ matchId: match.value.id, state }) : ''
-  const modelId = seat?.role?.type === 'nn' ? seat.role.modelId ?? 'latest' : null
-  const gate = precomputedGate ?? evaluatePageAiTurnPipelineGate({ runToken })
-  if (!gate.mayPrefetch) {
-    const skipTrace = buildAiTurnPrefetchSkipTrace(gate, {
-      seatId,
-      phase: state?.phase ?? null,
-      runToken,
-      modelId,
-      roleType: seat?.role?.type ?? null,
-    })
-    if (skipTrace) {
-      logAiTurnPrimeSkip(skipTrace.reason, skipTrace.detail)
-    }
-    return
-  }
-  lastPrimeSkipTraceKey = ''
-  startAiTurnPrefetch({
-    runToken,
-    mayPrefetch: true,
-    prefetchSkipReason: null,
-    trace: (step, detail) => trace(step, detail),
-    compute: async () => {
-      await ensureNnModelsReady()
-      return chooseNnActionWithRecovery(state, { seatId }, nnRuntimeOptions(modelId))
-    },
-  })
-}
-
-function enqueuePresentationTransition(prevState, nextState, action, actorSeatId, actorRoleType) {
-  const deferPostDungeonOutcomeAck = shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState)
-  presentationOrchestrator.enqueueEngineTransition(
-    {
-      phaseBefore: prevState.phase,
-      phaseAfter: nextState.phase,
-      turnBeforeSeatId: prevState.turn.activeSeatId,
-      turnAfterSeatId: nextState.turn.activeSeatId,
-      dungeonRunResult:
-        prevState.lastDungeonRun?.result === nextState.lastDungeonRun?.result ? null : nextState.lastDungeonRun?.result ?? null,
-      action,
-      actorSeatId,
-      actorRoleType,
-      centerEquipmentBefore: prevState.centerEquipment ?? [],
-      centerEquipmentAfter: nextState.centerEquipment ?? [],
-      heroBefore: prevState.hero,
-      heroAfter: nextState.hero,
-      dungeonBefore: summarizeDungeonForPresentation(prevState.dungeon),
-      dungeonAfter: summarizeDungeonForPresentation(nextState.dungeon),
-      biddingBefore:
-        prevState.phase === MATCH_PHASES.BIDDING
-          ? {
-              revealedMonsterCard: prevState.bidding?.revealedMonsterCard ?? null,
-              revealedBySeatId: prevState.bidding?.revealedBySeatId ?? null,
-            }
-          : null,
-    },
-    { deferPostDungeonOutcomeAck },
-  )
-  if (presentationTraceEnabled()) {
-    const snap = presentationOrchestrator.getQueueSnapshot()
-    console.log('[DungeonRunner][presentation] enqueue', {
-      phase: `${prevState.phase}→${nextState.phase}`,
-      action: action?.type ?? null,
-      actorRole: actorRoleType,
-      queue: snap.map((x) => x.kind),
-    })
-  }
-  syncPresentationLabel()
-}
-
-function summarizeDungeonForPresentation(dungeonState) {
-  if (!dungeonState) return null
-  const discardedRunMonsterIds = Array.isArray(dungeonState.discardedRunMonsters)
-    ? [...dungeonState.discardedRunMonsters]
-    : []
-  const rawDefeatRecord = dungeonState.lastDefeatRecord ?? null
-  const lastDefeatRecord = rawDefeatRecord
-    ? {
-        monsterCard: rawDefeatRecord.monsterCard ?? null,
-        byEquipmentIds: Array.isArray(rawDefeatRecord.byEquipmentIds) ? [...rawDefeatRecord.byEquipmentIds] : [],
-        expendedEquipmentIds: Array.isArray(rawDefeatRecord.expendedEquipmentIds)
-          ? [...rawDefeatRecord.expendedEquipmentIds]
-          : [],
-      }
-    : null
-  return {
-    subphase: dungeonState.subphase ?? null,
-    currentMonster: dungeonState.currentMonster ?? null,
-    remainingMonsterCount: Array.isArray(dungeonState.remainingMonsters)
-      ? dungeonState.remainingMonsters.length
-      : 0,
-    discardedMonsterCount: discardedRunMonsterIds.length,
-    discardedRunMonsterIds,
-    hp: Number.isFinite(dungeonState.hp) ? dungeonState.hp : null,
-    lastDefeatRecord,
-  }
-}
-
-function enrichPresentationForViewer(head) {
-  if (!head) return null
-  const kind = head.kind
-  const basePayload = head.payload && typeof head.payload === 'object' ? { ...head.payload } : {}
-
-  if (kind === 'BIDDING_DRAW') {
-    const actorSeatId = basePayload.actorSeatId ?? null
-    basePayload.shouldFlipFaceAfterArrival = viewerMaySeeBiddingDrawFace({
-      viewerSeatId: humanSeatId.value,
-      actorSeatId,
-    })
-    return { ...head, payload: basePayload }
-  }
-  if (kind === 'BIDDING_ADD') {
-    basePayload.shouldFlipToBackBeforeDungeon = viewerMaySeeAddToDungeonFlipDown({
-      viewerSeatId: humanSeatId.value,
-      actorSeatId: basePayload.actorSeatId ?? null,
-      actorRoleType: basePayload.actorRoleType ?? null,
-    })
-    return { ...head, payload: basePayload }
-  }
-  return head
-}
-
-function syncPresentationLabel() {
-  activePresentation.value = enrichPresentationForViewer(presentationOrchestrator.getActiveAnimation())
-  activePresentationLabel.value = activePresentation.value?.label ?? ''
-  const locked = presentationOrchestrator.isGameplayInputLocked()
-  gameplayInputLocked.value = locked
-  if (presentationInputWasLocked && !locked) {
-    lastScheduleSkipKey = ''
-    lastPrimeSkipTraceKey = ''
-    if (debugMode.value) {
-      const snap = presentationOrchestrator.getQueueSnapshot()
-      aiTurnTrace()('presentation.unlock', {
-        queuedKinds: snap.map((item) => item.kind),
-        isHumanTurn: isHumanTurn.value,
-        activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
-      })
-    }
-    if (liveMatchShellLifecycleActive) {
+  watch(
+    () => match.value?.state,
+    (state) => {
+      if (!match.value || !state) return
+      syncSeatRecoveryIndicators()
+      applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
+      persistCurrentMatch(window.localStorage, match.value)
+      if (!liveMatchShellLifecycleActive) return
       scheduleAiTurnIfReady()
       scheduleHumanAutoResolveIfReady()
-    }
+    },
+    { deep: true },
+  )
+
+  watch(
+    () => match.value?.state?.lastDungeonRun ?? null,
+    (run) => {
+      const update = resolveLastDungeonRunWatcherUpdate(run, match.value?.state?.centerEquipment)
+      if ('dismissedDungeonRun' in update) {
+        dismissedDungeonRun.value = update.dismissedDungeonRun
+        equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
+        return
+      }
+      equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => vorpalPromptView.value.open,
+    (open) => {
+      if (!open) {
+        vorpalDialogOpen.value = false
+        selectedVorpalSpecies.value = null
+        return
+      }
+      vorpalDialogOpen.value = true
+      const firstSpecies = vorpalPromptView.value.speciesOptions[0] ?? null
+      if (
+        !selectedVorpalSpecies.value ||
+        !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)
+      ) {
+        selectedVorpalSpecies.value = firstSpecies
+      }
+    },
+  )
+
+  function resetForSetupTerminal() {
+    resetLiveMatchPageState(liveMatchPageSessionSink, {
+      clearMatch: true,
+      openNeuralLoadGateTerminal: true,
+    })
   }
-  presentationInputWasLocked = locked
-  if (presentationTraceEnabled()) {
-    const a = activePresentation.value
-    const key = a ? `${a.id}:${a.kind}` : 'idle'
-    if (key !== lastPresentationTraceKey) {
-      lastPresentationTraceKey = key
-      const snap = presentationOrchestrator.getQueueSnapshot()
-      const d = match.value?.state?.dungeon
-      console.log('[DungeonRunner][presentation] active', a?.kind ?? 'idle', {
-        ms: a?.remainingMs ?? null,
-        queued: snap.map((x) => x.kind),
-        inputLocked: gameplayInputLocked.value,
-        engineDungeonCurrentMonster: d?.currentMonster ?? null,
-        engineDungeonSubphase: d?.subphase ?? null,
-        viewMonsterVisibility: showDungeonStage.value ? dungeonStageView.value.monster.visibility : null,
-        viewMonsterSpecies: showDungeonStage.value ? dungeonStageView.value.monster.species : null,
+
+  function resetForFreshMatchEntry() {
+    resetLiveMatchPageState(liveMatchPageSessionSink, {
+      warmModelsResolved: true,
+    })
+  }
+
+  function resetForBackToSetup() {
+    resetLiveMatchPageState(liveMatchPageSessionSink, {
+      clearMatch: true,
+      clearPersistedMatch: true,
+    })
+  }
+
+  const matchPageOrchestrationCtx = createMatchPageOrchestrationContext({
+    storage: window.localStorage,
+    recovery: nnRecovery,
+    loadModel: loadNnModel,
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      matchNeuralLoadGateInFlight.value = inFlight
+    },
+    clearCurrentMatch,
+    persistCurrentMatch,
+    applySetupSnapshot,
+    setupTarget: deps.setup,
+    cloneSetup: deps.cloneSetup,
+    onSetupTerminal: () => {
+      resetForSetupTerminal()
+    },
+  })
+
+  async function runLivePageMatchEntryGate(setupSnapshot) {
+    return runMatchEntryNeuralLoadGateForPage(matchPageOrchestrationCtx, {
+      setupSnapshot,
+      releaseInFlightAfterGate: false,
+    })
+  }
+
+  async function ensureNnModelsReady() {
+    await nnModelsWarmPromise?.catch(() => {})
+  }
+
+  function reloadPageForNeuralRefreshTerminal() {
+    window.location.reload()
+  }
+
+  function handleNeuralRecoveryTerminalError(error) {
+    const result = handleLivePlayNeuralRecoveryTerminalError({
+      error,
+      match: match.value,
+      recovery: nnRecovery,
+      storage: window.localStorage,
+      persistCurrentMatch,
+      restoreSetup: (setupSnapshot) => {
+        matchPageOrchestrationCtx.applySetupTerminal(deps.cloneSetup(setupSnapshot))
+      },
+    })
+    if (!result.handled) return false
+    if (result.action === 'refresh-dialog') {
+      match.value = result.match
+      neuralRefreshTerminalOpen.value = true
+      logNnRecoveryTrace(result.trace.modelId, 'terminal', {
+        terminal: result.trace.terminal,
+        failureKind: result.trace.failureKind,
       })
     }
+    return true
   }
-}
 
-function humanDungeonAutoRevealGapMs() {
-  const pace = presentationSpeedProfile.value
-  const profile = SPEED_PROFILES[pace] ?? SPEED_PROFILES.cinematic
-  return Math.max(0, profile.dungeonContinueMs)
-}
-
-function scheduleAiTurnIfReady() {
-  if (!liveMatchShellLifecycleActive) return
-  if (!match.value || isHumanTurn.value) {
-    return
+  function takeHumanAction(action) {
+    if (!match.value || !humanSeatId.value) {
+      return
+    }
+    resetAiTurnPrefetch()
+    if (humanGameplayBlocked.value) {
+      return
+    }
+    if (autoResolveTimerId) {
+      window.clearTimeout(autoResolveTimerId)
+      autoResolveTimerId = null
+    }
+    if (equipmentModalOpen.value) equipmentModalOpen.value = false
+    const prevState = match.value.state
+    previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
+    const result = applyAction(prevState, action, { seatId: humanSeatId.value })
+    if (!result.ok) {
+      return
+    }
+    const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
+    if (deferExit) {
+      deferredPostDungeonState.value = result.state
+      match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
+    } else {
+      deferredPostDungeonState.value = null
+      match.value = { ...match.value, state: result.state }
+    }
+    enqueuePresentationTransition(prevState, result.state, action, humanSeatId.value, 'human')
   }
-  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-  const gate = evaluatePageAiTurnPipelineGate({ runToken, timerPending: !!aiTurnTimerId })
-  if (!gate.maySchedule) {
-    const skipTrace = buildAiTurnScheduleSkipTrace(gate, {
-      runToken,
-      phase: match.value?.state?.phase ?? null,
-      activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
-      presentationQueueSnapshot: presentationOrchestrator.getQueueSnapshot(),
+
+  function onDeckTap() {
+    memoryAidState.value = tapDeck(memoryAidState.value)
+  }
+
+  function onCloseDeckSplay() {
+    memoryAidState.value = closeDeckSplay(memoryAidState.value)
+  }
+
+  function settleConfirmationDialog(result) {
+    confirmationDialogOpen.value = false
+    const resolve = confirmationDialogResolve
+    confirmationDialogResolve = null
+    if (typeof resolve === 'function') resolve(result)
+  }
+
+  function requestConfirmation({
+    title = 'Confirm',
+    message,
+    okLabel = 'OK',
+    cancelLabel = 'Cancel',
+  }) {
+    if (typeof confirmationDialogResolve === 'function') {
+      confirmationDialogResolve(false)
+      confirmationDialogResolve = null
+    }
+    confirmationDialogTitle.value = title
+    confirmationDialogMessage.value = message
+    confirmationDialogOkLabel.value = okLabel
+    confirmationDialogCancelLabel.value = cancelLabel
+    confirmationDialogOpen.value = true
+    return new Promise((resolve) => {
+      confirmationDialogResolve = resolve
     })
-    if (skipTrace) {
-      logAiTurnScheduleSkip(skipTrace.reason, skipTrace.detail)
+  }
+
+  function onConfirmationDialogOk() {
+    settleConfirmationDialog(true)
+  }
+
+  function onConfirmationDialogCancel() {
+    settleConfirmationDialog(false)
+  }
+
+  function openEquipmentModal(token) {
+    if (
+      shouldRejectEquipmentTokenTap({
+        hasModal: token?.hasModal,
+        humanGameplayBlocked: humanGameplayBlocked.value,
+      })
+    )
+      return
+    selectedEquipmentTokenId.value = token.equipmentId
+    equipmentModalOpen.value = true
+  }
+
+  function takeEquipmentUseAction() {
+    if (equipmentModalActionsDisabled.value || !selectedEquipmentModalView.value?.useAction) return
+    takeHumanAction(selectedEquipmentModalView.value.useAction)
+  }
+
+  function continueFromEquipmentModal() {
+    if (!equipmentModalActionsDisabled.value && selectedEquipmentModalView.value?.continueAction) {
+      takeHumanAction(selectedEquipmentModalView.value.continueAction)
+      return
     }
-    if (gate.mayPrefetch) {
-      primeAiTurnPrefetch(gate)
+    equipmentModalOpen.value = false
+  }
+
+  async function continueFromDungeonOutcome() {
+    const run = match.value?.state?.lastDungeonRun
+    if (!run) return
+    dismissedDungeonRun.value = dismissDungeonRunForOutcomeDialog(run)
+    if (deferredPostDungeonState.value) {
+      match.value = { ...match.value, state: deferredPostDungeonState.value }
+      deferredPostDungeonState.value = null
     }
-    if (gate.scheduleSkipReason === 'model-recovering' || gate.scheduleSkipReason === 'gameplay-locked') {
-      if (aiTurnTimerId) {
-        window.clearTimeout(aiTurnTimerId)
-        aiTurnTimerId = null
+    presentationOrchestrator.flushPostDungeonOutcomeAnimations()
+    syncPresentationLabel()
+    await maybeRunHeadlessMatchCompletion()
+  }
+
+  function teardownForHeadlessMatchCompletion() {
+    if (aiTurnTimerId) {
+      window.clearTimeout(aiTurnTimerId)
+      aiTurnTimerId = null
+    }
+    if (autoResolveTimerId) {
+      window.clearTimeout(autoResolveTimerId)
+      autoResolveTimerId = null
+    }
+    resetAiTurnPrefetch()
+    abandonScheduledInferenceQueue()
+    presentationOrchestrator.clear()
+    deferredPostDungeonState.value = null
+    lastAppliedAiTurnToken = null
+    const run = match.value?.state?.lastDungeonRun
+    if (run) dismissedDungeonRun.value = run
+  }
+
+  function createPageHeadlessCompletionFlightGate() {
+    return {
+      get inFlight() {
+        return headlessCompletionInFlight.value
+      },
+      tryStart() {
+        if (headlessCompletionInFlight.value) return false
+        headlessCompletionInFlight.value = true
+        return true
+      },
+      finish() {
+        headlessCompletionInFlight.value = false
+      },
+    }
+  }
+
+  async function maybeRunHeadlessMatchCompletion() {
+    try {
+      const result = await runHeadlessMatchCompletionForPage(matchPageOrchestrationCtx, {
+        match: match.value,
+        humanPlayerSeatId: humanSeatId.value,
+        chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
+        gate: createPageHeadlessCompletionFlightGate(),
+        teardown: teardownForHeadlessMatchCompletion,
+      })
+
+      if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
+        match.value = result.match
+      }
+      if (result.kind === 'refresh-terminal') {
+        neuralRefreshTerminalOpen.value = true
+        logNnRecoveryTrace(result.modelId, 'terminal', {
+          terminal: result.terminal,
+          failureKind: result.failureKind ?? null,
+        })
+      } else if (result.kind === 'setup-terminal') {
+        // applySetupTerminal already ran inside runHeadlessMatchCompletionForPage
+      } else if (result.kind === 'failed' && debugMode.value) {
+        console.warn(
+          '[DungeonRunner][headless] completion failed',
+          result.errorCode,
+          result.actionCount,
+        )
+      }
+    } finally {
+      syncPresentationLabel()
+    }
+  }
+
+  function confirmVorpalDeclaration() {
+    if (!selectedVorpalSpecies.value) return
+    takeHumanAction({
+      type: 'DECLARE_VORPAL',
+      species: selectedVorpalSpecies.value,
+    })
+  }
+
+  async function runAiTurn() {
+    const trace = aiTurnTrace()
+    const seatId = match.value?.state?.turn?.activeSeatId ?? null
+    const runToken = match.value
+      ? buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+      : ''
+    const gate = evaluatePageAiTurnPipelineGate({ runToken })
+    if (!gate.mayRunTurn) {
+      const presentationQueueSnapshot = presentationOrchestrator.getQueueSnapshot()
+      const skipTrace = buildAiTurnRunSkipTrace(gate, {
+        runToken,
+        seatId,
+        humanSeatId: humanSeatId.value,
+        phase: match.value?.state?.phase ?? null,
+        activePresentationKind: activePresentation.value?.kind ?? null,
+        queueMs: presentationQueueSnapshot.reduce((sum, item) => sum + item.remainingMs, 0),
+        lastAppliedAiTurnToken,
+      })
+      if (skipTrace) {
+        trace(skipTrace.step, skipTrace.detail)
+      }
+      return
+    }
+    aiTurnInFlight = true
+    try {
+      trace('run.begin', {
+        runToken,
+        phase: match.value.state.phase,
+        seatId,
+        turnNumber: match.value.state.turn.turnNumber,
+        biddingSubphase: match.value.state.bidding?.subphase ?? null,
+        revealedMonsterCard: match.value.state.bidding?.revealedMonsterCard ?? null,
+        dungeonSubphase: match.value.state.dungeon?.subphase ?? null,
+      })
+      const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
+      const roleType = seat?.role?.type
+      const chooseAction = createLivePlayActionChooser(
+        buildLivePlayChooserDeps({
+          tryConsumePrefetch: async ({ runToken: consumeRunToken }) => {
+            const prefetchGate = evaluatePageAiTurnPipelineGate({
+              runToken: consumeRunToken ?? runToken,
+            })
+            return consumeAiTurnPrefetch({
+              runToken: consumeRunToken ?? runToken,
+              mayPrefetch: prefetchGate.mayPrefetch,
+              prefetchSkipReason: prefetchGate.prefetchSkipReason,
+              trace: (step, detail) => trace(step, detail),
+            })
+          },
+        }),
+      )
+      let action
+      try {
+        action = await chooseAction({ state: match.value.state, seatId, runToken })
+      } catch (error) {
+        if (handleNeuralRecoveryTerminalError(error)) {
+          trace('run.abort', {
+            reason: 'nn-recovery-terminal',
+            terminal: error.terminal,
+            modelId: error.modelId,
+          })
+          return
+        }
+        throw error
+      }
+      if (!action) {
+        trace('run.abort', { reason: 'no-action' })
+        return
+      }
+      if (!match.value) {
+        trace('run.abort', { reason: 'match-cleared' })
+        return
+      }
+      const currentToken = buildAiTurnRunToken({
+        matchId: match.value.id,
+        state: match.value.state,
+      })
+      if (runToken !== currentToken) {
+        trace('run.abort', { reason: 'stale-token', runToken, currentToken })
+        return
+      }
+      const prevState = match.value.state
+      if (humanSeatId.value) {
+        previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
+      }
+      const result = applyAction(prevState, action, { seatId })
+      if (!result.ok) {
+        trace('run.abort', { reason: 'apply-failed', actionType: action.type })
+        return
+      }
+      lastAppliedAiTurnToken = runToken
+      const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
+      if (deferExit) {
+        deferredPostDungeonState.value = result.state
+        match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
+      } else {
+        deferredPostDungeonState.value = null
+        match.value = { ...match.value, state: result.state }
+      }
+      trace('run.applied', {
+        actionType: action.type,
+        nextRunToken: buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state }),
+        phaseAfter: match.value.state.phase,
+        turnAfterSeatId: match.value.state.turn.activeSeatId,
+        deferExit,
+      })
+      enqueuePresentationTransition(
+        prevState,
+        result.state,
+        action,
+        seatId,
+        roleType ?? 'randombot',
+      )
+      if (debugMode.value) {
+        const snap = presentationOrchestrator.getQueueSnapshot()
+        trace('presentation.enqueued', {
+          queue: snap.map((item) => item.kind),
+          queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
+        })
+      }
+      primeAiTurnPrefetch()
+    } finally {
+      aiTurnInFlight = false
+      trace('run.finally', { inFlight: false })
+    }
+  }
+
+  function primeAiTurnPrefetch(precomputedGate = null) {
+    const trace = aiTurnTrace()
+    const state = match.value?.state
+    const seatId = state?.turn?.activeSeatId ?? null
+    const seat = state?.seats?.find((candidate) => candidate.id === seatId)
+    const runToken = match.value ? buildAiTurnRunToken({ matchId: match.value.id, state }) : ''
+    const modelId = seat?.role?.type === 'nn' ? (seat.role.modelId ?? 'latest') : null
+    const gate = precomputedGate ?? evaluatePageAiTurnPipelineGate({ runToken })
+    if (!gate.mayPrefetch) {
+      const skipTrace = buildAiTurnPrefetchSkipTrace(gate, {
+        seatId,
+        phase: state?.phase ?? null,
+        runToken,
+        modelId,
+        roleType: seat?.role?.type ?? null,
+      })
+      if (skipTrace) {
+        logAiTurnPrimeSkip(skipTrace.reason, skipTrace.detail)
+      }
+      return
+    }
+    lastPrimeSkipTraceKey = ''
+    startAiTurnPrefetch({
+      runToken,
+      mayPrefetch: true,
+      prefetchSkipReason: null,
+      trace: (step, detail) => trace(step, detail),
+      compute: async () => {
+        await ensureNnModelsReady()
+        return chooseNnActionWithRecovery(state, { seatId }, nnRuntimeOptions(modelId))
+      },
+    })
+  }
+
+  function enqueuePresentationTransition(prevState, nextState, action, actorSeatId, actorRoleType) {
+    const deferPostDungeonOutcomeAck = shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState)
+    presentationOrchestrator.enqueueEngineTransition(
+      {
+        phaseBefore: prevState.phase,
+        phaseAfter: nextState.phase,
+        turnBeforeSeatId: prevState.turn.activeSeatId,
+        turnAfterSeatId: nextState.turn.activeSeatId,
+        dungeonRunResult:
+          prevState.lastDungeonRun?.result === nextState.lastDungeonRun?.result
+            ? null
+            : (nextState.lastDungeonRun?.result ?? null),
+        action,
+        actorSeatId,
+        actorRoleType,
+        centerEquipmentBefore: prevState.centerEquipment ?? [],
+        centerEquipmentAfter: nextState.centerEquipment ?? [],
+        heroBefore: prevState.hero,
+        heroAfter: nextState.hero,
+        dungeonBefore: summarizeDungeonForPresentation(prevState.dungeon),
+        dungeonAfter: summarizeDungeonForPresentation(nextState.dungeon),
+        biddingBefore:
+          prevState.phase === MATCH_PHASES.BIDDING
+            ? {
+                revealedMonsterCard: prevState.bidding?.revealedMonsterCard ?? null,
+                revealedBySeatId: prevState.bidding?.revealedBySeatId ?? null,
+              }
+            : null,
+      },
+      { deferPostDungeonOutcomeAck },
+    )
+    if (presentationTraceEnabled()) {
+      const snap = presentationOrchestrator.getQueueSnapshot()
+      console.log('[DungeonRunner][presentation] enqueue', {
+        phase: `${prevState.phase}→${nextState.phase}`,
+        action: action?.type ?? null,
+        actorRole: actorRoleType,
+        queue: snap.map((x) => x.kind),
+      })
+    }
+    syncPresentationLabel()
+  }
+
+  function summarizeDungeonForPresentation(dungeonState) {
+    if (!dungeonState) return null
+    const discardedRunMonsterIds = Array.isArray(dungeonState.discardedRunMonsters)
+      ? [...dungeonState.discardedRunMonsters]
+      : []
+    const rawDefeatRecord = dungeonState.lastDefeatRecord ?? null
+    const lastDefeatRecord = rawDefeatRecord
+      ? {
+          monsterCard: rawDefeatRecord.monsterCard ?? null,
+          byEquipmentIds: Array.isArray(rawDefeatRecord.byEquipmentIds)
+            ? [...rawDefeatRecord.byEquipmentIds]
+            : [],
+          expendedEquipmentIds: Array.isArray(rawDefeatRecord.expendedEquipmentIds)
+            ? [...rawDefeatRecord.expendedEquipmentIds]
+            : [],
+        }
+      : null
+    return {
+      subphase: dungeonState.subphase ?? null,
+      currentMonster: dungeonState.currentMonster ?? null,
+      remainingMonsterCount: Array.isArray(dungeonState.remainingMonsters)
+        ? dungeonState.remainingMonsters.length
+        : 0,
+      discardedMonsterCount: discardedRunMonsterIds.length,
+      discardedRunMonsterIds,
+      hp: Number.isFinite(dungeonState.hp) ? dungeonState.hp : null,
+      lastDefeatRecord,
+    }
+  }
+
+  function enrichPresentationForViewer(head) {
+    if (!head) return null
+    const kind = head.kind
+    const basePayload = head.payload && typeof head.payload === 'object' ? { ...head.payload } : {}
+
+    if (kind === 'BIDDING_DRAW') {
+      const actorSeatId = basePayload.actorSeatId ?? null
+      basePayload.shouldFlipFaceAfterArrival = viewerMaySeeBiddingDrawFace({
+        viewerSeatId: humanSeatId.value,
+        actorSeatId,
+      })
+      return { ...head, payload: basePayload }
+    }
+    if (kind === 'BIDDING_ADD') {
+      basePayload.shouldFlipToBackBeforeDungeon = viewerMaySeeAddToDungeonFlipDown({
+        viewerSeatId: humanSeatId.value,
+        actorSeatId: basePayload.actorSeatId ?? null,
+        actorRoleType: basePayload.actorRoleType ?? null,
+      })
+      return { ...head, payload: basePayload }
+    }
+    return head
+  }
+
+  function syncPresentationLabel() {
+    activePresentation.value = enrichPresentationForViewer(
+      presentationOrchestrator.getActiveAnimation(),
+    )
+    activePresentationLabel.value = activePresentation.value?.label ?? ''
+    const locked = presentationOrchestrator.isGameplayInputLocked()
+    gameplayInputLocked.value = locked
+    if (presentationInputWasLocked && !locked) {
+      lastScheduleSkipKey = ''
+      lastPrimeSkipTraceKey = ''
+      if (debugMode.value) {
+        const snap = presentationOrchestrator.getQueueSnapshot()
+        aiTurnTrace()('presentation.unlock', {
+          queuedKinds: snap.map((item) => item.kind),
+          isHumanTurn: isHumanTurn.value,
+          activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
+        })
+      }
+      if (liveMatchShellLifecycleActive) {
+        scheduleAiTurnIfReady()
+        scheduleHumanAutoResolveIfReady()
       }
     }
-    return
+    presentationInputWasLocked = locked
+    if (presentationTraceEnabled()) {
+      const a = activePresentation.value
+      const key = a ? `${a.id}:${a.kind}` : 'idle'
+      if (key !== lastPresentationTraceKey) {
+        lastPresentationTraceKey = key
+        const snap = presentationOrchestrator.getQueueSnapshot()
+        const d = match.value?.state?.dungeon
+        console.log('[DungeonRunner][presentation] active', a?.kind ?? 'idle', {
+          ms: a?.remainingMs ?? null,
+          queued: snap.map((x) => x.kind),
+          inputLocked: gameplayInputLocked.value,
+          engineDungeonCurrentMonster: d?.currentMonster ?? null,
+          engineDungeonSubphase: d?.subphase ?? null,
+          viewMonsterVisibility: showDungeonStage.value
+            ? dungeonStageView.value.monster.visibility
+            : null,
+          viewMonsterSpecies: showDungeonStage.value
+            ? dungeonStageView.value.monster.species
+            : null,
+        })
+      }
+    }
   }
-  primeAiTurnPrefetch(gate)
-  if (debugMode.value) {
-    aiTurnTrace()('schedule.timer-armed', { runToken, delayMs: AI_TURN_SCHEDULE_DELAY_MS })
-  }
-  aiTurnTimerId = window.setTimeout(() => {
-    aiTurnTimerId = null
-    if (debugMode.value) aiTurnTrace()('schedule.timer-fired', { runToken })
-    void runAiTurn()
-  }, AI_TURN_SCHEDULE_DELAY_MS)
-}
 
-function scheduleHumanAutoResolveIfReady() {
-  if (!liveMatchShellLifecycleActive) return
-  if (!match.value) {
-    return
+  function humanDungeonAutoRevealGapMs() {
+    const pace = presentationSpeedProfile.value
+    const profile = SPEED_PROFILES[pace] ?? SPEED_PROFILES.cinematic
+    return Math.max(0, profile.dungeonContinueMs)
   }
-  if (humanGameplayBlocked.value) {
-    return
+
+  function scheduleAiTurnIfReady() {
+    if (!liveMatchShellLifecycleActive) return
+    if (!match.value || isHumanTurn.value) {
+      return
+    }
+    const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+    const gate = evaluatePageAiTurnPipelineGate({ runToken, timerPending: !!aiTurnTimerId })
+    if (!gate.maySchedule) {
+      const skipTrace = buildAiTurnScheduleSkipTrace(gate, {
+        runToken,
+        phase: match.value?.state?.phase ?? null,
+        activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
+        presentationQueueSnapshot: presentationOrchestrator.getQueueSnapshot(),
+      })
+      if (skipTrace) {
+        logAiTurnScheduleSkip(skipTrace.reason, skipTrace.detail)
+      }
+      if (gate.mayPrefetch) {
+        primeAiTurnPrefetch(gate)
+      }
+      if (
+        gate.scheduleSkipReason === 'model-recovering' ||
+        gate.scheduleSkipReason === 'gameplay-locked'
+      ) {
+        if (aiTurnTimerId) {
+          window.clearTimeout(aiTurnTimerId)
+          aiTurnTimerId = null
+        }
+      }
+      return
+    }
+    primeAiTurnPrefetch(gate)
+    if (debugMode.value) {
+      aiTurnTrace()('schedule.timer-armed', { runToken, delayMs: AI_TURN_SCHEDULE_DELAY_MS })
+    }
+    aiTurnTimerId = window.setTimeout(() => {
+      aiTurnTimerId = null
+      if (debugMode.value) aiTurnTrace()('schedule.timer-fired', { runToken })
+      void runAiTurn()
+    }, AI_TURN_SCHEDULE_DELAY_MS)
   }
-  if (!isHumanTurn.value) {
-    return
-  }
-  if (match.value.state.phase !== 'dungeon') {
-    return
-  }
-  if (equipmentModalOpen.value || autoResolveTimerId) {
-    return
-  }
-  const action = dungeonResolutionView.value.autoAdvanceAction
-  const gate = {
-    phase: match.value.state.phase,
-    gameplayInputLocked: gameplayInputLocked.value,
-    isHumanTurn: isHumanTurn.value,
-    legalActions: legalActions.value,
-    autoAdvanceAction: action,
-    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
-    activeAnimationKind: activePresentation.value?.kind ?? null,
-  }
-  if (!shouldAutoResolveDungeonAdvance(gate)) {
-    return
-  }
-  autoResolveTimerId = window.setTimeout(() => {
-    autoResolveTimerId = null
-    const execGate = {
-      phase: match.value?.state?.phase ?? null,
+
+  function scheduleHumanAutoResolveIfReady() {
+    if (!liveMatchShellLifecycleActive) return
+    if (!match.value) {
+      return
+    }
+    if (humanGameplayBlocked.value) {
+      return
+    }
+    if (!isHumanTurn.value) {
+      return
+    }
+    if (match.value.state.phase !== 'dungeon') {
+      return
+    }
+    if (equipmentModalOpen.value || autoResolveTimerId) {
+      return
+    }
+    const action = dungeonResolutionView.value.autoAdvanceAction
+    const gate = {
+      phase: match.value.state.phase,
       gameplayInputLocked: gameplayInputLocked.value,
       isHumanTurn: isHumanTurn.value,
-      equipmentModalOpen: equipmentModalOpen.value,
-      autoAdvanceAction: action,
       legalActions: legalActions.value,
+      autoAdvanceAction: action,
       resolutionStatus: dungeonResolutionView.value.resolutionStatus,
       activeAnimationKind: activePresentation.value?.kind ?? null,
     }
-    const ok = shouldExecuteScheduledAutoResolve(execGate)
-    if (!ok) return
-    takeHumanAction(action)
-  }, humanDungeonAutoRevealGapMs())
-}
-
-function nnRuntimeOptions(modelId) {
-  if (!debugMode.value) return { modelId }
-  return {
-    modelId,
-    pipelineTrace: true,
-    debugTrace: true,
-    debugLogger(trace) {
-      const payload = {
-        at: new Date().toISOString(),
-        modelId,
-        seatId: match.value?.state?.turn?.activeSeatId ?? null,
-        trace,
+    if (!shouldAutoResolveDungeonAdvance(gate)) {
+      return
+    }
+    autoResolveTimerId = window.setTimeout(() => {
+      autoResolveTimerId = null
+      const execGate = {
+        phase: match.value?.state?.phase ?? null,
+        gameplayInputLocked: gameplayInputLocked.value,
+        isHumanTurn: isHumanTurn.value,
+        equipmentModalOpen: equipmentModalOpen.value,
+        autoAdvanceAction: action,
+        legalActions: legalActions.value,
+        resolutionStatus: dungeonResolutionView.value.resolutionStatus,
+        activeAnimationKind: activePresentation.value?.kind ?? null,
       }
-      nnDebugTraceHistory.value = [payload, ...nnDebugTraceHistory.value].slice(0, 20)
-      nnDebugTraceText.value = JSON.stringify(payload, null, 2)
-    },
+      const ok = shouldExecuteScheduledAutoResolve(execGate)
+      if (!ok) return
+      takeHumanAction(action)
+    }, humanDungeonAutoRevealGapMs())
   }
-}
 
-function actionLabel(action) {
-  return legalActionBoardLabel(action)
-}
-
-function actionKey(action) {
-  const id = [action.equipmentId, action.hero, action.species].filter((x) => x != null && x !== '').join('-')
-  return id ? `${action.type}-${id}` : action.type
-}
-
-function skipActivePresentation() {
-  presentationOrchestrator.skipActiveAnimation()
-  syncPresentationLabel()
-}
-
-function bindRefTarget(refTarget) {
-  return (componentOrEl) => {
-    refTarget.value = componentOrEl ?? null
+  function nnRuntimeOptions(modelId) {
+    if (!debugMode.value) return { modelId }
+    return {
+      modelId,
+      pipelineTrace: true,
+      debugTrace: true,
+      debugLogger(trace) {
+        const payload = {
+          at: new Date().toISOString(),
+          modelId,
+          seatId: match.value?.state?.turn?.activeSeatId ?? null,
+          trace,
+        }
+        nnDebugTraceHistory.value = [payload, ...nnDebugTraceHistory.value].slice(0, 20)
+        nnDebugTraceText.value = JSON.stringify(payload, null, 2)
+      },
+    }
   }
-}
 
-const bindBoardShellRef = bindRefTarget(boardShellRef)
-const bindHeroCardSlotRef = bindRefTarget(heroCardSlotRef)
-const bindDungeonCardMotionWrapRef = bindRefTarget(dungeonCardMotionWrap)
-const bindDungeonCardFaceRef = bindRefTarget(dungeonCardFaceRef)
-const bindDeckBadgeRef = bindRefTarget(deckBadgeRef)
-const bindDungeonPileMotionAnchorRef = bindRefTarget(dungeonPileMotionAnchorRef)
-const bindHeroChangeInterstitialOverlayRef = bindRefTarget(heroChangeInterstitialOverlayRef)
-const bindPresentationFlightLayerRef = bindRefTarget(presentationFlightLayerRef)
-
-function mountLiveMatchShell() {
-  if (liveMatchShellLifecycleActive) return
-  liveMatchShellLifecycleActive = true
-  presentationOrchestrator.setSpeedProfile(presentationSpeedProfile.value)
-  const lifecycle = activateLiveMatchShellLifecycle({
-    recovery: nnRecovery,
-    onRecoveryChanged: onNnRecoveryChanged,
-    presentationOrchestrator,
-    tickCallbacks: {
-      syncPresentationLabel,
-      scheduleAiTurnIfReady: scheduleAiTurnOnPresentationTick,
-      scheduleHumanAutoResolveIfReady,
-    },
-  })
-  unsubscribeNnRecovery = lifecycle.unsubscribe
-  presentationTimerId = lifecycle.presentationTimerId
-  if (presentationTraceEnabled()) {
-    console.log(
-      '[DungeonRunner][presentation] trace on — localStorage.setItem("dungeonPresentationTrace","1") — also logs [card-flight] for pile/deck → card motion',
-    )
+  function actionLabel(action) {
+    return legalActionBoardLabel(action)
   }
-}
 
-function unmountLiveMatchShell() {
-  if (!liveMatchShellLifecycleActive) return
-  liveMatchShellLifecycleActive = false
-  cancelAiTurnPrefetch()
-  deactivateLiveMatchShellLifecycle({
-    unsubscribe: unsubscribeNnRecovery,
-    presentationTimerId,
-    aiTurnTimerId,
-    autoResolveTimerId,
-    confirmationDialogResolve,
-  })
-  unsubscribeNnRecovery = null
-  presentationTimerId = null
-}
+  function actionKey(action) {
+    const id = [action.equipmentId, action.hero, action.species]
+      .filter((x) => x != null && x !== '')
+      .join('-')
+    return id ? `${action.type}-${id}` : action.type
+  }
 
-function exportReplay() {
-  if (!match.value) return
-  const payload = exportReplayEnvelope({
-    seed: match.value.state.rng.seed,
-    setup: match.value.setup,
-    history: match.value.state.history,
-    presentationSpeedProfile: match.value.presentationSpeedProfile,
-  })
-  replayExportText.value = JSON.stringify(payload, null, 2)
-}
-
-function importReplay() {
-  if (!replayImportText.value.trim()) return
-  try {
-    const parsed = JSON.parse(replayImportText.value)
-    const imported = importReplayEnvelope(parsed)
-    if (!imported.ok) {
-      deps.notify({ type: 'negative', message: 'Replay payload is invalid.' })
-      return
-    }
-    const replayResult = buildStateFromReplayEnvelope(imported.replay)
-    if (!replayResult.ok) {
-      deps.notify({ type: 'negative', message: 'Replay actions are invalid for this seed/setup.' })
-      return
-    }
-    const pace =
-      imported.replay.presentationSpeedProfile === 'brisk' ||
-      imported.replay.presentationSpeedProfile === 'cinematic'
-        ? imported.replay.presentationSpeedProfile
-        : 'cinematic'
-    dungeonRunnerSettingsStore.setAnimationPace(pace)
-    match.value = {
-      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-      id: `match-${Date.now()}`,
-      setup: imported.replay.setup,
-      state: replayResult.state,
-      history: [],
-      presentationSpeedProfile: pace,
-    }
-    deferredPostDungeonState.value = null
-    presentationSpeedProfile.value = pace
-    presentationOrchestrator.setSpeedProfile(pace)
-    presentationOrchestrator.clear()
+  function skipActivePresentation() {
+    presentationOrchestrator.skipActiveAnimation()
     syncPresentationLabel()
-  } catch {
-    deps.notify({ type: 'negative', message: 'Replay payload must be valid JSON.' })
   }
-}
+
+  function bindRefTarget(refTarget) {
+    return (componentOrEl) => {
+      refTarget.value = componentOrEl ?? null
+    }
+  }
+
+  const bindBoardShellRef = bindRefTarget(boardShellRef)
+  const bindHeroCardSlotRef = bindRefTarget(heroCardSlotRef)
+  const bindDungeonCardMotionWrapRef = bindRefTarget(dungeonCardMotionWrap)
+  const bindDungeonCardFaceRef = bindRefTarget(dungeonCardFaceRef)
+  const bindDeckBadgeRef = bindRefTarget(deckBadgeRef)
+  const bindDungeonPileMotionAnchorRef = bindRefTarget(dungeonPileMotionAnchorRef)
+  const bindHeroChangeInterstitialOverlayRef = bindRefTarget(heroChangeInterstitialOverlayRef)
+  const bindPresentationFlightLayerRef = bindRefTarget(presentationFlightLayerRef)
+
+  function mountLiveMatchShell() {
+    if (liveMatchShellLifecycleActive) return
+    liveMatchShellLifecycleActive = true
+    presentationOrchestrator.setSpeedProfile(presentationSpeedProfile.value)
+    const lifecycle = activateLiveMatchShellLifecycle({
+      recovery: nnRecovery,
+      onRecoveryChanged: onNnRecoveryChanged,
+      presentationOrchestrator,
+      tickCallbacks: {
+        syncPresentationLabel,
+        scheduleAiTurnIfReady: scheduleAiTurnOnPresentationTick,
+        scheduleHumanAutoResolveIfReady,
+      },
+    })
+    unsubscribeNnRecovery = lifecycle.unsubscribe
+    presentationTimerId = lifecycle.presentationTimerId
+    if (presentationTraceEnabled()) {
+      console.log(
+        '[DungeonRunner][presentation] trace on — localStorage.setItem("dungeonPresentationTrace","1") — also logs [card-flight] for pile/deck → card motion',
+      )
+    }
+  }
+
+  function unmountLiveMatchShell() {
+    if (!liveMatchShellLifecycleActive) return
+    liveMatchShellLifecycleActive = false
+    cancelAiTurnPrefetch()
+    deactivateLiveMatchShellLifecycle({
+      unsubscribe: unsubscribeNnRecovery,
+      presentationTimerId,
+      aiTurnTimerId,
+      autoResolveTimerId,
+      confirmationDialogResolve,
+    })
+    unsubscribeNnRecovery = null
+    presentationTimerId = null
+  }
+
+  function exportReplay() {
+    if (!match.value) return
+    const payload = exportReplayEnvelope({
+      seed: match.value.state.rng.seed,
+      setup: match.value.setup,
+      history: match.value.state.history,
+      presentationSpeedProfile: match.value.presentationSpeedProfile,
+    })
+    replayExportText.value = JSON.stringify(payload, null, 2)
+  }
+
+  function importReplay() {
+    if (!replayImportText.value.trim()) return
+    try {
+      const parsed = JSON.parse(replayImportText.value)
+      const imported = importReplayEnvelope(parsed)
+      if (!imported.ok) {
+        deps.notify({ type: 'negative', message: 'Replay payload is invalid.' })
+        return
+      }
+      const replayResult = buildStateFromReplayEnvelope(imported.replay)
+      if (!replayResult.ok) {
+        deps.notify({
+          type: 'negative',
+          message: 'Replay actions are invalid for this seed/setup.',
+        })
+        return
+      }
+      const pace =
+        imported.replay.presentationSpeedProfile === 'brisk' ||
+        imported.replay.presentationSpeedProfile === 'cinematic'
+          ? imported.replay.presentationSpeedProfile
+          : 'cinematic'
+      dungeonRunnerSettingsStore.setAnimationPace(pace)
+      match.value = {
+        schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+        id: `match-${Date.now()}`,
+        setup: imported.replay.setup,
+        state: replayResult.state,
+        history: [],
+        presentationSpeedProfile: pace,
+      }
+      deferredPostDungeonState.value = null
+      presentationSpeedProfile.value = pace
+      presentationOrchestrator.setSpeedProfile(pace)
+      presentationOrchestrator.clear()
+      syncPresentationLabel()
+    } catch {
+      deps.notify({ type: 'negative', message: 'Replay payload must be valid JSON.' })
+    }
+  }
 
   return reactive({
-    match,
-    boardShellRef,
-    heroCardSlotRef,
-    dungeonCardMotionWrap,
-    dungeonCardFaceRef,
-    deckBadgeRef,
-    dungeonPileMotionAnchorRef,
-    heroChangeInterstitialOverlayRef,
-    presentationFlightLayerRef,
-    bindBoardShellRef,
-    bindHeroCardSlotRef,
-    bindDungeonCardMotionWrapRef,
-    bindDungeonCardFaceRef,
-    bindDeckBadgeRef,
-    bindDungeonPileMotionAnchorRef,
-    bindHeroChangeInterstitialOverlayRef,
-    bindPresentationFlightLayerRef,
-    bindBiddingEquipmentBadgeRef,
-    showDungeonStage,
-    dungeonStageView,
-    biddingBoard,
-    seatRunTrackerRows,
-    monsterCardSlotEmpty,
-    dungeonStageAnimationClass,
-    uiAssets,
-    boardEquipmentTokens,
-    openEquipmentModal,
-    onDeckTap,
-    showActionPane,
-    activePresentationLabel,
-    isHumanTurn,
-    biddingSacrificeActions,
-    biddingNonSacrificeActions,
-    actionKey,
-    actionLabel,
-    humanGameplayBlocked,
-    takeHumanAction,
-    showHeroPickActionGrid,
-    heroPickActionsOrdered,
-    getHeroIdentity,
-    visiblePrimaryActions,
-    dungeonOutcomeTransitionControls,
-    gameplayInputLocked,
-    dungeonOutcomeDialogOpen,
-    debugMode,
-    nnDebugTraceHistory,
-    exportReplay,
-    importReplay,
-    replayExportText,
-    replayImportText,
-    nnDebugTraceText,
-    activePresentation,
-    heroChangeInterstitialView,
-    heroChangeInterstitialAriaLabel,
-    skipActivePresentation,
-    dungeonOutcomeSummary,
-    dungeonOutcomeToneClass,
-    dungeonOutcomeMessage,
-    continueFromDungeonOutcome,
-    equipmentModalOpen,
-    selectedEquipmentModalView,
-    equipmentModalActionsDisabled,
-    takeEquipmentUseAction,
-    continueFromEquipmentModal,
-    confirmationDialogOpen,
-    confirmationDialogTitle,
-    confirmationDialogMessage,
-    confirmationDialogOkLabel,
-    confirmationDialogCancelLabel,
-    onConfirmationDialogCancel,
-    onConfirmationDialogOk,
-    neuralRefreshTerminalOpen,
-    reloadPageForNeuralRefreshTerminal,
-    vorpalDialogOpen,
-    vorpalSelectOptions,
-    selectedVorpalSpecies,
-    confirmVorpalDeclaration,
-    deckSplayOpen,
-    onCloseDeckSplay,
-    headlessCompletionInFlight,
-    biddingStageSpecies,
-    biddingStageFaceDown,
-    mountLiveMatchShell,
-    unmountLiveMatchShell,
-    applyBootstrappedMatchSession,
-    processBootstrappedSession,
-    kickMatchAutomation,
-    maybeRunHeadlessMatchCompletion,
-    resetForSetupTerminal,
-    resetForFreshMatchEntry,
-    resetForBackToSetup,
-    matchPageOrchestrationCtx,
-    runLivePageMatchEntryGate,
-    requestConfirmation,
-    buildNewMatchEnvelope,
+    board: {
+      match,
+      boardShellRef,
+      heroCardSlotRef,
+      dungeonCardMotionWrap,
+      dungeonCardFaceRef,
+      deckBadgeRef,
+      dungeonPileMotionAnchorRef,
+      heroChangeInterstitialOverlayRef,
+      presentationFlightLayerRef,
+      bindBoardShellRef,
+      bindHeroCardSlotRef,
+      bindDungeonCardMotionWrapRef,
+      bindDungeonCardFaceRef,
+      bindDeckBadgeRef,
+      bindDungeonPileMotionAnchorRef,
+      bindHeroChangeInterstitialOverlayRef,
+      bindPresentationFlightLayerRef,
+      bindBiddingEquipmentBadgeRef,
+      showDungeonStage,
+      dungeonStageView,
+      biddingBoard,
+      seatRunTrackerRows,
+      monsterCardSlotEmpty,
+      dungeonStageAnimationClass,
+      uiAssets,
+      boardEquipmentTokens,
+      openEquipmentModal,
+      onDeckTap,
+      showActionPane,
+      activePresentationLabel,
+      isHumanTurn,
+      biddingSacrificeActions,
+      biddingNonSacrificeActions,
+      actionKey,
+      actionLabel,
+      humanGameplayBlocked,
+      takeHumanAction,
+      showHeroPickActionGrid,
+      heroPickActionsOrdered,
+      getHeroIdentity,
+      visiblePrimaryActions,
+      dungeonOutcomeTransitionControls,
+      gameplayInputLocked,
+      activePresentation,
+      heroChangeInterstitialView,
+      heroChangeInterstitialAriaLabel,
+      skipActivePresentation,
+      headlessCompletionInFlight,
+      biddingStageSpecies,
+      biddingStageFaceDown,
+    },
+    dialogs: {
+      dungeonOutcomeDialogOpen,
+      dungeonOutcomeSummary,
+      dungeonOutcomeToneClass,
+      dungeonOutcomeMessage,
+      continueFromDungeonOutcome,
+      equipmentModalOpen,
+      selectedEquipmentModalView,
+      equipmentModalActionsDisabled,
+      takeEquipmentUseAction,
+      continueFromEquipmentModal,
+      confirmationDialogOpen,
+      confirmationDialogTitle,
+      confirmationDialogMessage,
+      confirmationDialogOkLabel,
+      confirmationDialogCancelLabel,
+      onConfirmationDialogCancel,
+      onConfirmationDialogOk,
+      neuralRefreshTerminalOpen,
+      reloadPageForNeuralRefreshTerminal,
+      vorpalDialogOpen,
+      vorpalSelectOptions,
+      selectedVorpalSpecies,
+      confirmVorpalDeclaration,
+      deckSplayOpen,
+      onCloseDeckSplay,
+    },
+    debug: {
+      debugMode,
+      nnDebugTraceHistory,
+      nnDebugTraceText,
+      exportReplay,
+      importReplay,
+      replayExportText,
+      replayImportText,
+    },
+    page: {
+      mountLiveMatchShell,
+      unmountLiveMatchShell,
+      applyBootstrappedMatchSession,
+      processBootstrappedSession,
+      kickMatchAutomation,
+      maybeRunHeadlessMatchCompletion,
+      resetForSetupTerminal,
+      resetForFreshMatchEntry,
+      resetForBackToSetup,
+      matchPageOrchestrationCtx,
+      runLivePageMatchEntryGate,
+      requestConfirmation,
+      buildNewMatchEnvelope,
+    },
   })
 }

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -1,0 +1,1625 @@
+import { computed, reactive, ref, triggerRef, unref, watch } from 'vue'
+import {
+  MATCH_PHASES,
+  applyAction,
+  getLegalActions,
+  getPlayerView,
+} from '../../engine/kernel.js'
+import {
+  CURRENT_MATCH_SCHEMA_VERSION,
+  clearCurrentMatch,
+  persistCurrentMatch,
+} from '../../persistence/currentMatch.js'
+import { applySetupSnapshot } from '../../setup/state.js'
+import { isNnAdventurerPickEnabled } from '../../setup/nnAdventurerPick.js'
+import { buildStateFromReplayEnvelope } from '../../debug/replaySession.js'
+import { exportReplayEnvelope, importReplayEnvelope } from '../../debug/replay.js'
+import {
+  abandonScheduledInferenceQueue,
+  loadNnModel,
+} from '../../nn/runtime.js'
+import { createChooseNnActionWithRecovery } from '../../nn/chooseWithRecovery.js'
+import {
+  createPresentationOrchestrator,
+  SPEED_PROFILES,
+} from '../presentationOrchestrator.js'
+import { buildAiTurnRunToken } from '../dungeonRunnerAiTurnToken.js'
+import {
+  cancelAiTurnPrefetch,
+  consumeAiTurnPrefetch,
+  resetAiTurnPrefetch,
+  startAiTurnPrefetch,
+} from '../dungeonRunnerAiTurnPrefetch.js'
+import { createPipelineStepLogger } from '../../nn/nnPipelineTrace.js'
+import {
+  dungeonRunnerAssetPack,
+  dungeonRunnerEquipmentSymbolRuntimePath,
+} from '../assetPack.js'
+import { equipmentTokenAppearance } from '../../equipmentTokenAppearance.js'
+import { equipmentShortName } from '../../data/gameDataCatalog.js'
+import {
+  adventurerChoiceHeadline,
+  legalActionBoardLabel,
+} from '../dungeonRunnerPlayerPhrasing.js'
+import {
+  buildDungeonEquipmentTokenView,
+  createDungeonEquipmentModalView,
+  createVorpalDeclarationPromptView,
+  filterVisibleLegalActions,
+} from '../dungeonEquipmentInteractions.js'
+import { createBiddingBoardViewModel } from '../biddingBoardViewModel.js'
+import {
+  viewerMaySeeAddToDungeonFlipDown,
+  viewerMaySeeBiddingDrawFace,
+} from '../biddingPresentationVisibility.js'
+import { getHeroIdentity } from '../heroIdentity.js'
+import { createDungeonResolutionViewModel } from '../dungeonResolutionViewModel.js'
+import {
+  buildDungeonOutcomeTransitionControls,
+  dungeonStageClassForKind,
+  shouldExecuteScheduledAutoResolve,
+  shouldAutoResolveDungeonAdvance,
+} from '../dungeonResolutionFlow.js'
+import {
+  buildDungeonOutcomeSummary,
+  dismissDungeonRunForOutcomeDialog,
+  isDungeonOutcomeDialogOpen,
+  resolveLastDungeonRunWatcherUpdate,
+  shouldShowDungeonOutcomeDialog,
+} from '../dungeonOutcomeDialog.js'
+import {
+  isEquipmentModalActionsDisabled,
+  isHumanGameplayBlocked,
+  shouldRejectEquipmentTokenTap,
+} from '../humanGameplayGate.js'
+import { shouldDeferDungeonExitUntilOutcomeAck } from '../headlessMatchCompletionRunner.js'
+import {
+  runHeadlessMatchCompletionForPage,
+  buildNewMatchEnvelope,
+  runMatchEntryNeuralLoadGateForPage,
+} from '../../matchPageOrchestration.js'
+import { createMatchPageOrchestrationContext } from '../../createMatchPageOrchestrationContext.js'
+import { createLiveMatchPageSessionSink } from '../../createLiveMatchPageSessionSink.js'
+import { resetLiveMatchPageState } from '../../resetLiveMatchPageState.js'
+import { createLivePlayActionChooser } from '../livePlayActionChooser.js'
+import { closeDeckSplay, createMemoryAidState, setMemoryAidEnabled, tapDeck } from '../memoryAidState.js'
+import { isDungeonPresentationTraceEnabled } from '../dungeonPresentationTrace.js'
+import { isDungeonOrchestratorPresentationKind } from '../orchestratorPresentationKinds.js'
+import { usePresentationMotion } from '../usePresentationMotion.js'
+import { evaluateLiveAiTurnPipelineGateForContext } from '../liveAiTurnPipelineGateContext.js'
+import {
+  buildAiTurnPrefetchSkipTrace,
+  buildAiTurnRunSkipTrace,
+  buildAiTurnScheduleSkipTrace,
+} from '../liveAiTurnPipelineGateTrace.js'
+import {
+  buildSeatRecoveryIndicators,
+  isActiveNnSeatRecovering,
+} from '../neuralSeatRecoveryView.js'
+import { handleLivePlayNeuralRecoveryTerminalError } from '../livePlayNeuralRecoveryTerminal.js'
+import {
+  activateLiveMatchShellLifecycle,
+  deactivateLiveMatchShellLifecycle,
+} from './liveMatchShellLifecycle.js'
+
+/**
+ * Live-match session: board, mid-match dialogs, AI pipeline, presentation motion.
+ *
+ * @param {{
+ *   match: import('vue').Ref<object | null>
+ *   debugMode: import('vue').Ref<boolean>
+ *   presentationSpeedProfile: import('vue').WritableComputedRef<string>
+ *   dungeonRunnerSettingsStore: ReturnType<typeof import('../../../stores/dungeonRunnerSettings.js').useDungeonRunnerSettingsStore>
+ *   setup: object
+ *   cloneSetup: (source?: object) => object
+ *   nnRecovery: ReturnType<import('../../nn/recovery.js').createNeuralRuntimeRecoveryCoordinator>
+ *   replayImportText: import('vue').Ref<string>
+ *   replayExportText: import('vue').Ref<string>
+ *   nnDebugTraceText: import('vue').Ref<string>
+ *   nnDebugTraceHistory: import('vue').Ref<unknown[]>
+ *   neuralLoadGateTerminalOpen: import('vue').Ref<boolean>
+ *   matchNeuralLoadGateInFlight: import('vue').Ref<boolean>
+ *   notify: (opts: { type: string, message: string }) => void
+ * }} deps
+ */
+export function useLiveMatchShell(deps) {
+  const match = deps.match
+  const debugMode = deps.debugMode
+
+  function presentationTraceEnabled() {
+    return isDungeonPresentationTraceEnabled()
+  }
+const nnRecovery = deps.nnRecovery
+const seatRecoveryIndicators = ref([])
+/** @type {(() => void) | null} */
+let unsubscribeNnRecovery = null
+let activeSeatRecoveryBlocking = false
+
+function syncSeatRecoveryIndicators() {
+  const seats = match.value?.state?.seats ?? []
+  seatRecoveryIndicators.value = buildSeatRecoveryIndicators({ seats, recovery: nnRecovery })
+}
+
+function resolveActiveSeatRecoveryBlocking() {
+  return match.value?.state
+    ? isActiveNnSeatRecovering({ state: match.value.state, recovery: nnRecovery })
+    : false
+}
+
+function applySeatRecoveryBlockingTransition(blocking) {
+  if (!activeSeatRecoveryBlocking && blocking) {
+    cancelAiTurnPrefetch()
+  }
+  activeSeatRecoveryBlocking = blocking
+}
+
+function onNnRecoveryChanged() {
+  syncSeatRecoveryIndicators()
+  applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
+  if (!liveMatchShellLifecycleActive) return
+  scheduleAiTurnIfReady()
+}
+
+function logNnRecoveryTrace(modelId, step, detail = {}) {
+  if (!debugMode.value) return
+  aiTurnTrace({ modelId })(`recovery.${step}`, {
+    loadAttempts: nnRecovery.getLoadAttempts(modelId),
+    inferAttempts: nnRecovery.getInferAttempts(modelId),
+    loadBackend: nnRecovery.getBackendPreference(modelId, 'load'),
+    inferBackend: nnRecovery.getBackendPreference(modelId, 'infer'),
+    ...detail,
+  })
+}
+
+const chooseNnActionWithRecovery = createChooseNnActionWithRecovery({
+  recovery: nnRecovery,
+  onRecoveryBegin: (modelId) => logNnRecoveryTrace(modelId, 'begin'),
+  onRecoveryAttempt: (detail) => logNnRecoveryTrace(detail.modelId, 'attempt', detail),
+  onRecoverySettled: (modelId) => logNnRecoveryTrace(modelId, 'settled'),
+})
+
+function buildLivePlayChooserDeps(extra = {}) {
+  return {
+    nnRecovery,
+    ensureNnModelsReady,
+    nnRuntimeOptions,
+    chooseNnActionWithRecovery,
+    ...extra,
+  }
+}
+
+function evaluatePageAiTurnPipelineGate({ runToken = '', timerPending = false } = {}) {
+  return evaluateLiveAiTurnPipelineGateForContext({
+    matchState: match.value?.state ?? null,
+    humanSeatId: humanSeatId.value,
+    isHumanTurn: isHumanTurn.value,
+    hasMatch: !!match.value,
+    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
+    matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
+    aiTurnInFlight,
+    headlessCompletionInFlight: headlessCompletionInFlight.value,
+    deferredPostDungeonState: deferredPostDungeonState.value,
+    gameplayInputLocked: gameplayInputLocked.value,
+    recovery: nnRecovery,
+    runToken,
+    lastAppliedAiTurnToken,
+    timerPending,
+    pickAdventurerNnEnabled: isNnAdventurerPickEnabled(),
+  })
+}
+const replayImportText = deps.replayImportText
+const replayExportText = deps.replayExportText
+const nnDebugTraceText = deps.nnDebugTraceText
+const nnDebugTraceHistory = deps.nnDebugTraceHistory
+const presentationOrchestrator = createPresentationOrchestrator()
+const dungeonRunnerSettingsStore = deps.dungeonRunnerSettingsStore
+
+const presentationSpeedProfile = deps.presentationSpeedProfile
+const activePresentation = ref(null)
+const boardShellRef = ref(null)
+const heroCardSlotRef = ref(null)
+const dungeonCardMotionWrap = ref(null)
+const dungeonCardFaceRef = ref(null)
+const deckBadgeRef = ref(null)
+const dungeonPileMotionAnchorRef = ref(null)
+const heroChangeInterstitialOverlayRef = ref(null)
+const presentationFlightLayerRef = ref(null)
+const biddingEquipmentBadgeRefs = reactive({})
+
+function domEl(componentOrEl) {
+  if (!componentOrEl) return null
+  if (componentOrEl.nodeType === 1) return componentOrEl
+  const inner = componentOrEl.$el
+  return inner?.nodeType === 1 ? inner : null
+}
+
+/** `defineExpose`d Refs from child components; QBadge roots via {@link domEl}. */
+function unwrapMotionDom(exposedMaybeRef) {
+  if (exposedMaybeRef == null) return null
+  const el = unref(exposedMaybeRef)
+  return el?.nodeType === 1 ? el : null
+}
+
+function bindBiddingEquipmentBadgeRef(equipmentId, componentOrEl) {
+  const node = domEl(componentOrEl)
+  if (node) biddingEquipmentBadgeRefs[equipmentId] = node
+  else delete biddingEquipmentBadgeRefs[equipmentId]
+}
+
+// GSAP: most beats tween `boardShell` (shared placeholder) plus kind-specific refs — `DUNGEON_REVEAL` tweens `dungeonCardWrap` (opacity / y / scale) and `dungeonCardFlipAxis` (`rotationY` flip); damage / neutralize / continue use `dungeonCardWrap` + shell; `DUNGEON_OUTCOME` tweens the wrap only (no shell tween); teardown clears wrap + shell after that beat for neutral baseline (#66).
+// `HERO_CHANGE_INTERSTITIAL` → overlay only; bot bidding → `dungeonCardWrap` / `deckBadge` / equipment; neutralize + sacrifice use `presentationFlightLayer` + `equipment_*` (see presentationMotionRegistry.js).
+// Window resize during fragile motion (ghost flight #68, or dungeon reveal flip) swaps to shell+card-only tweens for the rest of that beat (#71); orchestrator `remainingMs` is not recomputed on resize (#68).
+usePresentationMotion({
+  activePresentation,
+  getMotionRefs: (head) => {
+    if (head?.kind === 'HERO_CHANGE_INTERSTITIAL') {
+      return {
+        heroChangeInterstitialOverlay: heroChangeInterstitialOverlayRef.value,
+        boardShell: boardShellRef.value,
+      }
+    }
+    const base = {
+      boardShell: boardShellRef.value,
+      dungeonCardWrap: dungeonCardMotionWrap.value,
+      dungeonCardFlipAxis: unwrapMotionDom(dungeonCardFaceRef.value?.dungeonCardFlipAxis),
+      deckBadge: domEl(deckBadgeRef.value),
+      dungeonPileBadge: dungeonPileMotionAnchorRef.value,
+      presentationFlightLayer: presentationFlightLayerRef.value,
+      presentationGhostTarget: heroCardSlotRef.value,
+    }
+    if (
+      presentationTraceEnabled() &&
+      (head?.kind === 'DUNGEON_REVEAL' || head?.kind === 'BIDDING_DRAW')
+    ) {
+      const snapEl = (el) => {
+        if (!el || typeof el.getBoundingClientRect !== 'function') return { present: false }
+        const r = el.getBoundingClientRect()
+        return {
+          present: true,
+          tag: el.tagName,
+          w: Math.round(r.width * 100) / 100,
+          h: Math.round(r.height * 100) / 100,
+          cx: Math.round((r.left + r.width / 2) * 100) / 100,
+          cy: Math.round((r.top + r.height / 2) * 100) / 100,
+        }
+      }
+      const deckNode = domEl(deckBadgeRef.value)
+      console.log('[DungeonRunner][card-flight][refs]', {
+        kind: head.kind,
+        id: head.id,
+        durationMs: head.durationMs,
+        dungeonCardWrap: snapEl(base.dungeonCardWrap),
+        dungeonPileAnchor: snapEl(base.dungeonPileBadge),
+        deckBadgeResolved: snapEl(base.deckBadge),
+        dungeonCardFlipAxis: snapEl(base.dungeonCardFlipAxis),
+        deckBadgeRawDomEl: snapEl(deckNode),
+        refsBound: {
+          dungeonPileMotionAnchorRef: !!dungeonPileMotionAnchorRef.value,
+          deckBadgeRef: !!deckBadgeRef.value,
+          dungeonCardMotionWrap: !!dungeonCardMotionWrap.value,
+          dungeonCardFaceRef: !!dungeonCardFaceRef.value,
+        },
+      })
+    }
+    if (head?.kind !== 'BIDDING_SACRIFICE' && head?.kind !== 'DUNGEON_NEUTRALIZE') return base
+    const ids = head?.payload?.responsibleEquipmentIds ?? head?.payload?.consumedEquipmentIds ?? []
+    const extra = {}
+    for (const id of ids) {
+      const node = biddingEquipmentBadgeRefs[id]
+      if (node?.nodeType === 1) extra[`equipment_${id}`] = node
+    }
+    return { ...base, ...extra }
+  },
+})
+const activePresentationLabel = ref('')
+const equipmentModalOpen = ref(false)
+const selectedEquipmentTokenId = ref(null)
+const neuralLoadGateTerminalOpen = deps.neuralLoadGateTerminalOpen
+const neuralRefreshTerminalOpen = ref(false)
+const matchNeuralLoadGateInFlight = deps.matchNeuralLoadGateInFlight
+const confirmationDialogOpen = ref(false)
+const confirmationDialogTitle = ref('Confirm')
+const confirmationDialogMessage = ref('')
+const confirmationDialogOkLabel = ref('OK')
+const confirmationDialogCancelLabel = ref('Cancel')
+let confirmationDialogResolve = null
+const vorpalDialogOpen = ref(false)
+const selectedVorpalSpecies = ref(null)
+const memoryAidState = ref(createMemoryAidState({ enabled: dungeonRunnerSettingsStore.memoryAidEnabled }))
+const previousVisibleState = ref(null)
+const dismissedDungeonRun = ref(null)
+const equipmentRemainingAtResolution = ref(null)
+const deferredPostDungeonState = ref(null)
+let presentationTimerId = null
+let aiTurnTimerId = null
+let liveMatchShellLifecycleActive = false
+let autoResolveTimerId = null
+let aiTurnInFlight = false
+let lastAppliedAiTurnToken = null
+let presentationInputWasLocked = false
+let lastPresentationTraceKey = null
+let lastScheduleSkipKey = ''
+let lastPrimeSkipTraceKey = ''
+/** @type {Promise<void> | null} */
+let nnModelsWarmPromise = null
+
+const liveMatchPageSessionSink = createLiveMatchPageSessionSink({
+  match,
+  setNnModelsWarmPromise: (promise) => {
+    nnModelsWarmPromise = promise
+  },
+  resetAiTurnPrefetch,
+  setLastAppliedAiTurnTokenNull: () => {
+    lastAppliedAiTurnToken = null
+  },
+  setPresentationInputWasLockedFalse: () => {
+    presentationInputWasLocked = false
+  },
+  deferredPostDungeonState,
+  nnDebugTraceText,
+  nnDebugTraceHistory,
+  presentationOrchestrator,
+  syncPresentationLabel,
+  neuralLoadGateTerminalOpen,
+  clearCurrentMatch,
+  storage: window.localStorage,
+})
+
+const AI_TURN_SCHEDULE_DELAY_MS = 300
+
+function aiTurnTrace(baseContext = {}) {
+  return createPipelineStepLogger('AITurn', debugMode.value, {
+    matchId: match.value?.id ?? null,
+    ...baseContext,
+  })
+}
+
+const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
+  'gameplay-locked',
+  'timer-pending',
+  'in-flight',
+  'already-applied-token',
+  'deferred-post-dungeon',
+  'headless-completion',
+])
+
+function logAiTurnScheduleSkip(reason, detail = {}) {
+  if (!debugMode.value) return
+  const key = `${reason}:${detail.runToken ?? detail.activeKind ?? ''}`
+  if (SCHEDULE_SKIP_THROTTLE_REASONS.has(reason) && key === lastScheduleSkipKey) return
+  lastScheduleSkipKey = key
+  console.warn('[DungeonRunner][AITurn][Schedule] skip', reason, detail)
+}
+
+function logAiTurnPrimeSkip(reason, detail = {}) {
+  if (!debugMode.value) return
+  const key = `${reason}:${detail.runToken ?? detail.phase ?? detail.seatId ?? detail.roleType ?? ''}`
+  if (key === lastPrimeSkipTraceKey) return
+  lastPrimeSkipTraceKey = key
+  aiTurnTrace()('prefetch.prime.skip', { reason, ...detail })
+}
+
+function scheduleAiTurnOnPresentationTick() {
+  if (!liveMatchShellLifecycleActive) return
+  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value || headlessCompletionInFlight.value) {
+    return
+  }
+  scheduleAiTurnIfReady()
+}
+const uiAssets = dungeonRunnerAssetPack
+
+watch(presentationSpeedProfile, (next) => {
+  presentationOrchestrator.setSpeedProfile(next)
+  syncPresentationLabel()
+  triggerRef(activePresentation)
+  if (match.value) {
+    match.value = { ...match.value, presentationSpeedProfile: next }
+    persistCurrentMatch(window.localStorage, match.value)
+  }
+})
+
+watch(
+  () => dungeonRunnerSettingsStore.memoryAidEnabled,
+  (enabled) => {
+    memoryAidState.value = setMemoryAidEnabled(memoryAidState.value, enabled)
+  },
+  { immediate: true },
+)
+
+const humanSeatId = computed(() => match.value?.state.seats.find((seat) => seat.role.type === 'human')?.id ?? null)
+const isHumanTurn = computed(
+  () => !!match.value && humanSeatId.value != null && match.value.state.turn.activeSeatId === humanSeatId.value,
+)
+const legalActions = computed(() => {
+  if (!match.value || !isHumanTurn.value) return []
+  return getLegalActions(match.value.state, { seatId: humanSeatId.value })
+})
+const visibleLegalActions = computed(() =>
+  filterVisibleLegalActions({
+    phase: match.value?.state?.phase ?? null,
+    legalActions: legalActions.value,
+  }),
+)
+const visiblePrimaryActions = computed(() =>
+  visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE'),
+)
+/** Matches engine pick-adventurer legal action order. */
+const HERO_CHOICE_ACTION_ORDER = ['WARRIOR', 'BARBARIAN', 'MAGE', 'ROGUE']
+const showHeroPickActionGrid = computed(() => {
+  const actions = visiblePrimaryActions.value
+  if (actions.length !== HERO_CHOICE_ACTION_ORDER.length) return false
+  return actions.every((a) => a.type === 'CHOOSE_NEXT_ADVENTURER')
+})
+const heroPickActionsOrdered = computed(() => {
+  if (!showHeroPickActionGrid.value) return []
+  const byHero = new Map(visiblePrimaryActions.value.map((a) => [a.hero, a]))
+  return HERO_CHOICE_ACTION_ORDER.map((hero) => byHero.get(hero)).filter(Boolean)
+})
+const showActionPane = computed(
+  () =>
+    !!activePresentationLabel.value ||
+    (isHumanTurn.value &&
+      (visiblePrimaryActions.value.length > 0 || dungeonOutcomeTransitionControls.value.length > 0)),
+)
+const biddingSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'))
+const biddingNonSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'))
+const gameplayInputLocked = ref(false)
+const headlessCompletionInFlight = ref(false)
+const visibleState = computed(() => {
+  if (!match.value || !humanSeatId.value) return null
+  return getPlayerView(match.value.state, { seatId: humanSeatId.value })
+})
+const dungeonOutcomeAckPending = computed(() =>
+  isDungeonOutcomeDialogOpen({
+    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+    dismissedDungeonRun: dismissedDungeonRun.value,
+  }),
+)
+const dungeonEquipmentTokens = computed(() =>
+  buildDungeonEquipmentTokenView({
+    inPlayEquipmentIds: visibleState.value?.dungeon?.inPlayEquipmentIds ?? [],
+    legalActions: legalActions.value,
+  }),
+)
+const dungeonResolutionView = computed(() =>
+  createDungeonResolutionViewModel({
+    visibleState: visibleState.value ?? {},
+    previousVisibleState: previousVisibleState.value ?? {},
+    legalActions: legalActions.value,
+    activeAnimation: activePresentation.value,
+  }),
+)
+const showDungeonStage = computed(() => {
+  if (match.value?.state?.phase === 'dungeon') return true
+  if (isDungeonOrchestratorPresentationKind(activePresentation.value?.kind ?? null)) return true
+  return dungeonOutcomeAckPending.value
+})
+const dungeonStageView = computed(() =>
+  createDungeonResolutionViewModel({
+    visibleState: visibleState.value ?? {},
+    previousVisibleState: previousVisibleState.value ?? {},
+    legalActions: legalActions.value,
+    activeAnimation: activePresentation.value,
+    preserveMonsterCardUntilRunAck: dungeonOutcomeAckPending.value,
+  }),
+)
+const dungeonStageAnimationClass = computed(() => dungeonStageClassForKind(activePresentation.value?.kind ?? null))
+const dungeonOutcomeTransitionControls = computed(() =>
+  buildDungeonOutcomeTransitionControls({
+    phase: match.value?.state?.phase ?? null,
+    gameplayInputLocked: gameplayInputLocked.value,
+    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
+    autoAdvanceAction: dungeonResolutionView.value.autoAdvanceAction,
+  }),
+)
+const actionableEquipmentIds = computed(() => new Set(dungeonResolutionView.value.highlightedEquipmentIds))
+const boardEquipmentTokens = computed(() => {
+  const dungeonTokenById = new Map(dungeonEquipmentTokens.value.map((token) => [token.equipmentId, token]))
+  const isDungeonPhase = match.value?.state?.phase === 'dungeon'
+  const hasActionable = actionableEquipmentIds.value.size > 0
+  return biddingBoard.value.secondary.equipment.map((equipment) => {
+    const dungeonToken = dungeonTokenById.get(equipment.equipmentId)
+    const removed =
+      equipment.removed ||
+      equipment.consumed ||
+      (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
+    const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
+    const appearance = equipmentTokenAppearance(equipment.equipmentId)
+    return {
+      equipmentId: equipment.equipmentId,
+      ariaLabel: equipmentShortName(equipment.equipmentId),
+      symbolRuntimePath: dungeonRunnerEquipmentSymbolRuntimePath(appearance.symbolKey),
+      equipmentOverlay: appearance.overlay,
+      removed,
+      glow: isDungeonPhase ? (dungeonToken?.glow ?? false) : false,
+      pulse: actionable,
+      deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
+      canUseNow: dungeonToken?.canUseNow ?? false,
+      hasModal: true,
+    }
+  })
+})
+const selectedEquipmentModalView = computed(() => {
+  if (!selectedEquipmentTokenId.value) return null
+  return createDungeonEquipmentModalView({
+    equipmentId: selectedEquipmentTokenId.value,
+    legalActions: legalActions.value,
+  })
+})
+const vorpalPromptView = computed(() =>
+  createVorpalDeclarationPromptView({
+    isHumanTurn: isHumanTurn.value,
+    gameplayInputLocked: gameplayInputLocked.value,
+    phase: match.value?.state?.phase ?? null,
+    subphase: match.value?.state?.dungeon?.subphase ?? null,
+    legalActions: legalActions.value,
+    memoryAidEnabled: memoryAidState.value.enabled,
+    viewerOwnPileAdds: visibleState.value?.playerOwnPileAdds?.[humanSeatId.value ?? ''] ?? [],
+  }),
+)
+const vorpalSelectOptions = computed(() => {
+  const pv = vorpalPromptView.value
+  const counts = pv.vorpalSpeciesOwnPileCounts
+  return pv.speciesOptions.map((species) => {
+    const n = counts?.[species] ?? 0
+    const label = n > 0 ? `${species} (${n})` : species
+    return { label, value: species }
+  })
+})
+const biddingBoard = computed(() =>
+  createBiddingBoardViewModel({
+    state: match.value?.state ?? null,
+    visibleState: visibleState.value,
+    activeAnimation: activePresentation.value,
+    viewerSeatId: humanSeatId.value,
+    settings: {
+      memoryAidEnabled: memoryAidState.value.enabled,
+    },
+  }),
+)
+const seatRunTrackerRows = computed(() => {
+  const recoveryBySeatId = new Map(
+    seatRecoveryIndicators.value.map((entry) => [entry.seatId, entry]),
+  )
+  return biddingBoard.value.secondary.seats.map((row) => {
+    const scoreboard = match.value?.state?.scoreboard ?? {}
+    const score = scoreboard[row.seatId] ?? {}
+    const successes = Math.max(0, Number(score.successes ?? 0))
+    const failures = Math.max(0, 2 - Number(score.lives ?? 2))
+    const recovery = recoveryBySeatId.get(row.seatId)
+    return {
+      seatId: row.seatId,
+      label: row.label,
+      passed: row.passed,
+      isActive: row.isActive,
+      successes,
+      failures,
+      recovering: recovery?.recovering ?? false,
+      recoveryTestId: recovery?.testId ?? null,
+      ariaLabel: `${row.label}: ${successes} successful run${successes === 1 ? '' : 's'}, ${failures} failed run${failures === 1 ? '' : 's'}`,
+    }
+  })
+})
+const biddingCardEmpty = computed(
+  () =>
+    match.value?.state?.phase === 'bidding' &&
+    !showDungeonStage.value &&
+    biddingBoard.value.primaryCard.variant === 'empty',
+)
+const monsterCardSlotEmpty = computed(() => {
+  if (showDungeonStage.value) return dungeonStageView.value.monster.visibility === 'empty'
+  return biddingCardEmpty.value
+})
+const biddingStageSpecies = computed(() => {
+  if (showDungeonStage.value) return null
+  if (match.value?.state?.phase !== 'bidding') return null
+  if (activePresentation.value?.kind === 'BIDDING_DRAW') return null
+  return biddingBoard.value.primaryCard.variant === 'revealed' ? biddingBoard.value.primaryCard.monsterCard : null
+})
+const biddingStageFaceDown = computed(() => {
+  if (showDungeonStage.value) return true
+  if (match.value?.state?.phase !== 'bidding') return true
+  if (activePresentation.value?.kind === 'BIDDING_DRAW') return true
+  return biddingBoard.value.primaryCard.variant !== 'revealed'
+})
+const heroChangeInterstitialView = computed(() => {
+  if (activePresentation.value?.kind !== 'HERO_CHANGE_INTERSTITIAL') return null
+  const payload = activePresentation.value?.payload
+  if (!payload?.heroAfter) return null
+  const seats = match.value?.state?.seats ?? []
+  const actorSeatId = payload.actorSeatId ?? null
+  const actorLabel =
+    seats.find((seat) => seat.id === actorSeatId)?.label ?? actorSeatId ?? 'Unknown'
+  const chosen = getHeroIdentity(payload.heroAfter)
+  return {
+    headline: adventurerChoiceHeadline(actorLabel, payload.heroAfter),
+    chosen,
+  }
+})
+const heroChangeInterstitialAriaLabel = computed(() => heroChangeInterstitialView.value?.headline ?? '')
+const deckSplayOpen = computed({
+  get() {
+    return memoryAidState.value.deckSplayOpen
+  },
+  set(open) {
+    memoryAidState.value = open ? tapDeck(memoryAidState.value) : closeDeckSplay(memoryAidState.value)
+  },
+})
+const dungeonOutcomeSummary = computed(() =>
+  buildDungeonOutcomeSummary({
+    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+    seats: match.value?.state?.seats ?? [],
+    equipmentRemainingAtResolution: equipmentRemainingAtResolution.value,
+  }),
+)
+const dungeonOutcomeToneClass = computed(() =>
+  dungeonOutcomeSummary.value?.resultLabel === 'Success' ? 'dr-outcome--success' : 'dr-outcome--failure',
+)
+const dungeonOutcomeMessage = computed(() =>
+  dungeonOutcomeSummary.value?.resultLabel === 'Success'
+    ? 'Clean run. The dungeon is cleared.'
+    : 'The run failed.',
+)
+const dungeonOutcomeDialogOpen = computed({
+  get() {
+    return shouldShowDungeonOutcomeDialog({
+      headlessCompletionInFlight: headlessCompletionInFlight.value,
+      gameplayInputLocked: gameplayInputLocked.value,
+      lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
+      dismissedDungeonRun: dismissedDungeonRun.value,
+    })
+  },
+  set(open) {
+    if (open) return
+    continueFromDungeonOutcome()
+  },
+})
+const humanGameplayBlocked = computed(() =>
+  isHumanGameplayBlocked({
+    gameplayInputLocked: gameplayInputLocked.value,
+    dungeonOutcomeDialogOpen: dungeonOutcomeDialogOpen.value,
+    headlessCompletionInFlight: headlessCompletionInFlight.value,
+    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
+  }),
+)
+const equipmentModalActionsDisabled = computed(() =>
+  isEquipmentModalActionsDisabled({
+    humanGameplayBlocked: humanGameplayBlocked.value,
+    isHumanTurn: isHumanTurn.value,
+  }),
+)
+function applyBootstrappedMatchSession(matchEnvelope, pace) {
+  dungeonRunnerSettingsStore.setAnimationPace(pace)
+  match.value = matchEnvelope
+  syncSeatRecoveryIndicators()
+  activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
+  deferredPostDungeonState.value = null
+  presentationOrchestrator.clear()
+  presentationSpeedProfile.value = pace
+  presentationOrchestrator.setSpeedProfile(pace)
+  nnModelsWarmPromise = Promise.resolve()
+  syncPresentationLabel()
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof import('../../matchPageOrchestration.js').bootstrapCurrentMatchFromStorage>>} result
+ */
+function processBootstrappedSession(result) {
+  if (result.kind === 'no-saved-match') return
+  if (result.kind === 'setup-terminal') {
+    resetForSetupTerminal()
+    return
+  }
+  applyBootstrappedMatchSession(result.match, result.presentationSpeedProfile)
+  if (result.kind === 'refresh-terminal') {
+    neuralRefreshTerminalOpen.value = true
+    return
+  }
+  void maybeRunHeadlessMatchCompletion()
+}
+
+function kickMatchAutomation() {
+  if (!liveMatchShellLifecycleActive) return
+  scheduleAiTurnIfReady()
+  scheduleHumanAutoResolveIfReady()
+}
+
+watch(
+  () => match.value?.state,
+  (state) => {
+    if (!match.value || !state) return
+    syncSeatRecoveryIndicators()
+    applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
+    persistCurrentMatch(window.localStorage, match.value)
+    if (!liveMatchShellLifecycleActive) return
+    scheduleAiTurnIfReady()
+    scheduleHumanAutoResolveIfReady()
+  },
+  { deep: true },
+)
+
+watch(
+  () => match.value?.state?.lastDungeonRun ?? null,
+  (run) => {
+    const update = resolveLastDungeonRunWatcherUpdate(run, match.value?.state?.centerEquipment)
+    if ('dismissedDungeonRun' in update) {
+      dismissedDungeonRun.value = update.dismissedDungeonRun
+      equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
+      return
+    }
+    equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
+  },
+  { immediate: true },
+)
+
+watch(
+  () => vorpalPromptView.value.open,
+  (open) => {
+    if (!open) {
+      vorpalDialogOpen.value = false
+      selectedVorpalSpecies.value = null
+      return
+    }
+    vorpalDialogOpen.value = true
+    const firstSpecies = vorpalPromptView.value.speciesOptions[0] ?? null
+    if (!selectedVorpalSpecies.value || !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)) {
+      selectedVorpalSpecies.value = firstSpecies
+    }
+  },
+)
+
+function resetForSetupTerminal() {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
+    clearMatch: true,
+    openNeuralLoadGateTerminal: true,
+  })
+}
+
+function resetForFreshMatchEntry() {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
+    warmModelsResolved: true,
+  })
+}
+
+function resetForBackToSetup() {
+  resetLiveMatchPageState(liveMatchPageSessionSink, {
+    clearMatch: true,
+    clearPersistedMatch: true,
+  })
+}
+
+const matchPageOrchestrationCtx = createMatchPageOrchestrationContext({
+  storage: window.localStorage,
+  recovery: nnRecovery,
+  loadModel: loadNnModel,
+  setMatchNeuralLoadGateInFlight: (inFlight) => {
+    matchNeuralLoadGateInFlight.value = inFlight
+  },
+  clearCurrentMatch,
+  persistCurrentMatch,
+  applySetupSnapshot,
+  setupTarget: deps.setup,
+  cloneSetup: deps.cloneSetup,
+  onSetupTerminal: () => {
+    resetForSetupTerminal()
+  },
+})
+
+async function runLivePageMatchEntryGate(setupSnapshot) {
+  return runMatchEntryNeuralLoadGateForPage(matchPageOrchestrationCtx, {
+    setupSnapshot,
+    releaseInFlightAfterGate: false,
+  })
+}
+
+async function ensureNnModelsReady() {
+  await nnModelsWarmPromise?.catch(() => {})
+}
+
+function reloadPageForNeuralRefreshTerminal() {
+  window.location.reload()
+}
+
+function handleNeuralRecoveryTerminalError(error) {
+  const result = handleLivePlayNeuralRecoveryTerminalError({
+    error,
+    match: match.value,
+    recovery: nnRecovery,
+    storage: window.localStorage,
+    persistCurrentMatch,
+    restoreSetup: (setupSnapshot) => {
+      matchPageOrchestrationCtx.applySetupTerminal(deps.cloneSetup(setupSnapshot))
+    },
+  })
+  if (!result.handled) return false
+  if (result.action === 'refresh-dialog') {
+    match.value = result.match
+    neuralRefreshTerminalOpen.value = true
+    logNnRecoveryTrace(result.trace.modelId, 'terminal', {
+      terminal: result.trace.terminal,
+      failureKind: result.trace.failureKind,
+    })
+  }
+  return true
+}
+
+function takeHumanAction(action) {
+  if (!match.value || !humanSeatId.value) {
+    return
+  }
+  resetAiTurnPrefetch()
+  if (humanGameplayBlocked.value) {
+    return
+  }
+  if (autoResolveTimerId) {
+    window.clearTimeout(autoResolveTimerId)
+    autoResolveTimerId = null
+  }
+  if (equipmentModalOpen.value) equipmentModalOpen.value = false
+  const prevState = match.value.state
+  previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
+  const result = applyAction(prevState, action, { seatId: humanSeatId.value })
+  if (!result.ok) {
+    return
+  }
+  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
+  if (deferExit) {
+    deferredPostDungeonState.value = result.state
+    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
+  } else {
+    deferredPostDungeonState.value = null
+    match.value = { ...match.value, state: result.state }
+  }
+  enqueuePresentationTransition(prevState, result.state, action, humanSeatId.value, 'human')
+}
+
+function onDeckTap() {
+  memoryAidState.value = tapDeck(memoryAidState.value)
+}
+
+function onCloseDeckSplay() {
+  memoryAidState.value = closeDeckSplay(memoryAidState.value)
+}
+
+function settleConfirmationDialog(result) {
+  confirmationDialogOpen.value = false
+  const resolve = confirmationDialogResolve
+  confirmationDialogResolve = null
+  if (typeof resolve === 'function') resolve(result)
+}
+
+function requestConfirmation({ title = 'Confirm', message, okLabel = 'OK', cancelLabel = 'Cancel' }) {
+  if (typeof confirmationDialogResolve === 'function') {
+    confirmationDialogResolve(false)
+    confirmationDialogResolve = null
+  }
+  confirmationDialogTitle.value = title
+  confirmationDialogMessage.value = message
+  confirmationDialogOkLabel.value = okLabel
+  confirmationDialogCancelLabel.value = cancelLabel
+  confirmationDialogOpen.value = true
+  return new Promise((resolve) => {
+    confirmationDialogResolve = resolve
+  })
+}
+
+function onConfirmationDialogOk() {
+  settleConfirmationDialog(true)
+}
+
+function onConfirmationDialogCancel() {
+  settleConfirmationDialog(false)
+}
+
+function openEquipmentModal(token) {
+  if (shouldRejectEquipmentTokenTap({ hasModal: token?.hasModal, humanGameplayBlocked: humanGameplayBlocked.value })) return
+  selectedEquipmentTokenId.value = token.equipmentId
+  equipmentModalOpen.value = true
+}
+
+function takeEquipmentUseAction() {
+  if (equipmentModalActionsDisabled.value || !selectedEquipmentModalView.value?.useAction) return
+  takeHumanAction(selectedEquipmentModalView.value.useAction)
+}
+
+function continueFromEquipmentModal() {
+  if (!equipmentModalActionsDisabled.value && selectedEquipmentModalView.value?.continueAction) {
+    takeHumanAction(selectedEquipmentModalView.value.continueAction)
+    return
+  }
+  equipmentModalOpen.value = false
+}
+
+async function continueFromDungeonOutcome() {
+  const run = match.value?.state?.lastDungeonRun
+  if (!run) return
+  dismissedDungeonRun.value = dismissDungeonRunForOutcomeDialog(run)
+  if (deferredPostDungeonState.value) {
+    match.value = { ...match.value, state: deferredPostDungeonState.value }
+    deferredPostDungeonState.value = null
+  }
+  presentationOrchestrator.flushPostDungeonOutcomeAnimations()
+  syncPresentationLabel()
+  await maybeRunHeadlessMatchCompletion()
+}
+
+function teardownForHeadlessMatchCompletion() {
+  if (aiTurnTimerId) {
+    window.clearTimeout(aiTurnTimerId)
+    aiTurnTimerId = null
+  }
+  if (autoResolveTimerId) {
+    window.clearTimeout(autoResolveTimerId)
+    autoResolveTimerId = null
+  }
+  resetAiTurnPrefetch()
+  abandonScheduledInferenceQueue()
+  presentationOrchestrator.clear()
+  deferredPostDungeonState.value = null
+  lastAppliedAiTurnToken = null
+  const run = match.value?.state?.lastDungeonRun
+  if (run) dismissedDungeonRun.value = run
+}
+
+function createPageHeadlessCompletionFlightGate() {
+  return {
+    get inFlight() {
+      return headlessCompletionInFlight.value
+    },
+    tryStart() {
+      if (headlessCompletionInFlight.value) return false
+      headlessCompletionInFlight.value = true
+      return true
+    },
+    finish() {
+      headlessCompletionInFlight.value = false
+    },
+  }
+}
+
+async function maybeRunHeadlessMatchCompletion() {
+  try {
+    const result = await runHeadlessMatchCompletionForPage(matchPageOrchestrationCtx, {
+      match: match.value,
+      humanPlayerSeatId: humanSeatId.value,
+      chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
+      gate: createPageHeadlessCompletionFlightGate(),
+      teardown: teardownForHeadlessMatchCompletion,
+    })
+
+    if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
+      match.value = result.match
+    }
+    if (result.kind === 'refresh-terminal') {
+      neuralRefreshTerminalOpen.value = true
+      logNnRecoveryTrace(result.modelId, 'terminal', {
+        terminal: result.terminal,
+        failureKind: result.failureKind ?? null,
+      })
+    } else if (result.kind === 'setup-terminal') {
+      // applySetupTerminal already ran inside runHeadlessMatchCompletionForPage
+    } else if (result.kind === 'failed' && debugMode.value) {
+      console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
+    }
+  } finally {
+    syncPresentationLabel()
+  }
+}
+
+function confirmVorpalDeclaration() {
+  if (!selectedVorpalSpecies.value) return
+  takeHumanAction({
+    type: 'DECLARE_VORPAL',
+    species: selectedVorpalSpecies.value,
+  })
+}
+
+async function runAiTurn() {
+  const trace = aiTurnTrace()
+  const seatId = match.value?.state?.turn?.activeSeatId ?? null
+  const runToken = match.value
+    ? buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+    : ''
+  const gate = evaluatePageAiTurnPipelineGate({ runToken })
+  if (!gate.mayRunTurn) {
+    const presentationQueueSnapshot = presentationOrchestrator.getQueueSnapshot()
+    const skipTrace = buildAiTurnRunSkipTrace(gate, {
+      runToken,
+      seatId,
+      humanSeatId: humanSeatId.value,
+      phase: match.value?.state?.phase ?? null,
+      activePresentationKind: activePresentation.value?.kind ?? null,
+      queueMs: presentationQueueSnapshot.reduce((sum, item) => sum + item.remainingMs, 0),
+      lastAppliedAiTurnToken,
+    })
+    if (skipTrace) {
+      trace(skipTrace.step, skipTrace.detail)
+    }
+    return
+  }
+  aiTurnInFlight = true
+  try {
+  trace('run.begin', {
+    runToken,
+    phase: match.value.state.phase,
+    seatId,
+    turnNumber: match.value.state.turn.turnNumber,
+    biddingSubphase: match.value.state.bidding?.subphase ?? null,
+    revealedMonsterCard: match.value.state.bidding?.revealedMonsterCard ?? null,
+    dungeonSubphase: match.value.state.dungeon?.subphase ?? null,
+  })
+  const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
+  const roleType = seat?.role?.type
+  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps({
+    tryConsumePrefetch: async ({ runToken: consumeRunToken }) => {
+      const prefetchGate = evaluatePageAiTurnPipelineGate({ runToken: consumeRunToken ?? runToken })
+      return consumeAiTurnPrefetch({
+        runToken: consumeRunToken ?? runToken,
+        mayPrefetch: prefetchGate.mayPrefetch,
+        prefetchSkipReason: prefetchGate.prefetchSkipReason,
+        trace: (step, detail) => trace(step, detail),
+      })
+    },
+  }))
+  let action
+  try {
+    action = await chooseAction({ state: match.value.state, seatId, runToken })
+  } catch (error) {
+    if (handleNeuralRecoveryTerminalError(error)) {
+      trace('run.abort', {
+        reason: 'nn-recovery-terminal',
+        terminal: error.terminal,
+        modelId: error.modelId,
+      })
+      return
+    }
+    throw error
+  }
+  if (!action) {
+    trace('run.abort', { reason: 'no-action' })
+    return
+  }
+  if (!match.value) {
+    trace('run.abort', { reason: 'match-cleared' })
+    return
+  }
+  const currentToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+  if (runToken !== currentToken) {
+    trace('run.abort', { reason: 'stale-token', runToken, currentToken })
+    return
+  }
+  const prevState = match.value.state
+  if (humanSeatId.value) {
+    previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
+  }
+  const result = applyAction(prevState, action, { seatId })
+  if (!result.ok) {
+    trace('run.abort', { reason: 'apply-failed', actionType: action.type })
+    return
+  }
+  lastAppliedAiTurnToken = runToken
+  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
+  if (deferExit) {
+    deferredPostDungeonState.value = result.state
+    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
+  } else {
+    deferredPostDungeonState.value = null
+    match.value = { ...match.value, state: result.state }
+  }
+  trace('run.applied', {
+    actionType: action.type,
+    nextRunToken: buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state }),
+    phaseAfter: match.value.state.phase,
+    turnAfterSeatId: match.value.state.turn.activeSeatId,
+    deferExit,
+  })
+  enqueuePresentationTransition(prevState, result.state, action, seatId, roleType ?? 'randombot')
+  if (debugMode.value) {
+    const snap = presentationOrchestrator.getQueueSnapshot()
+    trace('presentation.enqueued', {
+      queue: snap.map((item) => item.kind),
+      queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
+    })
+  }
+  primeAiTurnPrefetch()
+  } finally {
+    aiTurnInFlight = false
+    trace('run.finally', { inFlight: false })
+  }
+}
+
+function primeAiTurnPrefetch(precomputedGate = null) {
+  const trace = aiTurnTrace()
+  const state = match.value?.state
+  const seatId = state?.turn?.activeSeatId ?? null
+  const seat = state?.seats?.find((candidate) => candidate.id === seatId)
+  const runToken = match.value ? buildAiTurnRunToken({ matchId: match.value.id, state }) : ''
+  const modelId = seat?.role?.type === 'nn' ? seat.role.modelId ?? 'latest' : null
+  const gate = precomputedGate ?? evaluatePageAiTurnPipelineGate({ runToken })
+  if (!gate.mayPrefetch) {
+    const skipTrace = buildAiTurnPrefetchSkipTrace(gate, {
+      seatId,
+      phase: state?.phase ?? null,
+      runToken,
+      modelId,
+      roleType: seat?.role?.type ?? null,
+    })
+    if (skipTrace) {
+      logAiTurnPrimeSkip(skipTrace.reason, skipTrace.detail)
+    }
+    return
+  }
+  lastPrimeSkipTraceKey = ''
+  startAiTurnPrefetch({
+    runToken,
+    mayPrefetch: true,
+    prefetchSkipReason: null,
+    trace: (step, detail) => trace(step, detail),
+    compute: async () => {
+      await ensureNnModelsReady()
+      return chooseNnActionWithRecovery(state, { seatId }, nnRuntimeOptions(modelId))
+    },
+  })
+}
+
+function enqueuePresentationTransition(prevState, nextState, action, actorSeatId, actorRoleType) {
+  const deferPostDungeonOutcomeAck = shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState)
+  presentationOrchestrator.enqueueEngineTransition(
+    {
+      phaseBefore: prevState.phase,
+      phaseAfter: nextState.phase,
+      turnBeforeSeatId: prevState.turn.activeSeatId,
+      turnAfterSeatId: nextState.turn.activeSeatId,
+      dungeonRunResult:
+        prevState.lastDungeonRun?.result === nextState.lastDungeonRun?.result ? null : nextState.lastDungeonRun?.result ?? null,
+      action,
+      actorSeatId,
+      actorRoleType,
+      centerEquipmentBefore: prevState.centerEquipment ?? [],
+      centerEquipmentAfter: nextState.centerEquipment ?? [],
+      heroBefore: prevState.hero,
+      heroAfter: nextState.hero,
+      dungeonBefore: summarizeDungeonForPresentation(prevState.dungeon),
+      dungeonAfter: summarizeDungeonForPresentation(nextState.dungeon),
+      biddingBefore:
+        prevState.phase === MATCH_PHASES.BIDDING
+          ? {
+              revealedMonsterCard: prevState.bidding?.revealedMonsterCard ?? null,
+              revealedBySeatId: prevState.bidding?.revealedBySeatId ?? null,
+            }
+          : null,
+    },
+    { deferPostDungeonOutcomeAck },
+  )
+  if (presentationTraceEnabled()) {
+    const snap = presentationOrchestrator.getQueueSnapshot()
+    console.log('[DungeonRunner][presentation] enqueue', {
+      phase: `${prevState.phase}→${nextState.phase}`,
+      action: action?.type ?? null,
+      actorRole: actorRoleType,
+      queue: snap.map((x) => x.kind),
+    })
+  }
+  syncPresentationLabel()
+}
+
+function summarizeDungeonForPresentation(dungeonState) {
+  if (!dungeonState) return null
+  const discardedRunMonsterIds = Array.isArray(dungeonState.discardedRunMonsters)
+    ? [...dungeonState.discardedRunMonsters]
+    : []
+  const rawDefeatRecord = dungeonState.lastDefeatRecord ?? null
+  const lastDefeatRecord = rawDefeatRecord
+    ? {
+        monsterCard: rawDefeatRecord.monsterCard ?? null,
+        byEquipmentIds: Array.isArray(rawDefeatRecord.byEquipmentIds) ? [...rawDefeatRecord.byEquipmentIds] : [],
+        expendedEquipmentIds: Array.isArray(rawDefeatRecord.expendedEquipmentIds)
+          ? [...rawDefeatRecord.expendedEquipmentIds]
+          : [],
+      }
+    : null
+  return {
+    subphase: dungeonState.subphase ?? null,
+    currentMonster: dungeonState.currentMonster ?? null,
+    remainingMonsterCount: Array.isArray(dungeonState.remainingMonsters)
+      ? dungeonState.remainingMonsters.length
+      : 0,
+    discardedMonsterCount: discardedRunMonsterIds.length,
+    discardedRunMonsterIds,
+    hp: Number.isFinite(dungeonState.hp) ? dungeonState.hp : null,
+    lastDefeatRecord,
+  }
+}
+
+function enrichPresentationForViewer(head) {
+  if (!head) return null
+  const kind = head.kind
+  const basePayload = head.payload && typeof head.payload === 'object' ? { ...head.payload } : {}
+
+  if (kind === 'BIDDING_DRAW') {
+    const actorSeatId = basePayload.actorSeatId ?? null
+    basePayload.shouldFlipFaceAfterArrival = viewerMaySeeBiddingDrawFace({
+      viewerSeatId: humanSeatId.value,
+      actorSeatId,
+    })
+    return { ...head, payload: basePayload }
+  }
+  if (kind === 'BIDDING_ADD') {
+    basePayload.shouldFlipToBackBeforeDungeon = viewerMaySeeAddToDungeonFlipDown({
+      viewerSeatId: humanSeatId.value,
+      actorSeatId: basePayload.actorSeatId ?? null,
+      actorRoleType: basePayload.actorRoleType ?? null,
+    })
+    return { ...head, payload: basePayload }
+  }
+  return head
+}
+
+function syncPresentationLabel() {
+  activePresentation.value = enrichPresentationForViewer(presentationOrchestrator.getActiveAnimation())
+  activePresentationLabel.value = activePresentation.value?.label ?? ''
+  const locked = presentationOrchestrator.isGameplayInputLocked()
+  gameplayInputLocked.value = locked
+  if (presentationInputWasLocked && !locked) {
+    lastScheduleSkipKey = ''
+    lastPrimeSkipTraceKey = ''
+    if (debugMode.value) {
+      const snap = presentationOrchestrator.getQueueSnapshot()
+      aiTurnTrace()('presentation.unlock', {
+        queuedKinds: snap.map((item) => item.kind),
+        isHumanTurn: isHumanTurn.value,
+        activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
+      })
+    }
+    if (liveMatchShellLifecycleActive) {
+      scheduleAiTurnIfReady()
+      scheduleHumanAutoResolveIfReady()
+    }
+  }
+  presentationInputWasLocked = locked
+  if (presentationTraceEnabled()) {
+    const a = activePresentation.value
+    const key = a ? `${a.id}:${a.kind}` : 'idle'
+    if (key !== lastPresentationTraceKey) {
+      lastPresentationTraceKey = key
+      const snap = presentationOrchestrator.getQueueSnapshot()
+      const d = match.value?.state?.dungeon
+      console.log('[DungeonRunner][presentation] active', a?.kind ?? 'idle', {
+        ms: a?.remainingMs ?? null,
+        queued: snap.map((x) => x.kind),
+        inputLocked: gameplayInputLocked.value,
+        engineDungeonCurrentMonster: d?.currentMonster ?? null,
+        engineDungeonSubphase: d?.subphase ?? null,
+        viewMonsterVisibility: showDungeonStage.value ? dungeonStageView.value.monster.visibility : null,
+        viewMonsterSpecies: showDungeonStage.value ? dungeonStageView.value.monster.species : null,
+      })
+    }
+  }
+}
+
+function humanDungeonAutoRevealGapMs() {
+  const pace = presentationSpeedProfile.value
+  const profile = SPEED_PROFILES[pace] ?? SPEED_PROFILES.cinematic
+  return Math.max(0, profile.dungeonContinueMs)
+}
+
+function scheduleAiTurnIfReady() {
+  if (!liveMatchShellLifecycleActive) return
+  if (!match.value || isHumanTurn.value) {
+    return
+  }
+  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
+  const gate = evaluatePageAiTurnPipelineGate({ runToken, timerPending: !!aiTurnTimerId })
+  if (!gate.maySchedule) {
+    const skipTrace = buildAiTurnScheduleSkipTrace(gate, {
+      runToken,
+      phase: match.value?.state?.phase ?? null,
+      activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
+      presentationQueueSnapshot: presentationOrchestrator.getQueueSnapshot(),
+    })
+    if (skipTrace) {
+      logAiTurnScheduleSkip(skipTrace.reason, skipTrace.detail)
+    }
+    if (gate.mayPrefetch) {
+      primeAiTurnPrefetch(gate)
+    }
+    if (gate.scheduleSkipReason === 'model-recovering' || gate.scheduleSkipReason === 'gameplay-locked') {
+      if (aiTurnTimerId) {
+        window.clearTimeout(aiTurnTimerId)
+        aiTurnTimerId = null
+      }
+    }
+    return
+  }
+  primeAiTurnPrefetch(gate)
+  if (debugMode.value) {
+    aiTurnTrace()('schedule.timer-armed', { runToken, delayMs: AI_TURN_SCHEDULE_DELAY_MS })
+  }
+  aiTurnTimerId = window.setTimeout(() => {
+    aiTurnTimerId = null
+    if (debugMode.value) aiTurnTrace()('schedule.timer-fired', { runToken })
+    void runAiTurn()
+  }, AI_TURN_SCHEDULE_DELAY_MS)
+}
+
+function scheduleHumanAutoResolveIfReady() {
+  if (!liveMatchShellLifecycleActive) return
+  if (!match.value) {
+    return
+  }
+  if (humanGameplayBlocked.value) {
+    return
+  }
+  if (!isHumanTurn.value) {
+    return
+  }
+  if (match.value.state.phase !== 'dungeon') {
+    return
+  }
+  if (equipmentModalOpen.value || autoResolveTimerId) {
+    return
+  }
+  const action = dungeonResolutionView.value.autoAdvanceAction
+  const gate = {
+    phase: match.value.state.phase,
+    gameplayInputLocked: gameplayInputLocked.value,
+    isHumanTurn: isHumanTurn.value,
+    legalActions: legalActions.value,
+    autoAdvanceAction: action,
+    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
+    activeAnimationKind: activePresentation.value?.kind ?? null,
+  }
+  if (!shouldAutoResolveDungeonAdvance(gate)) {
+    return
+  }
+  autoResolveTimerId = window.setTimeout(() => {
+    autoResolveTimerId = null
+    const execGate = {
+      phase: match.value?.state?.phase ?? null,
+      gameplayInputLocked: gameplayInputLocked.value,
+      isHumanTurn: isHumanTurn.value,
+      equipmentModalOpen: equipmentModalOpen.value,
+      autoAdvanceAction: action,
+      legalActions: legalActions.value,
+      resolutionStatus: dungeonResolutionView.value.resolutionStatus,
+      activeAnimationKind: activePresentation.value?.kind ?? null,
+    }
+    const ok = shouldExecuteScheduledAutoResolve(execGate)
+    if (!ok) return
+    takeHumanAction(action)
+  }, humanDungeonAutoRevealGapMs())
+}
+
+function nnRuntimeOptions(modelId) {
+  if (!debugMode.value) return { modelId }
+  return {
+    modelId,
+    pipelineTrace: true,
+    debugTrace: true,
+    debugLogger(trace) {
+      const payload = {
+        at: new Date().toISOString(),
+        modelId,
+        seatId: match.value?.state?.turn?.activeSeatId ?? null,
+        trace,
+      }
+      nnDebugTraceHistory.value = [payload, ...nnDebugTraceHistory.value].slice(0, 20)
+      nnDebugTraceText.value = JSON.stringify(payload, null, 2)
+    },
+  }
+}
+
+function actionLabel(action) {
+  return legalActionBoardLabel(action)
+}
+
+function actionKey(action) {
+  const id = [action.equipmentId, action.hero, action.species].filter((x) => x != null && x !== '').join('-')
+  return id ? `${action.type}-${id}` : action.type
+}
+
+function skipActivePresentation() {
+  presentationOrchestrator.skipActiveAnimation()
+  syncPresentationLabel()
+}
+
+function bindRefTarget(refTarget) {
+  return (componentOrEl) => {
+    refTarget.value = componentOrEl ?? null
+  }
+}
+
+const bindBoardShellRef = bindRefTarget(boardShellRef)
+const bindHeroCardSlotRef = bindRefTarget(heroCardSlotRef)
+const bindDungeonCardMotionWrapRef = bindRefTarget(dungeonCardMotionWrap)
+const bindDungeonCardFaceRef = bindRefTarget(dungeonCardFaceRef)
+const bindDeckBadgeRef = bindRefTarget(deckBadgeRef)
+const bindDungeonPileMotionAnchorRef = bindRefTarget(dungeonPileMotionAnchorRef)
+const bindHeroChangeInterstitialOverlayRef = bindRefTarget(heroChangeInterstitialOverlayRef)
+const bindPresentationFlightLayerRef = bindRefTarget(presentationFlightLayerRef)
+
+function mountLiveMatchShell() {
+  if (liveMatchShellLifecycleActive) return
+  liveMatchShellLifecycleActive = true
+  presentationOrchestrator.setSpeedProfile(presentationSpeedProfile.value)
+  const lifecycle = activateLiveMatchShellLifecycle({
+    recovery: nnRecovery,
+    onRecoveryChanged: onNnRecoveryChanged,
+    presentationOrchestrator,
+    tickCallbacks: {
+      syncPresentationLabel,
+      scheduleAiTurnIfReady: scheduleAiTurnOnPresentationTick,
+      scheduleHumanAutoResolveIfReady,
+    },
+  })
+  unsubscribeNnRecovery = lifecycle.unsubscribe
+  presentationTimerId = lifecycle.presentationTimerId
+  if (presentationTraceEnabled()) {
+    console.log(
+      '[DungeonRunner][presentation] trace on — localStorage.setItem("dungeonPresentationTrace","1") — also logs [card-flight] for pile/deck → card motion',
+    )
+  }
+}
+
+function unmountLiveMatchShell() {
+  if (!liveMatchShellLifecycleActive) return
+  liveMatchShellLifecycleActive = false
+  cancelAiTurnPrefetch()
+  deactivateLiveMatchShellLifecycle({
+    unsubscribe: unsubscribeNnRecovery,
+    presentationTimerId,
+    aiTurnTimerId,
+    autoResolveTimerId,
+    confirmationDialogResolve,
+  })
+  unsubscribeNnRecovery = null
+  presentationTimerId = null
+}
+
+function exportReplay() {
+  if (!match.value) return
+  const payload = exportReplayEnvelope({
+    seed: match.value.state.rng.seed,
+    setup: match.value.setup,
+    history: match.value.state.history,
+    presentationSpeedProfile: match.value.presentationSpeedProfile,
+  })
+  replayExportText.value = JSON.stringify(payload, null, 2)
+}
+
+function importReplay() {
+  if (!replayImportText.value.trim()) return
+  try {
+    const parsed = JSON.parse(replayImportText.value)
+    const imported = importReplayEnvelope(parsed)
+    if (!imported.ok) {
+      deps.notify({ type: 'negative', message: 'Replay payload is invalid.' })
+      return
+    }
+    const replayResult = buildStateFromReplayEnvelope(imported.replay)
+    if (!replayResult.ok) {
+      deps.notify({ type: 'negative', message: 'Replay actions are invalid for this seed/setup.' })
+      return
+    }
+    const pace =
+      imported.replay.presentationSpeedProfile === 'brisk' ||
+      imported.replay.presentationSpeedProfile === 'cinematic'
+        ? imported.replay.presentationSpeedProfile
+        : 'cinematic'
+    dungeonRunnerSettingsStore.setAnimationPace(pace)
+    match.value = {
+      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
+      id: `match-${Date.now()}`,
+      setup: imported.replay.setup,
+      state: replayResult.state,
+      history: [],
+      presentationSpeedProfile: pace,
+    }
+    deferredPostDungeonState.value = null
+    presentationSpeedProfile.value = pace
+    presentationOrchestrator.setSpeedProfile(pace)
+    presentationOrchestrator.clear()
+    syncPresentationLabel()
+  } catch {
+    deps.notify({ type: 'negative', message: 'Replay payload must be valid JSON.' })
+  }
+}
+
+  return reactive({
+    match,
+    boardShellRef,
+    heroCardSlotRef,
+    dungeonCardMotionWrap,
+    dungeonCardFaceRef,
+    deckBadgeRef,
+    dungeonPileMotionAnchorRef,
+    heroChangeInterstitialOverlayRef,
+    presentationFlightLayerRef,
+    bindBoardShellRef,
+    bindHeroCardSlotRef,
+    bindDungeonCardMotionWrapRef,
+    bindDungeonCardFaceRef,
+    bindDeckBadgeRef,
+    bindDungeonPileMotionAnchorRef,
+    bindHeroChangeInterstitialOverlayRef,
+    bindPresentationFlightLayerRef,
+    bindBiddingEquipmentBadgeRef,
+    showDungeonStage,
+    dungeonStageView,
+    biddingBoard,
+    seatRunTrackerRows,
+    monsterCardSlotEmpty,
+    dungeonStageAnimationClass,
+    uiAssets,
+    boardEquipmentTokens,
+    openEquipmentModal,
+    onDeckTap,
+    showActionPane,
+    activePresentationLabel,
+    isHumanTurn,
+    biddingSacrificeActions,
+    biddingNonSacrificeActions,
+    actionKey,
+    actionLabel,
+    humanGameplayBlocked,
+    takeHumanAction,
+    showHeroPickActionGrid,
+    heroPickActionsOrdered,
+    getHeroIdentity,
+    visiblePrimaryActions,
+    dungeonOutcomeTransitionControls,
+    gameplayInputLocked,
+    dungeonOutcomeDialogOpen,
+    debugMode,
+    nnDebugTraceHistory,
+    exportReplay,
+    importReplay,
+    replayExportText,
+    replayImportText,
+    nnDebugTraceText,
+    activePresentation,
+    heroChangeInterstitialView,
+    heroChangeInterstitialAriaLabel,
+    skipActivePresentation,
+    dungeonOutcomeSummary,
+    dungeonOutcomeToneClass,
+    dungeonOutcomeMessage,
+    continueFromDungeonOutcome,
+    equipmentModalOpen,
+    selectedEquipmentModalView,
+    equipmentModalActionsDisabled,
+    takeEquipmentUseAction,
+    continueFromEquipmentModal,
+    confirmationDialogOpen,
+    confirmationDialogTitle,
+    confirmationDialogMessage,
+    confirmationDialogOkLabel,
+    confirmationDialogCancelLabel,
+    onConfirmationDialogCancel,
+    onConfirmationDialogOk,
+    neuralRefreshTerminalOpen,
+    reloadPageForNeuralRefreshTerminal,
+    vorpalDialogOpen,
+    vorpalSelectOptions,
+    selectedVorpalSpecies,
+    confirmVorpalDeclaration,
+    deckSplayOpen,
+    onCloseDeckSplay,
+    headlessCompletionInFlight,
+    biddingStageSpecies,
+    biddingStageFaceDown,
+    mountLiveMatchShell,
+    unmountLiveMatchShell,
+    applyBootstrappedMatchSession,
+    processBootstrappedSession,
+    kickMatchAutomation,
+    maybeRunHeadlessMatchCompletion,
+    resetForSetupTerminal,
+    resetForFreshMatchEntry,
+    resetForBackToSetup,
+    matchPageOrchestrationCtx,
+    runLivePageMatchEntryGate,
+    requestConfirmation,
+    buildNewMatchEnvelope,
+  })
+}

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -8,7 +8,7 @@
           dense
           icon="refresh"
           aria-label="Start new match"
-          :disable="liveMatch.dungeonOutcomeDialogOpen"
+          :disable="liveMatch.dialogs.dungeonOutcomeDialogOpen"
           @click="startNewMatchIntentional"
         />
         <q-badge v-if="debugMode" color="negative" label="Debug" />
@@ -20,7 +20,7 @@
         dense
         icon="help"
         aria-label="How to play"
-        :disable="match && liveMatch.dungeonOutcomeDialogOpen"
+        :disable="match && liveMatch.dialogs.dungeonOutcomeDialogOpen"
         @click="helpOpen = true"
       />
       <q-btn
@@ -28,7 +28,7 @@
         dense
         icon="settings"
         aria-label="Dungeon Runner settings"
-        :disable="Boolean(match) && liveMatch.dungeonOutcomeDialogOpen"
+        :disable="Boolean(match) && liveMatch.dialogs.dungeonOutcomeDialogOpen"
       >
         <q-menu anchor="bottom right" self="top right" :offset="[0, 6]">
           <div class="dr-match-settings-menu q-pa-md" style="min-width: 260px">
@@ -57,7 +57,7 @@
     <div class="col dr-scroll q-px-md q-pb-md">
       <PlaySetupShell
         v-if="activePlayShell === PLAY_SHELL.PLAY_SETUP"
-        v-model:setup="setup"
+        :setup="setup"
         :model-options="modelOptions"
         :total-seat-slider="totalSeatSlider"
         :opponent-type-options="opponentTypeOptions"
@@ -92,9 +92,12 @@ import { storeToRefs } from 'pinia'
 import { useQuasar } from 'quasar'
 import { useScopedFullscreen } from '../../features/game-timer/composables/useScopedFullscreen.js'
 import { useDungeonRunnerSettingsStore } from '../../stores/dungeonRunnerSettings.js'
+import {
+  collectPreservedBotLabelsFromMatchState,
+  enterMatchFromSetupSnapshot,
+} from '../../features/dungeon-runner/enterMatchFromSetupSnapshot.js'
 import { clearCurrentMatch } from '../../features/dungeon-runner/persistence/currentMatch.js'
 import { createDefaultSetupConfig } from '../../features/dungeon-runner/setup/config.js'
-import { createMatchSeed } from '../../features/dungeon-runner/setup/seed.js'
 import { shouldEnableDebugOnBoot } from '../../features/dungeon-runner/debug/mode.js'
 import { createNeuralRuntimeRecoveryCoordinator } from '../../features/dungeon-runner/nn/recovery.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
@@ -103,7 +106,6 @@ import { bootstrapCurrentMatchFromStorage } from '../../features/dungeon-runner/
 import DungeonRunnerHelpDialog from '../../features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue'
 import {
   PLAY_SHELL,
-  buildPlayShellSnapshot,
   resolveActivePlayShell,
 } from '../../features/dungeon-runner/ui/playShellResolver.js'
 import PlaySetupShell from '../../features/dungeon-runner/ui/shells/PlaySetupShell.vue'
@@ -201,22 +203,20 @@ const humanSeatId = computed(
 )
 
 const activePlayShell = computed(() =>
-  resolveActivePlayShell(
-    buildPlayShellSnapshot({
-      match: match.value,
-      neuralRefreshTerminalSurfaced: liveMatch.neuralRefreshTerminalOpen,
-      matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
-    }),
-  ),
+  resolveActivePlayShell({
+    match: match.value,
+    neuralRefreshTerminalSurfaced: liveMatch.dialogs.neuralRefreshTerminalOpen,
+    matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
+  }),
 )
 
 watch(
   activePlayShell,
   (shell) => {
     if (shell === PLAY_SHELL.LIVE_MATCH) {
-      liveMatch.mountLiveMatchShell()
+      liveMatch.page.mountLiveMatchShell()
     } else {
-      liveMatch.unmountLiveMatchShell()
+      liveMatch.page.unmountLiveMatchShell()
     }
   },
   { immediate: true },
@@ -229,12 +229,29 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  liveMatch.unmountLiveMatchShell()
+  liveMatch.page.unmountLiveMatchShell()
 })
 
 async function bootstrapDungeonRunnerPage() {
-  const result = await bootstrapCurrentMatchFromStorage(liveMatch.matchPageOrchestrationCtx)
-  liveMatch.processBootstrappedSession(result)
+  const result = await bootstrapCurrentMatchFromStorage(liveMatch.page.matchPageOrchestrationCtx)
+  liveMatch.page.processBootstrappedSession(result)
+}
+
+function liveMatchEntryDeps(overrides = {}) {
+  return {
+    presentationSpeedProfile: presentationSpeedProfile.value,
+    runMatchEntryGate: liveMatch.page.runLivePageMatchEntryGate,
+    resetForSetupTerminal: liveMatch.page.resetForSetupTerminal,
+    resetForFreshMatchEntry: liveMatch.page.resetForFreshMatchEntry,
+    buildNewMatchEnvelope: liveMatch.page.buildNewMatchEnvelope,
+    kickMatchAutomation: liveMatch.page.kickMatchAutomation,
+    setMatchNeuralLoadGateInFlight: (inFlight) => {
+      matchNeuralLoadGateInFlight.value = inFlight
+    },
+    clearCurrentMatch,
+    storage: window.localStorage,
+    ...overrides,
+  }
 }
 
 async function startNewMatch() {
@@ -252,67 +269,38 @@ async function startNewMatch() {
     $q.notify({ type: 'negative', message })
     return
   }
-  const setupSnapshot = cloneSetup()
-  matchNeuralLoadGateInFlight.value = true
-  try {
-    const gateResult = await liveMatch.runLivePageMatchEntryGate(setupSnapshot)
-    if (gateResult.kind === 'setup-terminal') {
-      liveMatch.resetForSetupTerminal()
-      return
-    }
-    clearCurrentMatch(window.localStorage)
-    const seed = createMatchSeed()
-    liveMatch.resetForFreshMatchEntry()
-    match.value = liveMatch.buildNewMatchEnvelope({
-      setupSnapshot,
-      seed,
-      id: `match-${Date.now()}`,
-      presentationSpeedProfile: presentationSpeedProfile.value,
-    })
-  } finally {
-    matchNeuralLoadGateInFlight.value = false
-    liveMatch.kickMatchAutomation()
+  const result = await enterMatchFromSetupSnapshot({
+    setupSnapshot: cloneSetup(),
+    clearPersistedMatch: true,
+    ...liveMatchEntryDeps(),
+  })
+  if (result.kind === 'entered') {
+    match.value = result.match
   }
 }
 
 async function rematch() {
   if (!match.value) return
-  const setupSnapshot = cloneSetup(match.value.setup)
-  matchNeuralLoadGateInFlight.value = true
-  try {
-    const gateResult = await liveMatch.runLivePageMatchEntryGate(setupSnapshot)
-    if (gateResult.kind === 'setup-terminal') {
-      liveMatch.resetForSetupTerminal()
-      return
-    }
-    const preservedBotLabels = match.value.state.seats
-      .filter((seat) => seat.role?.type !== 'human' && seat.label)
-      .map((seat) => seat.label)
-    const seed = createMatchSeed()
-    liveMatch.resetForFreshMatchEntry()
-    match.value = liveMatch.buildNewMatchEnvelope({
-      setupSnapshot,
-      seed,
-      id: `match-${Date.now()}`,
-      presentationSpeedProfile: presentationSpeedProfile.value,
-      preservedBotLabels,
-    })
-  } finally {
-    matchNeuralLoadGateInFlight.value = false
-    liveMatch.kickMatchAutomation()
+  const result = await enterMatchFromSetupSnapshot({
+    setupSnapshot: cloneSetup(match.value.setup),
+    preservedBotLabels: collectPreservedBotLabelsFromMatchState(match.value.state.seats),
+    ...liveMatchEntryDeps(),
+  })
+  if (result.kind === 'entered') {
+    match.value = result.match
   }
 }
 
 function backToSetup() {
-  liveMatch.resetForBackToSetup()
+  liveMatch.page.resetForBackToSetup()
 }
 
 function exportReplay() {
-  liveMatch.exportReplay()
+  liveMatch.debug.exportReplay()
 }
 
 async function startNewMatchIntentional() {
-  const shouldStartFresh = await liveMatch.requestConfirmation({
+  const shouldStartFresh = await liveMatch.page.requestConfirmation({
     title: 'Start a new match?',
     message: 'This will discard your current match and return to setup.',
     okLabel: 'Start new',

--- a/src/pages/projects/DungeonRunnerPage.vue
+++ b/src/pages/projects/DungeonRunnerPage.vue
@@ -8,7 +8,7 @@
           dense
           icon="refresh"
           aria-label="Start new match"
-          :disable="dungeonOutcomeDialogOpen"
+          :disable="liveMatch.dungeonOutcomeDialogOpen"
           @click="startNewMatchIntentional"
         />
         <q-badge v-if="debugMode" color="negative" label="Debug" />
@@ -20,7 +20,7 @@
         dense
         icon="help"
         aria-label="How to play"
-        :disable="match && dungeonOutcomeDialogOpen"
+        :disable="match && liveMatch.dungeonOutcomeDialogOpen"
         @click="helpOpen = true"
       />
       <q-btn
@@ -28,7 +28,7 @@
         dense
         icon="settings"
         aria-label="Dungeon Runner settings"
-        :disable="Boolean(match) && dungeonOutcomeDialogOpen"
+        :disable="Boolean(match) && liveMatch.dungeonOutcomeDialogOpen"
       >
         <q-menu anchor="bottom right" self="top right" :offset="[0, 6]">
           <div class="dr-match-settings-menu q-pa-md" style="min-width: 260px">
@@ -40,9 +40,8 @@
               type="radio"
             />
             <q-separator class="q-my-md" />
-            
             <q-toggle
-              :model-value="memoryAidState.enabled"
+              :model-value="dungeonRunnerSettingsStore.memoryAidEnabled"
               dense
               label="Memory Aid"
               aria-label="Toggle memory aid"
@@ -56,701 +55,63 @@
     </div>
 
     <div class="col dr-scroll q-px-md q-pb-md">
-      <q-card v-if="!match" flat bordered class="q-pa-md">
-        <div class="text-subtitle1 q-mb-sm">Setup</div>
-        <div class="row q-col-gutter-md q-mb-md">
-          <div class="col-12 col-sm-6">
-            <div class="text-body2 q-mb-sm">Total players</div>
-            <q-slider
-              v-model="setup.totalSeats"
-              :min="totalSeatSlider.min"
-              :max="totalSeatSlider.max"
-              :step="totalSeatSlider.step"
-              snap
-              markers
-              marker-labels
-              color="primary"
-              aria-label="Total players"
-              class="dr-total-seats-slider q-px-sm"
-            />
-          </div>
-        </div>
+      <PlaySetupShell
+        v-if="activePlayShell === PLAY_SHELL.PLAY_SETUP"
+        v-model:setup="setup"
+        :model-options="modelOptions"
+        :total-seat-slider="totalSeatSlider"
+        :opponent-type-options="opponentTypeOptions"
+        v-model:neural-load-gate-terminal-open="neuralLoadGateTerminalOpen"
+        @start-match="startNewMatch"
+      />
 
-        <div class="q-gutter-y-sm">
-          <div
-            v-for="(opponent, index) in setup.opponents"
-            :key="`opponent-${index}`"
-            class="row items-center q-col-gutter-sm"
-          >
-            <div class="col-7">
-              <q-select
-                v-model="opponent.type"
-                :options="opponentTypeOptions"
-                option-value="value"
-                option-label="label"
-                emit-value
-                map-options
-                behavior="menu"
-                outlined
-                dense
-                :label="`Opponent ${index + 1}`"
-              />
-            </div>
-            <div class="col-5" v-if="opponent.type === 'nn'">
-              <q-select
-                v-if="modelOptions.length"
-                v-model="opponent.modelId"
-                :options="modelOptions"
-                label="Model"
-                behavior="menu"
-                outlined
-                dense
-              />
-              <q-input v-else v-model="opponent.modelId" label="Model" outlined dense />
-            </div>
-          </div>
-        </div>
+      <LiveMatchShell v-else-if="activePlayShell === PLAY_SHELL.LIVE_MATCH" />
 
-        <div class="q-mt-md">
-          <q-btn unelevated color="primary" label="Start match" :disable="!setupIsValid" @click="startNewMatch" />
-        </div>
-      </q-card>
-
-      <template v-else>
-        <div ref="boardShellRef" class="dr-board-shell">
-          <div
-            v-if="showDungeonStage && dungeonStageView.hpBar"
-            class="dr-dungeon-hp-bar q-mb-sm"
-            role="meter"
-            aria-label="Adventurer HP"
-            aria-valuemin="0"
-            :aria-valuemax="dungeonStageView.hpBar.displayMaxHp"
-            :aria-valuenow="dungeonStageView.hpBar.currentHp"
-          >
-            <div class="row items-center justify-between q-mb-xs">
-              <span class="text-caption text-weight-medium">HP</span>
-              <span class="text-caption">{{ dungeonStageView.hpBar.text }}</span>
-            </div>
-            <div class="dr-dungeon-hp-bar__track">
-              <div
-                class="dr-dungeon-hp-bar__fill"
-                :style="{ width: `${dungeonStageView.hpBar.percent}%` }"
-              />
-            </div>
-          </div>
-          <q-card
-            flat
-            bordered
-            class="q-pa-sm q-mb-sm dr-bidding-board"
-            :class="biddingBoard.heroCue.accentClass"
-          >
-          <div
-            v-if="seatRunTrackerRows.length"
-            class="dr-seat-strip q-mb-sm"
-          >
-            <div class="row q-col-gutter-xs">
-              <div v-for="row in seatRunTrackerRows" :key="`seat-${row.seatId}`" class="col dr-seat-stack">
-                <q-badge
-                  :color="row.passed ? 'grey-9' : biddingBoard.heroCue.badgeColor"
-                  text-color="white"
-                  class="dr-seat-chip q-px-sm full-width"
-                  :class="{ 'dr-token-glow': row.isActive }"
-                >
-                  <span class="text-caption">{{ row.label }}</span>
-                </q-badge>
-                <div
-                  v-if="row.recovering"
-                  class="row items-center justify-center q-mt-xs"
-                  :data-testid="row.recoveryTestId"
-                >
-                  <q-spinner size="16px" color="primary" />
-                </div>
-                <div class="dr-seat-progress-cell text-caption" :aria-label="row.ariaLabel">
-                  <span
-                    v-for="index in row.successes"
-                    :key="`success-${row.seatId}-${index}`"
-                    class="dr-seat-progress-marker dr-seat-progress-marker--success"
-                  >
-                    ✓
-                  </span>
-                  <span
-                    v-for="index in row.failures"
-                    :key="`failure-${row.seatId}-${index}`"
-                    class="dr-seat-progress-marker dr-seat-progress-marker--failure"
-                  >
-                    X
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <q-card-section class="q-pa-none q-mb-sm dr-board-primary">
-            <div
-              ref="heroCardSlotRef"
-              class="dr-hero-card-slot"
-              :class="{
-                'dr-dungeon-stage': showDungeonStage,
-                [dungeonStageAnimationClass]: showDungeonStage && dungeonStageAnimationClass,
-              }"
-            >
-              <div ref="dungeonCardMotionWrap" class="dr-dungeon-card-motion-wrap">
-                <MonsterCardFace
-                  ref="dungeonCardFaceRef"
-                  class="dr-hero-card-control"
-                  :empty="monsterCardSlotEmpty"
-                  :hide-empty-slot="showDungeonStage"
-                  :species="showDungeonStage ? dungeonStageView.monster.frontFaceSpecies : biddingStageSpecies"
-                  :face-down="
-                    showDungeonStage
-                      ? dungeonStageView.monster.visibility === 'face-down'
-                      : biddingStageFaceDown
-                  "
-                />
-              </div>
-              <q-badge
-                v-if="showDungeonStage && dungeonStageView.hpDelta"
-                class="dr-dungeon-stage__hp-chip"
-                :color="dungeonStageView.hpDelta.tone === 'damage' ? 'negative' : 'positive'"
-                text-color="white"
-              >
-                {{ dungeonStageView.hpDelta.text }}
-              </q-badge>
-            </div>
-          </q-card-section>
-          <div class="row q-col-gutter-xs items-start">
-            <div class="col-4">
-              <q-badge
-                ref="deckBadgeRef"
-                text-color="white"
-                class="full-width q-py-xs justify-between dr-deck-badge dr-pile-badge dr-pile-badge--deck"
-                :style="{ '--dr-pile': `url('${uiAssets.piles.deck.runtimePath}')` }"
-                :class="{
-                  'dr-deck-badge--interactive': biddingBoard.memoryAid.deckTapEnabled,
-                }"
-                @click="onDeckTap"
-              >
-                <span>Deck</span>
-                <span>{{ biddingBoard.secondary.deckCount }}</span>
-              </q-badge>
-              <div v-if="biddingBoard.memoryAid.knownDeckCountHint !== null" class="text-caption text-grey-6 q-mt-xs">
-                Known to you: {{ biddingBoard.memoryAid.knownDeckCountHint }}
-              </div>
-            </div>
-            <div class="col-4">
-              <div ref="dungeonPileMotionAnchorRef" class="full-width">
-                <q-badge
-                  text-color="white"
-                  class="full-width q-py-xs justify-between dr-pile-badge dr-pile-badge--dungeon"
-                  :style="{ '--dr-pile': `url('${uiAssets.piles.dungeon.runtimePath}')` }"
-                >
-                  <span>Dungeon</span>
-                  <span>{{ biddingBoard.secondary.dungeonCount }}</span>
-                </q-badge>
-              </div>
-            </div>
-            <div class="col-4">
-              <div class="row no-wrap items-center full-width dr-turn-hero-row">
-                <q-chip
-                  :color="biddingBoard.heroCue.badgeColor"
-                  text-color="white"
-                  dense
-                  :aria-label="biddingBoard.heroCue.shortLabel"
-                >
-                  {{ biddingBoard.heroCue.shortLabel }}
-                </q-chip>
-              </div>
-            </div>
-          </div>
-          <div class="row q-mt-none">
-            <div
-              v-for="token in boardEquipmentTokens"
-              :key="token.equipmentId"
-              class="col-4 flex flex-center"
-            >
-              <div
-                :ref="(el) => bindBiddingEquipmentBadgeRef(token.equipmentId, el)"
-                class="dr-equip-token"
-                :class="{
-                  'dr-equip-token--spent': token.removed,
-                  'dr-token-glow': token.glow,
-                  'dr-token-pulse': token.pulse,
-                  'dr-equip-token--deemphasized': token.deemphasized,
-                  'dr-equip-token--interactive': token.hasModal,
-                }"
-                :tabindex="token.hasModal ? 0 : -1"
-                :role="token.hasModal ? 'button' : 'img'"
-                :aria-disabled="token.hasModal ? undefined : 'true'"
-                :aria-label="token.ariaLabel"
-                @click="openEquipmentModal(token)"
-                @keydown.enter.prevent="openEquipmentModal(token)"
-                @keydown.space.prevent="openEquipmentModal(token)"
-              >
-                <img
-                  class="dr-equip-token__plate"
-                  :src="uiAssets.equipment.plate.runtimePath"
-                  alt=""
-                  draggable="false"
-                />
-                <img
-                  class="dr-equip-token__symbol"
-                  :src="token.symbolRuntimePath"
-                  alt=""
-                  draggable="false"
-                />
-                <span v-if="token.equipmentOverlay != null" class="dr-equip-token__overlay" aria-hidden="true">
-                  +{{ token.equipmentOverlay }}
-                </span>
-              </div>
-            </div>
-          </div>
-        </q-card>
-
-        <q-card v-if="showActionPane" flat bordered class="q-pa-sm q-mb-md">
-          <div v-if="activePresentationLabel" class="text-body2 text-grey-6 q-mb-xs">{{ activePresentationLabel }}</div>
-          <div v-if="isHumanTurn" class="row q-col-gutter-sm q-gutter-y-sm">
-            <template v-if="match.state.phase === 'bidding' && biddingSacrificeActions.length > 1">
-              <q-btn
-                v-for="action in biddingNonSacrificeActions"
-                :key="actionKey(action)"
-                :color="biddingBoard.heroCue.buttonColor"
-                unelevated
-                no-caps
-                size="lg"
-                class="col-12 col-sm-auto"
-                :label="actionLabel(action)"
-                :disable="humanGameplayBlocked"
-                @click="takeHumanAction(action)"
-              />
-              <q-btn-dropdown
-                :color="biddingBoard.heroCue.buttonColor"
-                unelevated
-                no-caps
-                dense
-                size="lg"
-                class="col-12 col-sm-auto"
-                label="Sacrifice equipment"
-                :disable="humanGameplayBlocked"
-              >
-                <q-list dense>
-                  <q-item
-                    v-for="action in biddingSacrificeActions"
-                    :key="actionKey(action)"
-                    v-close-popup
-                    clickable
-                    @click="takeHumanAction(action)"
-                  >
-                    <q-item-section>{{ actionLabel(action) }}</q-item-section>
-                  </q-item>
-                </q-list>
-              </q-btn-dropdown>
-            </template>
-            <template v-else>
-              <template v-if="showHeroPickActionGrid">
-                <div class="col-12 text-h5 text-weight-medium text-grey-5 q-mb-xs" style="text-align: center;">Select Adventurer</div>
-                <div class="dr-hero-pick-grid col-12">
-                  <q-btn
-                    v-for="action in heroPickActionsOrdered"
-                    :key="actionKey(action)"
-                    :color="getHeroIdentity(action.hero).buttonColor"
-                    unelevated
-                    no-caps
-                    dense
-                    size="lg"
-                    class="dr-hero-pick-grid__btn full-width"
-                    :label="getHeroIdentity(action.hero).shortLabel"
-                    :aria-label="actionLabel(action)"
-                    :disable="humanGameplayBlocked"
-                    @click="takeHumanAction(action)"
-                  />
-                </div>
-              </template>
-              <template v-else>
-                <q-btn
-                  v-for="action in visiblePrimaryActions"
-                  :key="actionKey(action)"
-                  :color="biddingBoard.heroCue.buttonColor"
-                  unelevated
-                  no-caps
-                  dense
-                  size="lg"
-                  class="col-12 col-sm-auto"
-                  :label="actionLabel(action)"
-                  :disable="humanGameplayBlocked"
-                  @click="takeHumanAction(action)"
-                />
-              </template>
-            </template>
-          </div>
-          <div v-if="isHumanTurn && dungeonOutcomeTransitionControls.length" class="row q-col-gutter-sm q-gutter-y-sm q-mt-xs">
-            <q-btn
-              v-for="control in dungeonOutcomeTransitionControls"
-              :key="control.key"
-              :color="biddingBoard.heroCue.buttonColor"
-              unelevated
-              no-caps
-              dense
-              size="md"
-              class="col-12 col-sm-auto"
-              :label="control.label"
-              :disable="gameplayInputLocked || dungeonOutcomeDialogOpen"
-              @click="takeHumanAction(control.action)"
-            />
-          </div>
-        </q-card>
-
-        <q-card v-if="debugMode" flat bordered class="q-pa-md q-mb-md">
-          <div class="text-subtitle2 q-mb-sm">Debug replay</div>
-          <div v-if="nnDebugTraceHistory.length" class="q-mb-sm">
-            <div class="text-caption text-grey-5 q-mb-xs">NN trace history</div>
-            <div v-for="(entry, index) in nnDebugTraceHistory" :key="`nn-trace-${index}`" class="text-caption">
-              {{ entry.at }} | {{ entry.modelId }} | {{ entry.trace.kind }} |
-              {{ entry.trace.fallbackReason ?? entry.trace.mode ?? 'sample' }}
-            </div>
-          </div>
-          <div class="row q-gutter-sm q-mb-sm">
-            <q-btn color="primary" flat label="Export replay" @click="exportReplay" />
-            <q-btn color="primary" flat label="Import replay" @click="importReplay" />
-          </div>
-          <q-input
-            v-model="replayExportText"
-            type="textarea"
-            autogrow
-            readonly
-            label="Export payload"
-            outlined
-            dense
-            class="q-mb-sm"
-          />
-          <q-input v-model="replayImportText" type="textarea" autogrow label="Import payload" outlined dense />
-          <q-input
-            v-model="nnDebugTraceText"
-            type="textarea"
-            autogrow
-            readonly
-            label="NN trace (features/mask/logits)"
-            outlined
-            dense
-            class="q-mt-sm"
-          />
-        </q-card>
-
-          <div
-            ref="presentationFlightLayerRef"
-            class="dr-presentation-flight-layer"
-            aria-hidden="true"
-          />
-        </div>
-      </template>
+      <MatchOverShell
+        v-else-if="activePlayShell === PLAY_SHELL.MATCH_OVER"
+        :match="match"
+        :human-seat-id="humanSeatId"
+        :debug-mode="debugMode"
+        :replay-export-text="replayExportText"
+        :nn-debug-trace-text="nnDebugTraceText"
+        :nn-debug-trace-history="nnDebugTraceHistory"
+        :upload-tracker="completedMatchReplayUpload"
+        @rematch="rematch"
+        @back-to-setup="backToSetup"
+        @export-replay="exportReplay"
+      />
     </div>
-
-    <button
-      v-if="activePresentation?.kind === 'HERO_CHANGE_INTERSTITIAL' && heroChangeInterstitialView"
-      ref="heroChangeInterstitialOverlayRef"
-      type="button"
-      class="dr-hero-interstitial"
-      :aria-label="heroChangeInterstitialAriaLabel"
-      @click="skipActivePresentation"
-    >
-      <p class="dr-hero-interstitial__headline">{{ heroChangeInterstitialView.headline }}</p>
-      <q-avatar
-        :color="heroChangeInterstitialView.chosen.badgeColor"
-        text-color="white"
-        size="56px"
-        font-size="1.25rem"
-        class="dr-hero-interstitial__avatar"
-      >
-        {{ heroChangeInterstitialView.chosen.badgeGlyph }}
-      </q-avatar>
-    </button>
-
-    <q-dialog v-model="dungeonOutcomeDialogOpen" persistent transition-show="scale" transition-hide="scale">
-      <q-card class="q-pa-md dr-dungeon-outcome-dialog" :class="dungeonOutcomeToneClass" style="min-width: 340px">
-        <div class="text-overline dr-outcome-kicker">Dungeon run resolved</div>
-        <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">
-          {{ dungeonOutcomeSummary?.resultLabel }}
-        </div>
-        <div class="text-body1 q-mb-xs">
-          Runner: <span class="text-weight-bold">{{ dungeonOutcomeSummary?.runnerLabel }}</span>
-        </div>
-        <div class="text-body2 q-mb-md dr-outcome-message">{{ dungeonOutcomeMessage }}</div>
-        <div class="row justify-end">
-          <q-btn color="primary" unelevated label="Continue" class="dr-outcome-btn" @click="continueFromDungeonOutcome" />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="matchOverDialogOpen" persistent transition-show="scale" transition-hide="scale">
-      <q-card class="q-pa-md dr-match-over-dialog" :class="matchOverToneClass" style="min-width: 340px">
-        <div class="text-overline dr-outcome-kicker">Match complete</div>
-        <div class="text-h5 text-weight-bold q-mb-sm dr-outcome-title">{{ matchOverSummary.title }}</div>
-        <div class="text-body1 q-mb-xs">{{ matchOverSummary.message }}</div>
-        <div v-if="matchOverSummary.showWinner" class="text-body2 q-mb-md">
-          Winner: {{ matchOverSummary.winnerLabel }}
-        </div>
-        <div class="row q-gutter-sm justify-end">
-          <q-btn color="primary" unelevated label="Rematch" class="dr-outcome-btn" @click="rematch" />
-          <q-btn flat color="primary" label="Back to setup" class="dr-outcome-btn-secondary" @click="backToSetup" />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="equipmentModalOpen" class="dr-equipment-dialog">
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">{{ selectedEquipmentModalView?.title }}</div>
-        <div class="text-body2 q-mb-md">{{ selectedEquipmentModalView?.details }}</div>
-        <div class="row justify-end q-gutter-sm">
-          <q-btn
-            v-if="selectedEquipmentModalView?.showUseButton"
-            color="primary"
-            unelevated
-            label="Use"
-            :disable="equipmentModalActionsDisabled"
-            @click="takeEquipmentUseAction"
-          />
-          <q-btn flat color="primary" label="Continue" @click="continueFromEquipmentModal" />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="confirmationDialogOpen" persistent>
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">{{ confirmationDialogTitle }}</div>
-        <div class="text-body2 q-mb-md">{{ confirmationDialogMessage }}</div>
-        <div class="row justify-end q-gutter-sm">
-          <q-btn flat color="primary" :label="confirmationDialogCancelLabel" @click="onConfirmationDialogCancel" />
-          <q-btn color="primary" unelevated :label="confirmationDialogOkLabel" @click="onConfirmationDialogOk" />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="neuralLoadGateTerminalOpen" persistent data-testid="neural-load-gate-terminal">
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
-        <div class="text-body2 q-mb-md">
-          A selected neural model could not load. Adjust setup and start a new match.
-        </div>
-        <div class="row justify-end">
-          <q-btn
-            color="primary"
-            unelevated
-            label="Back to setup"
-            data-testid="neural-load-gate-terminal-dismiss"
-            @click="dismissNeuralLoadGateTerminal"
-          />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="neuralRefreshTerminalOpen" persistent data-testid="neural-refresh-terminal">
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">Neural opponent unavailable</div>
-        <div class="text-body2 q-mb-md">
-          Inference could not recover. Refresh the page to reload the neural runtime; your match stays saved.
-        </div>
-        <div class="row justify-end">
-          <q-btn
-            color="primary"
-            unelevated
-            label="Refresh page"
-            data-testid="neural-refresh-terminal-reload"
-            @click="reloadPageForNeuralRefreshTerminal"
-          />
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-dialog v-model="vorpalDialogOpen" persistent>
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">Vorpal target</div>
-        <div class="text-body2 q-mb-md">Choose a species before entering the dungeon.</div>
-        <q-select
-          v-model="selectedVorpalSpecies"
-          :options="vorpalSelectOptions"
-          emit-value
-          map-options
-          option-value="value"
-          option-label="label"
-          label="Species"
-          behavior="menu"
-          outlined
-          dense
-          class="q-mb-md"
-        />
-        <div class="row justify-end">
-          <q-btn
-            color="primary"
-            unelevated
-            label="Confirm"
-            :disable="!selectedVorpalSpecies || humanGameplayBlocked"
-            @click="confirmVorpalDeclaration"
-          />
-        </div>
-      </q-card>
-    </q-dialog>
-    <q-dialog v-model="deckSplayOpen" maximized>
-      <q-card class="dr-deck-splay-panel">
-        <div class="row items-center q-px-md q-pt-md q-pb-sm">
-          <div class="text-subtitle1">Deck splay</div>
-          <q-space />
-          <q-btn flat dense icon="close" aria-label="Close deck splay" @click="onCloseDeckSplay" />
-        </div>
-        <q-separator />
-        <div class="q-pa-md dr-deck-splay-scroll">
-          <div class="row q-col-gutter-sm q-row-gutter-sm">
-            <div
-              v-for="(slot, index) in biddingBoard.memoryAid.deckSplayCards"
-              :key="`deck-card-${index}`"
-              class="col-6 col-sm-4 col-md-3"
-            >
-              <MonsterCardFace
-                class="dr-card-preview"
-                :species="slot.visibility === 'face' ? slot.species : null"
-                :face-down="slot.visibility !== 'face'"
-              />
-            </div>
-          </div>
-        </div>
-      </q-card>
-    </q-dialog>
-
-    <q-inner-loading
-      :showing="headlessCompletionInFlight"
-      data-testid="finishing-match-overlay"
-      class="dr-finishing-match-overlay"
-    >
-      <q-spinner size="50px" color="primary" />
-    </q-inner-loading>
 
     <DungeonRunnerHelpDialog v-model="helpOpen" />
   </q-page>
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, reactive, ref, triggerRef, unref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, provide, reactive, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useQuasar } from 'quasar'
 import { useScopedFullscreen } from '../../features/game-timer/composables/useScopedFullscreen.js'
 import { useDungeonRunnerSettingsStore } from '../../stores/dungeonRunnerSettings.js'
-import {
-  MATCH_PHASES,
-  applyAction,
-  getLegalActions,
-  getPlayerView,
-} from '../../features/dungeon-runner/engine/kernel.js'
-import {
-  CURRENT_MATCH_SCHEMA_VERSION,
-  clearCurrentMatch,
-  persistCurrentMatch,
-} from '../../features/dungeon-runner/persistence/currentMatch.js'
-import { createDefaultSetupConfig, validateSetupConfig } from '../../features/dungeon-runner/setup/config.js'
-import {
-  applySetupSnapshot,
-  canStartMatchFromSetup,
-  normalizeSetupState,
-} from '../../features/dungeon-runner/setup/state.js'
+import { clearCurrentMatch } from '../../features/dungeon-runner/persistence/currentMatch.js'
+import { createDefaultSetupConfig } from '../../features/dungeon-runner/setup/config.js'
 import { createMatchSeed } from '../../features/dungeon-runner/setup/seed.js'
-import { isNnAdventurerPickEnabled } from '../../features/dungeon-runner/setup/nnAdventurerPick.js'
 import { shouldEnableDebugOnBoot } from '../../features/dungeon-runner/debug/mode.js'
-import { buildStateFromReplayEnvelope } from '../../features/dungeon-runner/debug/replaySession.js'
-import { exportReplayEnvelope, importReplayEnvelope } from '../../features/dungeon-runner/debug/replay.js'
-import {
-  abandonScheduledInferenceQueue,
-  loadNnModel,
-} from '../../features/dungeon-runner/nn/runtime.js'
 import { createNeuralRuntimeRecoveryCoordinator } from '../../features/dungeon-runner/nn/recovery.js'
-import { createChooseNnActionWithRecovery } from '../../features/dungeon-runner/nn/chooseWithRecovery.js'
 import { fetchModelCatalog } from '../../features/dungeon-runner/models/catalog.js'
-import { pickDefaultModelId, validateSelectedModels } from '../../features/dungeon-runner/models/discovery.js'
-import {
-  createPresentationOrchestrator,
-  SPEED_PROFILES,
-} from '../../features/dungeon-runner/ui/presentationOrchestrator.js'
-import {
-  DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS,
-  runPresentationIntervalTick,
-} from '../../features/dungeon-runner/ui/dungeonRunnerPresentationInterval.js'
-import { buildAiTurnRunToken } from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnToken.js'
-import {
-  cancelAiTurnPrefetch,
-  consumeAiTurnPrefetch,
-  resetAiTurnPrefetch,
-  startAiTurnPrefetch,
-} from '../../features/dungeon-runner/ui/dungeonRunnerAiTurnPrefetch.js'
-import { createPipelineStepLogger } from '../../features/dungeon-runner/nn/nnPipelineTrace.js'
-import {
-  dungeonRunnerAssetPack,
-  dungeonRunnerEquipmentSymbolRuntimePath,
-} from '../../features/dungeon-runner/ui/assetPack.js'
-import { equipmentTokenAppearance } from '../../features/dungeon-runner/equipmentTokenAppearance.js'
-import { equipmentShortName } from '../../features/dungeon-runner/data/gameDataCatalog.js'
-import {
-  adventurerChoiceHeadline,
-  legalActionBoardLabel,
-} from '../../features/dungeon-runner/ui/dungeonRunnerPlayerPhrasing.js'
-import {
-  buildDungeonEquipmentTokenView,
-  createDungeonEquipmentModalView,
-  createVorpalDeclarationPromptView,
-  filterVisibleLegalActions,
-} from '../../features/dungeon-runner/ui/dungeonEquipmentInteractions.js'
-import { createBiddingBoardViewModel } from '../../features/dungeon-runner/ui/biddingBoardViewModel.js'
-import {
-  viewerMaySeeAddToDungeonFlipDown,
-  viewerMaySeeBiddingDrawFace,
-} from '../../features/dungeon-runner/ui/biddingPresentationVisibility.js'
-import { getHeroIdentity } from '../../features/dungeon-runner/ui/heroIdentity.js'
-import { createDungeonResolutionViewModel } from '../../features/dungeon-runner/ui/dungeonResolutionViewModel.js'
-import {
-  buildDungeonOutcomeTransitionControls,
-  dungeonStageClassForKind,
-  shouldExecuteScheduledAutoResolve,
-  shouldAutoResolveDungeonAdvance,
-} from '../../features/dungeon-runner/ui/dungeonResolutionFlow.js'
-import {
-  buildDungeonOutcomeSummary,
-  dismissDungeonRunForOutcomeDialog,
-  isDungeonOutcomeDialogOpen,
-  resolveLastDungeonRunWatcherUpdate,
-  shouldShowDungeonOutcomeDialog,
-} from '../../features/dungeon-runner/ui/dungeonOutcomeDialog.js'
-import {
-  isEquipmentModalActionsDisabled,
-  isHumanGameplayBlocked,
-  shouldRejectEquipmentTokenTap,
-} from '../../features/dungeon-runner/ui/humanGameplayGate.js'
-import { MATCH_OVER_END_VARIANTS } from '../../features/dungeon-runner/ui/humanEliminationCompletionPolicy.js'
-import {
-  shouldDeferDungeonExitUntilOutcomeAck,
-} from '../../features/dungeon-runner/ui/headlessMatchCompletionRunner.js'
-import {
-  bootstrapCurrentMatchFromStorage,
-  runHeadlessMatchCompletionForPage,
-  buildNewMatchEnvelope,
-  runMatchEntryNeuralLoadGateForPage,
-} from '../../features/dungeon-runner/matchPageOrchestration.js'
-import { createMatchPageOrchestrationContext } from '../../features/dungeon-runner/createMatchPageOrchestrationContext.js'
-import { createLiveMatchPageSessionSink } from '../../features/dungeon-runner/createLiveMatchPageSessionSink.js'
-import { resetLiveMatchPageState } from '../../features/dungeon-runner/resetLiveMatchPageState.js'
-import { createLivePlayActionChooser } from '../../features/dungeon-runner/ui/livePlayActionChooser.js'
-import { buildMatchOverSummary } from '../../features/dungeon-runner/ui/matchOverSummaryBuilder.js'
-import MonsterCardFace from '../../components/dungeon-runner/MonsterCardFace.vue'
+import { evaluatePlaySetupStart, applyNnDefaultModelIds } from '../../features/dungeon-runner/ui/playSetupShell.js'
+import { bootstrapCurrentMatchFromStorage } from '../../features/dungeon-runner/matchPageOrchestration.js'
 import DungeonRunnerHelpDialog from '../../features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue'
-import { closeDeckSplay, createMemoryAidState, setMemoryAidEnabled, tapDeck } from '../../features/dungeon-runner/ui/memoryAidState.js'
-import { isDungeonPresentationTraceEnabled } from '../../features/dungeon-runner/ui/dungeonPresentationTrace.js'
-import { isDungeonOrchestratorPresentationKind } from '../../features/dungeon-runner/ui/orchestratorPresentationKinds.js'
-import { usePresentationMotion } from '../../features/dungeon-runner/ui/usePresentationMotion.js'
-import { evaluateLiveAiTurnPipelineGateForContext } from '../../features/dungeon-runner/ui/liveAiTurnPipelineGateContext.js'
 import {
-  buildAiTurnPrefetchSkipTrace,
-  buildAiTurnRunSkipTrace,
-  buildAiTurnScheduleSkipTrace,
-} from '../../features/dungeon-runner/ui/liveAiTurnPipelineGateTrace.js'
-import { createCompletedMatchReplayUploadTracker, shouldUploadCompletedMatchReplayForPhase } from '../../features/dungeon-runner/firebase/completedMatchReplayUpload.js'
-import {
-  buildSeatRecoveryIndicators,
-  isActiveNnSeatRecovering,
-} from '../../features/dungeon-runner/ui/neuralSeatRecoveryView.js'
-import { handleLivePlayNeuralRecoveryTerminalError } from '../../features/dungeon-runner/ui/livePlayNeuralRecoveryTerminal.js'
+  PLAY_SHELL,
+  buildPlayShellSnapshot,
+  resolveActivePlayShell,
+} from '../../features/dungeon-runner/ui/playShellResolver.js'
+import PlaySetupShell from '../../features/dungeon-runner/ui/shells/PlaySetupShell.vue'
+import LiveMatchShell from '../../features/dungeon-runner/ui/shells/LiveMatchShell.vue'
+import MatchOverShell from '../../features/dungeon-runner/ui/shells/MatchOverShell.vue'
+import { useLiveMatchShell } from '../../features/dungeon-runner/ui/shells/useLiveMatchShell.js'
+import { LIVE_MATCH_SHELL_SESSION_KEY } from '../../features/dungeon-runner/ui/shells/liveMatchShellSessionKey.js'
+import { createCompletedMatchReplayUploadTracker } from '../../features/dungeon-runner/firebase/completedMatchReplayUpload.js'
 
 const completedMatchReplayUpload = createCompletedMatchReplayUploadTracker(window.sessionStorage)
 
@@ -764,92 +125,15 @@ const opponentTypeOptions = [
   { label: 'AI', value: 'nn' },
 ]
 const debugMode = ref(false)
-function presentationTraceEnabled() {
-  return isDungeonPresentationTraceEnabled()
-}
 const modelOptions = ref([])
 const nnRecovery = createNeuralRuntimeRecoveryCoordinator()
-const seatRecoveryIndicators = ref([])
-/** @type {(() => void) | null} */
-let unsubscribeNnRecovery = null
-let activeSeatRecoveryBlocking = false
-
-function syncSeatRecoveryIndicators() {
-  const seats = match.value?.state?.seats ?? []
-  seatRecoveryIndicators.value = buildSeatRecoveryIndicators({ seats, recovery: nnRecovery })
-}
-
-function resolveActiveSeatRecoveryBlocking() {
-  return match.value?.state
-    ? isActiveNnSeatRecovering({ state: match.value.state, recovery: nnRecovery })
-    : false
-}
-
-function applySeatRecoveryBlockingTransition(blocking) {
-  if (!activeSeatRecoveryBlocking && blocking) {
-    cancelAiTurnPrefetch()
-  }
-  activeSeatRecoveryBlocking = blocking
-}
-
-function onNnRecoveryChanged() {
-  syncSeatRecoveryIndicators()
-  applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
-  scheduleAiTurnIfReady()
-}
-
-function logNnRecoveryTrace(modelId, step, detail = {}) {
-  if (!debugMode.value) return
-  aiTurnTrace({ modelId })(`recovery.${step}`, {
-    loadAttempts: nnRecovery.getLoadAttempts(modelId),
-    inferAttempts: nnRecovery.getInferAttempts(modelId),
-    loadBackend: nnRecovery.getBackendPreference(modelId, 'load'),
-    inferBackend: nnRecovery.getBackendPreference(modelId, 'infer'),
-    ...detail,
-  })
-}
-
-const chooseNnActionWithRecovery = createChooseNnActionWithRecovery({
-  recovery: nnRecovery,
-  onRecoveryBegin: (modelId) => logNnRecoveryTrace(modelId, 'begin'),
-  onRecoveryAttempt: (detail) => logNnRecoveryTrace(detail.modelId, 'attempt', detail),
-  onRecoverySettled: (modelId) => logNnRecoveryTrace(modelId, 'settled'),
-})
-
-function buildLivePlayChooserDeps(extra = {}) {
-  return {
-    nnRecovery,
-    ensureNnModelsReady,
-    nnRuntimeOptions,
-    chooseNnActionWithRecovery,
-    ...extra,
-  }
-}
-
-function evaluatePageAiTurnPipelineGate({ runToken = '', timerPending = false } = {}) {
-  return evaluateLiveAiTurnPipelineGateForContext({
-    matchState: match.value?.state ?? null,
-    humanSeatId: humanSeatId.value,
-    isHumanTurn: isHumanTurn.value,
-    hasMatch: !!match.value,
-    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
-    matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
-    aiTurnInFlight,
-    headlessCompletionInFlight: headlessCompletionInFlight.value,
-    deferredPostDungeonState: deferredPostDungeonState.value,
-    gameplayInputLocked: gameplayInputLocked.value,
-    recovery: nnRecovery,
-    runToken,
-    lastAppliedAiTurnToken,
-    timerPending,
-    pickAdventurerNnEnabled: isNnAdventurerPickEnabled(),
-  })
-}
 const replayImportText = ref('')
 const replayExportText = ref('')
 const nnDebugTraceText = ref('')
 const nnDebugTraceHistory = ref([])
-const presentationOrchestrator = createPresentationOrchestrator()
+const neuralLoadGateTerminalOpen = ref(false)
+const matchNeuralLoadGateInFlight = ref(false)
+
 const dungeonRunnerSettingsStore = useDungeonRunnerSettingsStore()
 const { fullscreenEnabled } = storeToRefs(dungeonRunnerSettingsStore)
 
@@ -880,713 +164,106 @@ const presentationSpeedProfile = computed({
     dungeonRunnerSettingsStore.setAnimationPace(value)
   },
 })
+
 const presentationSpeedOptions = [
   { label: 'Cinematic', value: 'cinematic' },
   { label: 'Brisk', value: 'brisk' },
 ]
-const activePresentation = ref(null)
-const boardShellRef = ref(null)
-const heroCardSlotRef = ref(null)
-const dungeonCardMotionWrap = ref(null)
-const dungeonCardFaceRef = ref(null)
-const deckBadgeRef = ref(null)
-const dungeonPileMotionAnchorRef = ref(null)
-const heroChangeInterstitialOverlayRef = ref(null)
-const presentationFlightLayerRef = ref(null)
-const biddingEquipmentBadgeRefs = reactive({})
 
-function domEl(componentOrEl) {
-  if (!componentOrEl) return null
-  if (componentOrEl.nodeType === 1) return componentOrEl
-  const inner = componentOrEl.$el
-  return inner?.nodeType === 1 ? inner : null
+function cloneSetup(source = setup) {
+  return {
+    totalSeats: source.totalSeats,
+    opponents: source.opponents.map((opponent) => ({ ...opponent })),
+  }
 }
 
-/** `defineExpose`d Refs from child components; QBadge roots via {@link domEl}. */
-function unwrapMotionDom(exposedMaybeRef) {
-  if (exposedMaybeRef == null) return null
-  const el = unref(exposedMaybeRef)
-  return el?.nodeType === 1 ? el : null
-}
-
-function bindBiddingEquipmentBadgeRef(equipmentId, componentOrEl) {
-  const node = domEl(componentOrEl)
-  if (node) biddingEquipmentBadgeRefs[equipmentId] = node
-  else delete biddingEquipmentBadgeRefs[equipmentId]
-}
-
-// GSAP: most beats tween `boardShell` (shared placeholder) plus kind-specific refs — `DUNGEON_REVEAL` tweens `dungeonCardWrap` (opacity / y / scale) and `dungeonCardFlipAxis` (`rotationY` flip); damage / neutralize / continue use `dungeonCardWrap` + shell; `DUNGEON_OUTCOME` tweens the wrap only (no shell tween); teardown clears wrap + shell after that beat for neutral baseline (#66).
-// `HERO_CHANGE_INTERSTITIAL` → overlay only; bot bidding → `dungeonCardWrap` / `deckBadge` / equipment; neutralize + sacrifice use `presentationFlightLayer` + `equipment_*` (see presentationMotionRegistry.js).
-// Window resize during fragile motion (ghost flight #68, or dungeon reveal flip) swaps to shell+card-only tweens for the rest of that beat (#71); orchestrator `remainingMs` is not recomputed on resize (#68).
-usePresentationMotion({
-  activePresentation,
-  getMotionRefs: (head) => {
-    if (head?.kind === 'HERO_CHANGE_INTERSTITIAL') {
-      return {
-        heroChangeInterstitialOverlay: heroChangeInterstitialOverlayRef.value,
-        boardShell: boardShellRef.value,
-      }
-    }
-    const base = {
-      boardShell: boardShellRef.value,
-      dungeonCardWrap: dungeonCardMotionWrap.value,
-      dungeonCardFlipAxis: unwrapMotionDom(dungeonCardFaceRef.value?.dungeonCardFlipAxis),
-      deckBadge: domEl(deckBadgeRef.value),
-      dungeonPileBadge: dungeonPileMotionAnchorRef.value,
-      presentationFlightLayer: presentationFlightLayerRef.value,
-      presentationGhostTarget: heroCardSlotRef.value,
-    }
-    if (
-      presentationTraceEnabled() &&
-      (head?.kind === 'DUNGEON_REVEAL' || head?.kind === 'BIDDING_DRAW')
-    ) {
-      const snapEl = (el) => {
-        if (!el || typeof el.getBoundingClientRect !== 'function') return { present: false }
-        const r = el.getBoundingClientRect()
-        return {
-          present: true,
-          tag: el.tagName,
-          w: Math.round(r.width * 100) / 100,
-          h: Math.round(r.height * 100) / 100,
-          cx: Math.round((r.left + r.width / 2) * 100) / 100,
-          cy: Math.round((r.top + r.height / 2) * 100) / 100,
-        }
-      }
-      const deckNode = domEl(deckBadgeRef.value)
-      console.log('[DungeonRunner][card-flight][refs]', {
-        kind: head.kind,
-        id: head.id,
-        durationMs: head.durationMs,
-        dungeonCardWrap: snapEl(base.dungeonCardWrap),
-        dungeonPileAnchor: snapEl(base.dungeonPileBadge),
-        deckBadgeResolved: snapEl(base.deckBadge),
-        dungeonCardFlipAxis: snapEl(base.dungeonCardFlipAxis),
-        deckBadgeRawDomEl: snapEl(deckNode),
-        refsBound: {
-          dungeonPileMotionAnchorRef: !!dungeonPileMotionAnchorRef.value,
-          deckBadgeRef: !!deckBadgeRef.value,
-          dungeonCardMotionWrap: !!dungeonCardMotionWrap.value,
-          dungeonCardFaceRef: !!dungeonCardFaceRef.value,
-        },
-      })
-    }
-    if (head?.kind !== 'BIDDING_SACRIFICE' && head?.kind !== 'DUNGEON_NEUTRALIZE') return base
-    const ids = head?.payload?.responsibleEquipmentIds ?? head?.payload?.consumedEquipmentIds ?? []
-    const extra = {}
-    for (const id of ids) {
-      const node = biddingEquipmentBadgeRefs[id]
-      if (node?.nodeType === 1) extra[`equipment_${id}`] = node
-    }
-    return { ...base, ...extra }
-  },
-})
-const activePresentationLabel = ref('')
-const equipmentModalOpen = ref(false)
-const selectedEquipmentTokenId = ref(null)
-const neuralLoadGateTerminalOpen = ref(false)
-const neuralRefreshTerminalOpen = ref(false)
-const matchNeuralLoadGateInFlight = ref(false)
-const confirmationDialogOpen = ref(false)
-const confirmationDialogTitle = ref('Confirm')
-const confirmationDialogMessage = ref('')
-const confirmationDialogOkLabel = ref('OK')
-const confirmationDialogCancelLabel = ref('Cancel')
-let confirmationDialogResolve = null
-const vorpalDialogOpen = ref(false)
-const selectedVorpalSpecies = ref(null)
-const memoryAidState = ref(createMemoryAidState({ enabled: dungeonRunnerSettingsStore.memoryAidEnabled }))
-const previousVisibleState = ref(null)
-const dismissedDungeonRun = ref(null)
-const equipmentRemainingAtResolution = ref(null)
-const deferredPostDungeonState = ref(null)
-let presentationTimerId = null
-let aiTurnTimerId = null
-let autoResolveTimerId = null
-let aiTurnInFlight = false
-let lastAppliedAiTurnToken = null
-let presentationInputWasLocked = false
-let lastPresentationTraceKey = null
-let lastScheduleSkipKey = ''
-let lastPrimeSkipTraceKey = ''
-/** @type {Promise<void> | null} */
-let nnModelsWarmPromise = null
-
-const liveMatchPageSessionSink = createLiveMatchPageSessionSink({
+const liveMatch = useLiveMatchShell({
   match,
-  setNnModelsWarmPromise: (promise) => {
-    nnModelsWarmPromise = promise
-  },
-  resetAiTurnPrefetch,
-  setLastAppliedAiTurnTokenNull: () => {
-    lastAppliedAiTurnToken = null
-  },
-  setPresentationInputWasLockedFalse: () => {
-    presentationInputWasLocked = false
-  },
-  deferredPostDungeonState,
+  debugMode,
+  presentationSpeedProfile,
+  dungeonRunnerSettingsStore,
+  setup,
+  cloneSetup,
+  nnRecovery,
+  replayImportText,
+  replayExportText,
   nnDebugTraceText,
   nnDebugTraceHistory,
-  presentationOrchestrator,
-  syncPresentationLabel,
   neuralLoadGateTerminalOpen,
-  clearCurrentMatch,
-  storage: window.localStorage,
+  matchNeuralLoadGateInFlight,
+  notify: (opts) => $q.notify(opts),
 })
 
-const AI_TURN_SCHEDULE_DELAY_MS = 300
+provide(LIVE_MATCH_SHELL_SESSION_KEY, liveMatch)
 
-function aiTurnTrace(baseContext = {}) {
-  return createPipelineStepLogger('AITurn', debugMode.value, {
-    matchId: match.value?.id ?? null,
-    ...baseContext,
-  })
-}
+const humanSeatId = computed(
+  () => match.value?.state.seats.find((seat) => seat.role.type === 'human')?.id ?? null,
+)
 
-const SCHEDULE_SKIP_THROTTLE_REASONS = new Set([
-  'gameplay-locked',
-  'timer-pending',
-  'in-flight',
-  'already-applied-token',
-  'deferred-post-dungeon',
-  'headless-completion',
-])
-
-function logAiTurnScheduleSkip(reason, detail = {}) {
-  if (!debugMode.value) return
-  const key = `${reason}:${detail.runToken ?? detail.activeKind ?? ''}`
-  if (SCHEDULE_SKIP_THROTTLE_REASONS.has(reason) && key === lastScheduleSkipKey) return
-  lastScheduleSkipKey = key
-  console.warn('[DungeonRunner][AITurn][Schedule] skip', reason, detail)
-}
-
-function logAiTurnPrimeSkip(reason, detail = {}) {
-  if (!debugMode.value) return
-  const key = `${reason}:${detail.runToken ?? detail.phase ?? detail.seatId ?? detail.roleType ?? ''}`
-  if (key === lastPrimeSkipTraceKey) return
-  lastPrimeSkipTraceKey = key
-  aiTurnTrace()('prefetch.prime.skip', { reason, ...detail })
-}
-
-function scheduleAiTurnOnPresentationTick() {
-  if (!match.value || isHumanTurn.value || deferredPostDungeonState.value || headlessCompletionInFlight.value) {
-    return
-  }
-  scheduleAiTurnIfReady()
-}
-const uiAssets = dungeonRunnerAssetPack
-
-watch(presentationSpeedProfile, (next) => {
-  presentationOrchestrator.setSpeedProfile(next)
-  syncPresentationLabel()
-  triggerRef(activePresentation)
-  if (match.value) {
-    match.value = { ...match.value, presentationSpeedProfile: next }
-    persistCurrentMatch(window.localStorage, match.value)
-  }
-})
+const activePlayShell = computed(() =>
+  resolveActivePlayShell(
+    buildPlayShellSnapshot({
+      match: match.value,
+      neuralRefreshTerminalSurfaced: liveMatch.neuralRefreshTerminalOpen,
+      matchNeuralLoadGateInFlight: matchNeuralLoadGateInFlight.value,
+    }),
+  ),
+)
 
 watch(
-  () => dungeonRunnerSettingsStore.memoryAidEnabled,
-  (enabled) => {
-    memoryAidState.value = setMemoryAidEnabled(memoryAidState.value, enabled)
+  activePlayShell,
+  (shell) => {
+    if (shell === PLAY_SHELL.LIVE_MATCH) {
+      liveMatch.mountLiveMatchShell()
+    } else {
+      liveMatch.unmountLiveMatchShell()
+    }
   },
   { immediate: true },
 )
-
-watch(
-  () => setup.totalSeats,
-  (totalSeats) => {
-    const normalized = normalizeSetupState({ totalSeats, opponents: setup.opponents })
-    setup.totalSeats = normalized.totalSeats
-    setup.opponents.splice(0, setup.opponents.length, ...normalized.opponents)
-  },
-)
-
-watch(
-  () => setup.opponents.map((opponent) => opponent.type),
-  () => {
-    const defaultModel = pickDefaultModelId(modelOptions.value)
-    if (!defaultModel) return
-    for (const opponent of setup.opponents) {
-      if (opponent.type === 'nn' && !opponent.modelId) opponent.modelId = defaultModel
-    }
-  },
-)
-
-const setupIsValid = computed(
-  () =>
-    validateSetupConfig(normalizeSetupState(setup)).ok &&
-    canStartMatchFromSetup(setup) &&
-    validateSelectedModels(setup.opponents, modelOptions.value).ok,
-)
-const humanSeatId = computed(() => match.value?.state.seats.find((seat) => seat.role.type === 'human')?.id ?? null)
-const isHumanTurn = computed(
-  () => !!match.value && humanSeatId.value != null && match.value.state.turn.activeSeatId === humanSeatId.value,
-)
-const legalActions = computed(() => {
-  if (!match.value || !isHumanTurn.value) return []
-  return getLegalActions(match.value.state, { seatId: humanSeatId.value })
-})
-const visibleLegalActions = computed(() =>
-  filterVisibleLegalActions({
-    phase: match.value?.state?.phase ?? null,
-    legalActions: legalActions.value,
-  }),
-)
-const visiblePrimaryActions = computed(() =>
-  visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE'),
-)
-/** Matches engine pick-adventurer legal action order. */
-const HERO_CHOICE_ACTION_ORDER = ['WARRIOR', 'BARBARIAN', 'MAGE', 'ROGUE']
-const showHeroPickActionGrid = computed(() => {
-  const actions = visiblePrimaryActions.value
-  if (actions.length !== HERO_CHOICE_ACTION_ORDER.length) return false
-  return actions.every((a) => a.type === 'CHOOSE_NEXT_ADVENTURER')
-})
-const heroPickActionsOrdered = computed(() => {
-  if (!showHeroPickActionGrid.value) return []
-  const byHero = new Map(visiblePrimaryActions.value.map((a) => [a.hero, a]))
-  return HERO_CHOICE_ACTION_ORDER.map((hero) => byHero.get(hero)).filter(Boolean)
-})
-const showActionPane = computed(
-  () =>
-    !!activePresentationLabel.value ||
-    (isHumanTurn.value &&
-      (visiblePrimaryActions.value.length > 0 || dungeonOutcomeTransitionControls.value.length > 0)),
-)
-const biddingSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'))
-const biddingNonSacrificeActions = computed(() => visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'))
-const gameplayInputLocked = ref(false)
-const headlessCompletionInFlight = ref(false)
-const visibleState = computed(() => {
-  if (!match.value || !humanSeatId.value) return null
-  return getPlayerView(match.value.state, { seatId: humanSeatId.value })
-})
-const dungeonOutcomeAckPending = computed(() =>
-  isDungeonOutcomeDialogOpen({
-    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-    dismissedDungeonRun: dismissedDungeonRun.value,
-  }),
-)
-const dungeonEquipmentTokens = computed(() =>
-  buildDungeonEquipmentTokenView({
-    inPlayEquipmentIds: visibleState.value?.dungeon?.inPlayEquipmentIds ?? [],
-    legalActions: legalActions.value,
-  }),
-)
-const dungeonResolutionView = computed(() =>
-  createDungeonResolutionViewModel({
-    visibleState: visibleState.value ?? {},
-    previousVisibleState: previousVisibleState.value ?? {},
-    legalActions: legalActions.value,
-    activeAnimation: activePresentation.value,
-  }),
-)
-const showDungeonStage = computed(() => {
-  if (match.value?.state?.phase === 'dungeon') return true
-  if (isDungeonOrchestratorPresentationKind(activePresentation.value?.kind ?? null)) return true
-  return dungeonOutcomeAckPending.value
-})
-const dungeonStageView = computed(() =>
-  createDungeonResolutionViewModel({
-    visibleState: visibleState.value ?? {},
-    previousVisibleState: previousVisibleState.value ?? {},
-    legalActions: legalActions.value,
-    activeAnimation: activePresentation.value,
-    preserveMonsterCardUntilRunAck: dungeonOutcomeAckPending.value,
-  }),
-)
-const dungeonStageAnimationClass = computed(() => dungeonStageClassForKind(activePresentation.value?.kind ?? null))
-const dungeonOutcomeTransitionControls = computed(() =>
-  buildDungeonOutcomeTransitionControls({
-    phase: match.value?.state?.phase ?? null,
-    gameplayInputLocked: gameplayInputLocked.value,
-    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
-    autoAdvanceAction: dungeonResolutionView.value.autoAdvanceAction,
-  }),
-)
-const actionableEquipmentIds = computed(() => new Set(dungeonResolutionView.value.highlightedEquipmentIds))
-const boardEquipmentTokens = computed(() => {
-  const dungeonTokenById = new Map(dungeonEquipmentTokens.value.map((token) => [token.equipmentId, token]))
-  const isDungeonPhase = match.value?.state?.phase === 'dungeon'
-  const hasActionable = actionableEquipmentIds.value.size > 0
-  return biddingBoard.value.secondary.equipment.map((equipment) => {
-    const dungeonToken = dungeonTokenById.get(equipment.equipmentId)
-    const removed =
-      equipment.removed ||
-      equipment.consumed ||
-      (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
-    const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
-    const appearance = equipmentTokenAppearance(equipment.equipmentId)
-    return {
-      equipmentId: equipment.equipmentId,
-      ariaLabel: equipmentShortName(equipment.equipmentId),
-      symbolRuntimePath: dungeonRunnerEquipmentSymbolRuntimePath(appearance.symbolKey),
-      equipmentOverlay: appearance.overlay,
-      removed,
-      glow: isDungeonPhase ? (dungeonToken?.glow ?? false) : false,
-      pulse: actionable,
-      deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
-      canUseNow: dungeonToken?.canUseNow ?? false,
-      hasModal: true,
-    }
-  })
-})
-const selectedEquipmentModalView = computed(() => {
-  if (!selectedEquipmentTokenId.value) return null
-  return createDungeonEquipmentModalView({
-    equipmentId: selectedEquipmentTokenId.value,
-    legalActions: legalActions.value,
-  })
-})
-const vorpalPromptView = computed(() =>
-  createVorpalDeclarationPromptView({
-    isHumanTurn: isHumanTurn.value,
-    gameplayInputLocked: gameplayInputLocked.value,
-    phase: match.value?.state?.phase ?? null,
-    subphase: match.value?.state?.dungeon?.subphase ?? null,
-    legalActions: legalActions.value,
-    memoryAidEnabled: memoryAidState.value.enabled,
-    viewerOwnPileAdds: visibleState.value?.playerOwnPileAdds?.[humanSeatId.value ?? ''] ?? [],
-  }),
-)
-const vorpalSelectOptions = computed(() => {
-  const pv = vorpalPromptView.value
-  const counts = pv.vorpalSpeciesOwnPileCounts
-  return pv.speciesOptions.map((species) => {
-    const n = counts?.[species] ?? 0
-    const label = n > 0 ? `${species} (${n})` : species
-    return { label, value: species }
-  })
-})
-const biddingBoard = computed(() =>
-  createBiddingBoardViewModel({
-    state: match.value?.state ?? null,
-    visibleState: visibleState.value,
-    activeAnimation: activePresentation.value,
-    viewerSeatId: humanSeatId.value,
-    settings: {
-      memoryAidEnabled: memoryAidState.value.enabled,
-    },
-  }),
-)
-const seatRunTrackerRows = computed(() => {
-  const recoveryBySeatId = new Map(
-    seatRecoveryIndicators.value.map((entry) => [entry.seatId, entry]),
-  )
-  return biddingBoard.value.secondary.seats.map((row) => {
-    const scoreboard = match.value?.state?.scoreboard ?? {}
-    const score = scoreboard[row.seatId] ?? {}
-    const successes = Math.max(0, Number(score.successes ?? 0))
-    const failures = Math.max(0, 2 - Number(score.lives ?? 2))
-    const recovery = recoveryBySeatId.get(row.seatId)
-    return {
-      seatId: row.seatId,
-      label: row.label,
-      passed: row.passed,
-      isActive: row.isActive,
-      successes,
-      failures,
-      recovering: recovery?.recovering ?? false,
-      recoveryTestId: recovery?.testId ?? null,
-      ariaLabel: `${row.label}: ${successes} successful run${successes === 1 ? '' : 's'}, ${failures} failed run${failures === 1 ? '' : 's'}`,
-    }
-  })
-})
-const biddingCardEmpty = computed(
-  () =>
-    match.value?.state?.phase === 'bidding' &&
-    !showDungeonStage.value &&
-    biddingBoard.value.primaryCard.variant === 'empty',
-)
-const monsterCardSlotEmpty = computed(() => {
-  if (showDungeonStage.value) return dungeonStageView.value.monster.visibility === 'empty'
-  return biddingCardEmpty.value
-})
-const biddingStageSpecies = computed(() => {
-  if (showDungeonStage.value) return null
-  if (match.value?.state?.phase !== 'bidding') return null
-  if (activePresentation.value?.kind === 'BIDDING_DRAW') return null
-  return biddingBoard.value.primaryCard.variant === 'revealed' ? biddingBoard.value.primaryCard.monsterCard : null
-})
-const biddingStageFaceDown = computed(() => {
-  if (showDungeonStage.value) return true
-  if (match.value?.state?.phase !== 'bidding') return true
-  if (activePresentation.value?.kind === 'BIDDING_DRAW') return true
-  return biddingBoard.value.primaryCard.variant !== 'revealed'
-})
-const heroChangeInterstitialView = computed(() => {
-  if (activePresentation.value?.kind !== 'HERO_CHANGE_INTERSTITIAL') return null
-  const payload = activePresentation.value?.payload
-  if (!payload?.heroAfter) return null
-  const seats = match.value?.state?.seats ?? []
-  const actorSeatId = payload.actorSeatId ?? null
-  const actorLabel =
-    seats.find((seat) => seat.id === actorSeatId)?.label ?? actorSeatId ?? 'Unknown'
-  const chosen = getHeroIdentity(payload.heroAfter)
-  return {
-    headline: adventurerChoiceHeadline(actorLabel, payload.heroAfter),
-    chosen,
-  }
-})
-const heroChangeInterstitialAriaLabel = computed(() => heroChangeInterstitialView.value?.headline ?? '')
-const deckSplayOpen = computed({
-  get() {
-    return memoryAidState.value.deckSplayOpen
-  },
-  set(open) {
-    memoryAidState.value = open ? tapDeck(memoryAidState.value) : closeDeckSplay(memoryAidState.value)
-  },
-})
-const dungeonOutcomeSummary = computed(() =>
-  buildDungeonOutcomeSummary({
-    lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-    seats: match.value?.state?.seats ?? [],
-    equipmentRemainingAtResolution: equipmentRemainingAtResolution.value,
-  }),
-)
-const dungeonOutcomeToneClass = computed(() =>
-  dungeonOutcomeSummary.value?.resultLabel === 'Success' ? 'dr-outcome--success' : 'dr-outcome--failure',
-)
-const dungeonOutcomeMessage = computed(() =>
-  dungeonOutcomeSummary.value?.resultLabel === 'Success'
-    ? 'Clean run. The dungeon is cleared.'
-    : 'The run failed.',
-)
-const dungeonOutcomeDialogOpen = computed({
-  get() {
-    return shouldShowDungeonOutcomeDialog({
-      headlessCompletionInFlight: headlessCompletionInFlight.value,
-      gameplayInputLocked: gameplayInputLocked.value,
-      lastDungeonRun: match.value?.state?.lastDungeonRun ?? null,
-      dismissedDungeonRun: dismissedDungeonRun.value,
-    })
-  },
-  set(open) {
-    if (open) return
-    continueFromDungeonOutcome()
-  },
-})
-const humanGameplayBlocked = computed(() =>
-  isHumanGameplayBlocked({
-    gameplayInputLocked: gameplayInputLocked.value,
-    dungeonOutcomeDialogOpen: dungeonOutcomeDialogOpen.value,
-    headlessCompletionInFlight: headlessCompletionInFlight.value,
-    neuralRefreshTerminalOpen: neuralRefreshTerminalOpen.value,
-  }),
-)
-const equipmentModalActionsDisabled = computed(() =>
-  isEquipmentModalActionsDisabled({
-    humanGameplayBlocked: humanGameplayBlocked.value,
-    isHumanTurn: isHumanTurn.value,
-  }),
-)
-const matchOverSummary = computed(() =>
-  buildMatchOverSummary({
-    state: match.value?.state ?? null,
-    humanPlayerSeatId: humanSeatId.value,
-    seats: match.value?.state?.seats ?? [],
-  }),
-)
-const matchOverToneClass = computed(() =>
-  matchOverSummary.value.variant === MATCH_OVER_END_VARIANTS.VICTORY
-    ? 'dr-outcome--success'
-    : 'dr-outcome--failure',
-)
-const matchOverDialogOpen = computed({
-  get() {
-    return !!match.value && match.value.state.phase === MATCH_PHASES.MATCH_OVER
-  },
-  set() {
-    // Persistent modal; rematch/back-to-setup are the only exits.
-  },
-})
 
 onMounted(() => {
   debugMode.value = shouldEnableDebugOnBoot(window.location.href)
-  presentationOrchestrator.setSpeedProfile(presentationSpeedProfile.value)
-  unsubscribeNnRecovery = nnRecovery.subscribe(onNnRecoveryChanged)
-  if (presentationTraceEnabled()) {
-    console.log(
-      '[DungeonRunner][presentation] trace on — localStorage.setItem("dungeonPresentationTrace","1") — also logs [card-flight] for pile/deck → card motion',
-    )
-  }
   void bootstrapDungeonRunnerPage()
   void loadModelCatalog()
-  presentationTimerId = window.setInterval(() => {
-    runPresentationIntervalTick(presentationOrchestrator, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS, {
-      syncPresentationLabel,
-      scheduleAiTurnIfReady: scheduleAiTurnOnPresentationTick,
-      scheduleHumanAutoResolveIfReady,
-    })
-  }, DUNGEON_RUNNER_PRESENTATION_ADVANCE_MS)
 })
-
-function applyBootstrappedMatchSession(matchEnvelope, pace) {
-  dungeonRunnerSettingsStore.setAnimationPace(pace)
-  match.value = matchEnvelope
-  syncSeatRecoveryIndicators()
-  activeSeatRecoveryBlocking = resolveActiveSeatRecoveryBlocking()
-  deferredPostDungeonState.value = null
-  presentationOrchestrator.clear()
-  presentationSpeedProfile.value = pace
-  presentationOrchestrator.setSpeedProfile(pace)
-  nnModelsWarmPromise = Promise.resolve()
-  syncPresentationLabel()
-}
-
-async function bootstrapDungeonRunnerPage() {
-  const result = await bootstrapCurrentMatchFromStorage(matchPageOrchestrationCtx)
-
-  if (result.kind === 'no-saved-match') return
-  if (result.kind === 'setup-terminal') {
-    resetLiveMatchPageStateForSetupTerminal()
-    return
-  }
-
-  applyBootstrappedMatchSession(result.match, result.presentationSpeedProfile)
-
-  if (result.kind === 'refresh-terminal') {
-    neuralRefreshTerminalOpen.value = true
-    return
-  }
-
-  void maybeRunHeadlessMatchCompletion()
-}
 
 onBeforeUnmount(() => {
-  unsubscribeNnRecovery?.()
-  unsubscribeNnRecovery = null
-  if (presentationTimerId) window.clearInterval(presentationTimerId)
-  if (aiTurnTimerId) window.clearTimeout(aiTurnTimerId)
-  if (autoResolveTimerId) window.clearTimeout(autoResolveTimerId)
-  if (typeof confirmationDialogResolve === 'function') {
-    confirmationDialogResolve(false)
-    confirmationDialogResolve = null
-  }
+  liveMatch.unmountLiveMatchShell()
 })
 
-watch(
-  () => match.value?.state?.phase,
-  (phase) => {
-    if (shouldUploadCompletedMatchReplayForPhase(phase)) {
-      completedMatchReplayUpload.maybeUpload(match.value)
-    }
-  },
-  { immediate: true },
-)
-
-watch(
-  () => match.value?.state,
-  (state) => {
-    if (!match.value || !state) return
-    syncSeatRecoveryIndicators()
-    applySeatRecoveryBlockingTransition(resolveActiveSeatRecoveryBlocking())
-    persistCurrentMatch(window.localStorage, match.value)
-    scheduleAiTurnIfReady()
-    scheduleHumanAutoResolveIfReady()
-  },
-  { deep: true },
-)
-
-watch(
-  () => match.value?.state?.lastDungeonRun ?? null,
-  (run) => {
-    const update = resolveLastDungeonRunWatcherUpdate(run, match.value?.state?.centerEquipment)
-    if ('dismissedDungeonRun' in update) {
-      dismissedDungeonRun.value = update.dismissedDungeonRun
-      equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
-      return
-    }
-    equipmentRemainingAtResolution.value = update.equipmentRemainingAtResolution
-  },
-  { immediate: true },
-)
-
-watch(
-  () => vorpalPromptView.value.open,
-  (open) => {
-    if (!open) {
-      vorpalDialogOpen.value = false
-      selectedVorpalSpecies.value = null
-      return
-    }
-    vorpalDialogOpen.value = true
-    const firstSpecies = vorpalPromptView.value.speciesOptions[0] ?? null
-    if (!selectedVorpalSpecies.value || !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)) {
-      selectedVorpalSpecies.value = firstSpecies
-    }
-  },
-)
-
-function resetLiveMatchPageStateForSetupTerminal() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    clearMatch: true,
-    openNeuralLoadGateTerminal: true,
-  })
-}
-
-function resetLiveMatchPageStateForFreshMatchEntry() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    warmModelsResolved: true,
-  })
-}
-
-function resetLiveMatchPageStateForBackToSetup() {
-  resetLiveMatchPageState(liveMatchPageSessionSink, {
-    clearMatch: true,
-    clearPersistedMatch: true,
-  })
-}
-
-const matchPageOrchestrationCtx = createMatchPageOrchestrationContext({
-  storage: window.localStorage,
-  recovery: nnRecovery,
-  loadModel: loadNnModel,
-  setMatchNeuralLoadGateInFlight: (inFlight) => {
-    matchNeuralLoadGateInFlight.value = inFlight
-  },
-  clearCurrentMatch,
-  persistCurrentMatch,
-  applySetupSnapshot,
-  setupTarget: setup,
-  cloneSetup,
-  onSetupTerminal: () => {
-    resetLiveMatchPageStateForSetupTerminal()
-  },
-})
-
-async function runLivePageMatchEntryGate(setupSnapshot) {
-  return runMatchEntryNeuralLoadGateForPage(matchPageOrchestrationCtx, {
-    setupSnapshot,
-    releaseInFlightAfterGate: false,
-  })
+async function bootstrapDungeonRunnerPage() {
+  const result = await bootstrapCurrentMatchFromStorage(liveMatch.matchPageOrchestrationCtx)
+  liveMatch.processBootstrappedSession(result)
 }
 
 async function startNewMatch() {
-  const modelValidation = validateSelectedModels(setup.opponents, modelOptions.value)
-  if (!modelValidation.ok) {
-    $q.notify({
-      type: 'negative',
-      message:
-        modelValidation.errorCode === 'MODEL_REQUIRED'
-          ? 'Every NN opponent must select a model.'
-          : 'One or more NN model selections are unavailable.',
-    })
+  const startCheck = evaluatePlaySetupStart({
+    setup,
+    modelOptions: modelOptions.value,
+  })
+  if (!startCheck.ok) {
+    const message =
+      startCheck.errorCode === 'MODEL_REQUIRED'
+        ? 'Every NN opponent must select a model.'
+        : startCheck.errorCode === 'MODEL_UNAVAILABLE'
+          ? 'One or more NN model selections are unavailable.'
+          : 'Match setup is invalid.'
+    $q.notify({ type: 'negative', message })
     return
   }
   const setupSnapshot = cloneSetup()
   matchNeuralLoadGateInFlight.value = true
   try {
-    const gateResult = await runLivePageMatchEntryGate(setupSnapshot)
+    const gateResult = await liveMatch.runLivePageMatchEntryGate(setupSnapshot)
     if (gateResult.kind === 'setup-terminal') {
-      resetLiveMatchPageStateForSetupTerminal()
+      liveMatch.resetForSetupTerminal()
       return
     }
     clearCurrentMatch(window.localStorage)
     const seed = createMatchSeed()
-    resetLiveMatchPageStateForFreshMatchEntry()
-    match.value = buildNewMatchEnvelope({
+    liveMatch.resetForFreshMatchEntry()
+    match.value = liveMatch.buildNewMatchEnvelope({
       setupSnapshot,
       seed,
       id: `match-${Date.now()}`,
@@ -1594,8 +271,7 @@ async function startNewMatch() {
     })
   } finally {
     matchNeuralLoadGateInFlight.value = false
-    scheduleAiTurnIfReady()
-    scheduleHumanAutoResolveIfReady()
+    liveMatch.kickMatchAutomation()
   }
 }
 
@@ -1604,17 +280,17 @@ async function rematch() {
   const setupSnapshot = cloneSetup(match.value.setup)
   matchNeuralLoadGateInFlight.value = true
   try {
-    const gateResult = await runLivePageMatchEntryGate(setupSnapshot)
+    const gateResult = await liveMatch.runLivePageMatchEntryGate(setupSnapshot)
     if (gateResult.kind === 'setup-terminal') {
-      resetLiveMatchPageStateForSetupTerminal()
+      liveMatch.resetForSetupTerminal()
       return
     }
     const preservedBotLabels = match.value.state.seats
       .filter((seat) => seat.role?.type !== 'human' && seat.label)
       .map((seat) => seat.label)
     const seed = createMatchSeed()
-    resetLiveMatchPageStateForFreshMatchEntry()
-    match.value = buildNewMatchEnvelope({
+    liveMatch.resetForFreshMatchEntry()
+    match.value = liveMatch.buildNewMatchEnvelope({
       setupSnapshot,
       seed,
       id: `match-${Date.now()}`,
@@ -1623,135 +299,20 @@ async function rematch() {
     })
   } finally {
     matchNeuralLoadGateInFlight.value = false
-    scheduleAiTurnIfReady()
-    scheduleHumanAutoResolveIfReady()
+    liveMatch.kickMatchAutomation()
   }
-}
-
-async function ensureNnModelsReady() {
-  await nnModelsWarmPromise?.catch(() => {})
-}
-
-function dismissNeuralLoadGateTerminal() {
-  neuralLoadGateTerminalOpen.value = false
-}
-
-function reloadPageForNeuralRefreshTerminal() {
-  window.location.reload()
-}
-
-function handleNeuralRecoveryTerminalError(error) {
-  const result = handleLivePlayNeuralRecoveryTerminalError({
-    error,
-    match: match.value,
-    recovery: nnRecovery,
-    storage: window.localStorage,
-    persistCurrentMatch,
-    restoreSetup: (setupSnapshot) => {
-      matchPageOrchestrationCtx.applySetupTerminal(cloneSetup(setupSnapshot))
-    },
-  })
-  if (!result.handled) return false
-  if (result.action === 'refresh-dialog') {
-    match.value = result.match
-    neuralRefreshTerminalOpen.value = true
-    logNnRecoveryTrace(result.trace.modelId, 'terminal', {
-      terminal: result.trace.terminal,
-      failureKind: result.trace.failureKind,
-    })
-  }
-  return true
 }
 
 function backToSetup() {
-  resetLiveMatchPageStateForBackToSetup()
+  liveMatch.resetForBackToSetup()
 }
 
-function takeHumanAction(action) {
-  if (!match.value || !humanSeatId.value) {
-    return
-  }
-  resetAiTurnPrefetch()
-  if (humanGameplayBlocked.value) {
-    return
-  }
-  if (autoResolveTimerId) {
-    window.clearTimeout(autoResolveTimerId)
-    autoResolveTimerId = null
-  }
-  if (equipmentModalOpen.value) equipmentModalOpen.value = false
-  const prevState = match.value.state
-  previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
-  const result = applyAction(prevState, action, { seatId: humanSeatId.value })
-  if (!result.ok) {
-    return
-  }
-  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
-  if (deferExit) {
-    deferredPostDungeonState.value = result.state
-    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
-  } else {
-    deferredPostDungeonState.value = null
-    match.value = { ...match.value, state: result.state }
-  }
-  enqueuePresentationTransition(prevState, result.state, action, humanSeatId.value, 'human')
-}
-
-function onMemoryAidToggle(enabled) {
-  dungeonRunnerSettingsStore.setMemoryAidEnabled(enabled === true)
-}
-
-function onDeckTap() {
-  memoryAidState.value = tapDeck(memoryAidState.value)
-}
-
-function onCloseDeckSplay() {
-  memoryAidState.value = closeDeckSplay(memoryAidState.value)
-}
-
-function settleConfirmationDialog(result) {
-  confirmationDialogOpen.value = false
-  const resolve = confirmationDialogResolve
-  confirmationDialogResolve = null
-  if (typeof resolve === 'function') resolve(result)
-}
-
-function requestConfirmation({ title = 'Confirm', message, okLabel = 'OK', cancelLabel = 'Cancel' }) {
-  if (typeof confirmationDialogResolve === 'function') {
-    confirmationDialogResolve(false)
-    confirmationDialogResolve = null
-  }
-  confirmationDialogTitle.value = title
-  confirmationDialogMessage.value = message
-  confirmationDialogOkLabel.value = okLabel
-  confirmationDialogCancelLabel.value = cancelLabel
-  confirmationDialogOpen.value = true
-  return new Promise((resolve) => {
-    confirmationDialogResolve = resolve
-  })
-}
-
-function onConfirmationDialogOk() {
-  settleConfirmationDialog(true)
-}
-
-function onConfirmationDialogCancel() {
-  settleConfirmationDialog(false)
-}
-
-function openEquipmentModal(token) {
-  if (shouldRejectEquipmentTokenTap({ hasModal: token?.hasModal, humanGameplayBlocked: humanGameplayBlocked.value })) return
-  selectedEquipmentTokenId.value = token.equipmentId
-  equipmentModalOpen.value = true
-}
-
-function takeEquipmentUseAction() {
-  if (equipmentModalActionsDisabled.value || !selectedEquipmentModalView.value?.useAction) return
-  takeHumanAction(selectedEquipmentModalView.value.useAction)
+function exportReplay() {
+  liveMatch.exportReplay()
 }
 
 async function startNewMatchIntentional() {
-  const shouldStartFresh = await requestConfirmation({
+  const shouldStartFresh = await liveMatch.requestConfirmation({
     title: 'Start a new match?',
     message: 'This will discard your current match and return to setup.',
     okLabel: 'Start new',
@@ -1761,569 +322,14 @@ async function startNewMatchIntentional() {
   backToSetup()
 }
 
-function continueFromEquipmentModal() {
-  if (!equipmentModalActionsDisabled.value && selectedEquipmentModalView.value?.continueAction) {
-    takeHumanAction(selectedEquipmentModalView.value.continueAction)
-    return
-  }
-  equipmentModalOpen.value = false
-}
-
-async function continueFromDungeonOutcome() {
-  const run = match.value?.state?.lastDungeonRun
-  if (!run) return
-  dismissedDungeonRun.value = dismissDungeonRunForOutcomeDialog(run)
-  if (deferredPostDungeonState.value) {
-    match.value = { ...match.value, state: deferredPostDungeonState.value }
-    deferredPostDungeonState.value = null
-  }
-  presentationOrchestrator.flushPostDungeonOutcomeAnimations()
-  syncPresentationLabel()
-  await maybeRunHeadlessMatchCompletion()
-}
-
-function teardownForHeadlessMatchCompletion() {
-  if (aiTurnTimerId) {
-    window.clearTimeout(aiTurnTimerId)
-    aiTurnTimerId = null
-  }
-  if (autoResolveTimerId) {
-    window.clearTimeout(autoResolveTimerId)
-    autoResolveTimerId = null
-  }
-  resetAiTurnPrefetch()
-  abandonScheduledInferenceQueue()
-  presentationOrchestrator.clear()
-  deferredPostDungeonState.value = null
-  lastAppliedAiTurnToken = null
-  const run = match.value?.state?.lastDungeonRun
-  if (run) dismissedDungeonRun.value = run
-}
-
-function createPageHeadlessCompletionFlightGate() {
-  return {
-    get inFlight() {
-      return headlessCompletionInFlight.value
-    },
-    tryStart() {
-      if (headlessCompletionInFlight.value) return false
-      headlessCompletionInFlight.value = true
-      return true
-    },
-    finish() {
-      headlessCompletionInFlight.value = false
-    },
-  }
-}
-
-async function maybeRunHeadlessMatchCompletion() {
-  try {
-    const result = await runHeadlessMatchCompletionForPage(matchPageOrchestrationCtx, {
-      match: match.value,
-      humanPlayerSeatId: humanSeatId.value,
-      chooseAction: createLivePlayActionChooser(buildLivePlayChooserDeps()),
-      gate: createPageHeadlessCompletionFlightGate(),
-      teardown: teardownForHeadlessMatchCompletion,
-    })
-
-    if (result.kind === 'completed' || result.kind === 'refresh-terminal') {
-      match.value = result.match
-    }
-    if (result.kind === 'refresh-terminal') {
-      neuralRefreshTerminalOpen.value = true
-      logNnRecoveryTrace(result.modelId, 'terminal', {
-        terminal: result.terminal,
-        failureKind: result.failureKind ?? null,
-      })
-    } else if (result.kind === 'setup-terminal') {
-      // applySetupTerminal already ran inside runHeadlessMatchCompletionForPage
-    } else if (result.kind === 'failed' && debugMode.value) {
-      console.warn('[DungeonRunner][headless] completion failed', result.errorCode, result.actionCount)
-    }
-  } finally {
-    syncPresentationLabel()
-  }
-}
-
-function confirmVorpalDeclaration() {
-  if (!selectedVorpalSpecies.value) return
-  takeHumanAction({
-    type: 'DECLARE_VORPAL',
-    species: selectedVorpalSpecies.value,
-  })
-}
-
-async function runAiTurn() {
-  const trace = aiTurnTrace()
-  const seatId = match.value?.state?.turn?.activeSeatId ?? null
-  const runToken = match.value
-    ? buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-    : ''
-  const gate = evaluatePageAiTurnPipelineGate({ runToken })
-  if (!gate.mayRunTurn) {
-    const presentationQueueSnapshot = presentationOrchestrator.getQueueSnapshot()
-    const skipTrace = buildAiTurnRunSkipTrace(gate, {
-      runToken,
-      seatId,
-      humanSeatId: humanSeatId.value,
-      phase: match.value?.state?.phase ?? null,
-      activePresentationKind: activePresentation.value?.kind ?? null,
-      queueMs: presentationQueueSnapshot.reduce((sum, item) => sum + item.remainingMs, 0),
-      lastAppliedAiTurnToken,
-    })
-    if (skipTrace) {
-      trace(skipTrace.step, skipTrace.detail)
-    }
-    return
-  }
-  aiTurnInFlight = true
-  try {
-  trace('run.begin', {
-    runToken,
-    phase: match.value.state.phase,
-    seatId,
-    turnNumber: match.value.state.turn.turnNumber,
-    biddingSubphase: match.value.state.bidding?.subphase ?? null,
-    revealedMonsterCard: match.value.state.bidding?.revealedMonsterCard ?? null,
-    dungeonSubphase: match.value.state.dungeon?.subphase ?? null,
-  })
-  const seat = match.value.state.seats.find((candidate) => candidate.id === seatId)
-  const roleType = seat?.role?.type
-  const chooseAction = createLivePlayActionChooser(buildLivePlayChooserDeps({
-    tryConsumePrefetch: async ({ runToken: consumeRunToken }) => {
-      const prefetchGate = evaluatePageAiTurnPipelineGate({ runToken: consumeRunToken ?? runToken })
-      return consumeAiTurnPrefetch({
-        runToken: consumeRunToken ?? runToken,
-        mayPrefetch: prefetchGate.mayPrefetch,
-        prefetchSkipReason: prefetchGate.prefetchSkipReason,
-        trace: (step, detail) => trace(step, detail),
-      })
-    },
-  }))
-  let action
-  try {
-    action = await chooseAction({ state: match.value.state, seatId, runToken })
-  } catch (error) {
-    if (handleNeuralRecoveryTerminalError(error)) {
-      trace('run.abort', {
-        reason: 'nn-recovery-terminal',
-        terminal: error.terminal,
-        modelId: error.modelId,
-      })
-      return
-    }
-    throw error
-  }
-  if (!action) {
-    trace('run.abort', { reason: 'no-action' })
-    return
-  }
-  if (!match.value) {
-    trace('run.abort', { reason: 'match-cleared' })
-    return
-  }
-  const currentToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-  if (runToken !== currentToken) {
-    trace('run.abort', { reason: 'stale-token', runToken, currentToken })
-    return
-  }
-  const prevState = match.value.state
-  if (humanSeatId.value) {
-    previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
-  }
-  const result = applyAction(prevState, action, { seatId })
-  if (!result.ok) {
-    trace('run.abort', { reason: 'apply-failed', actionType: action.type })
-    return
-  }
-  lastAppliedAiTurnToken = runToken
-  const deferExit = shouldDeferDungeonExitUntilOutcomeAck(prevState, result.state)
-  if (deferExit) {
-    deferredPostDungeonState.value = result.state
-    match.value = { ...match.value, state: { ...result.state, phase: MATCH_PHASES.DUNGEON } }
-  } else {
-    deferredPostDungeonState.value = null
-    match.value = { ...match.value, state: result.state }
-  }
-  trace('run.applied', {
-    actionType: action.type,
-    nextRunToken: buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state }),
-    phaseAfter: match.value.state.phase,
-    turnAfterSeatId: match.value.state.turn.activeSeatId,
-    deferExit,
-  })
-  enqueuePresentationTransition(prevState, result.state, action, seatId, roleType ?? 'randombot')
-  if (debugMode.value) {
-    const snap = presentationOrchestrator.getQueueSnapshot()
-    trace('presentation.enqueued', {
-      queue: snap.map((item) => item.kind),
-      queueMs: snap.reduce((sum, item) => sum + item.remainingMs, 0),
-    })
-  }
-  primeAiTurnPrefetch()
-  } finally {
-    aiTurnInFlight = false
-    trace('run.finally', { inFlight: false })
-  }
-}
-
-function primeAiTurnPrefetch(precomputedGate = null) {
-  const trace = aiTurnTrace()
-  const state = match.value?.state
-  const seatId = state?.turn?.activeSeatId ?? null
-  const seat = state?.seats?.find((candidate) => candidate.id === seatId)
-  const runToken = match.value ? buildAiTurnRunToken({ matchId: match.value.id, state }) : ''
-  const modelId = seat?.role?.type === 'nn' ? seat.role.modelId ?? 'latest' : null
-  const gate = precomputedGate ?? evaluatePageAiTurnPipelineGate({ runToken })
-  if (!gate.mayPrefetch) {
-    const skipTrace = buildAiTurnPrefetchSkipTrace(gate, {
-      seatId,
-      phase: state?.phase ?? null,
-      runToken,
-      modelId,
-      roleType: seat?.role?.type ?? null,
-    })
-    if (skipTrace) {
-      logAiTurnPrimeSkip(skipTrace.reason, skipTrace.detail)
-    }
-    return
-  }
-  lastPrimeSkipTraceKey = ''
-  startAiTurnPrefetch({
-    runToken,
-    mayPrefetch: true,
-    prefetchSkipReason: null,
-    trace: (step, detail) => trace(step, detail),
-    compute: async () => {
-      await ensureNnModelsReady()
-      return chooseNnActionWithRecovery(state, { seatId }, nnRuntimeOptions(modelId))
-    },
-  })
-}
-
-function enqueuePresentationTransition(prevState, nextState, action, actorSeatId, actorRoleType) {
-  const deferPostDungeonOutcomeAck = shouldDeferDungeonExitUntilOutcomeAck(prevState, nextState)
-  presentationOrchestrator.enqueueEngineTransition(
-    {
-      phaseBefore: prevState.phase,
-      phaseAfter: nextState.phase,
-      turnBeforeSeatId: prevState.turn.activeSeatId,
-      turnAfterSeatId: nextState.turn.activeSeatId,
-      dungeonRunResult:
-        prevState.lastDungeonRun?.result === nextState.lastDungeonRun?.result ? null : nextState.lastDungeonRun?.result ?? null,
-      action,
-      actorSeatId,
-      actorRoleType,
-      centerEquipmentBefore: prevState.centerEquipment ?? [],
-      centerEquipmentAfter: nextState.centerEquipment ?? [],
-      heroBefore: prevState.hero,
-      heroAfter: nextState.hero,
-      dungeonBefore: summarizeDungeonForPresentation(prevState.dungeon),
-      dungeonAfter: summarizeDungeonForPresentation(nextState.dungeon),
-      biddingBefore:
-        prevState.phase === MATCH_PHASES.BIDDING
-          ? {
-              revealedMonsterCard: prevState.bidding?.revealedMonsterCard ?? null,
-              revealedBySeatId: prevState.bidding?.revealedBySeatId ?? null,
-            }
-          : null,
-    },
-    { deferPostDungeonOutcomeAck },
-  )
-  if (presentationTraceEnabled()) {
-    const snap = presentationOrchestrator.getQueueSnapshot()
-    console.log('[DungeonRunner][presentation] enqueue', {
-      phase: `${prevState.phase}→${nextState.phase}`,
-      action: action?.type ?? null,
-      actorRole: actorRoleType,
-      queue: snap.map((x) => x.kind),
-    })
-  }
-  syncPresentationLabel()
-}
-
-function summarizeDungeonForPresentation(dungeonState) {
-  if (!dungeonState) return null
-  const discardedRunMonsterIds = Array.isArray(dungeonState.discardedRunMonsters)
-    ? [...dungeonState.discardedRunMonsters]
-    : []
-  const rawDefeatRecord = dungeonState.lastDefeatRecord ?? null
-  const lastDefeatRecord = rawDefeatRecord
-    ? {
-        monsterCard: rawDefeatRecord.monsterCard ?? null,
-        byEquipmentIds: Array.isArray(rawDefeatRecord.byEquipmentIds) ? [...rawDefeatRecord.byEquipmentIds] : [],
-        expendedEquipmentIds: Array.isArray(rawDefeatRecord.expendedEquipmentIds)
-          ? [...rawDefeatRecord.expendedEquipmentIds]
-          : [],
-      }
-    : null
-  return {
-    subphase: dungeonState.subphase ?? null,
-    currentMonster: dungeonState.currentMonster ?? null,
-    remainingMonsterCount: Array.isArray(dungeonState.remainingMonsters)
-      ? dungeonState.remainingMonsters.length
-      : 0,
-    discardedMonsterCount: discardedRunMonsterIds.length,
-    discardedRunMonsterIds,
-    hp: Number.isFinite(dungeonState.hp) ? dungeonState.hp : null,
-    lastDefeatRecord,
-  }
-}
-
-function enrichPresentationForViewer(head) {
-  if (!head) return null
-  const kind = head.kind
-  const basePayload = head.payload && typeof head.payload === 'object' ? { ...head.payload } : {}
-
-  if (kind === 'BIDDING_DRAW') {
-    const actorSeatId = basePayload.actorSeatId ?? null
-    basePayload.shouldFlipFaceAfterArrival = viewerMaySeeBiddingDrawFace({
-      viewerSeatId: humanSeatId.value,
-      actorSeatId,
-    })
-    return { ...head, payload: basePayload }
-  }
-  if (kind === 'BIDDING_ADD') {
-    basePayload.shouldFlipToBackBeforeDungeon = viewerMaySeeAddToDungeonFlipDown({
-      viewerSeatId: humanSeatId.value,
-      actorSeatId: basePayload.actorSeatId ?? null,
-      actorRoleType: basePayload.actorRoleType ?? null,
-    })
-    return { ...head, payload: basePayload }
-  }
-  return head
-}
-
-function syncPresentationLabel() {
-  activePresentation.value = enrichPresentationForViewer(presentationOrchestrator.getActiveAnimation())
-  activePresentationLabel.value = activePresentation.value?.label ?? ''
-  const locked = presentationOrchestrator.isGameplayInputLocked()
-  gameplayInputLocked.value = locked
-  if (presentationInputWasLocked && !locked) {
-    lastScheduleSkipKey = ''
-    lastPrimeSkipTraceKey = ''
-    if (debugMode.value) {
-      const snap = presentationOrchestrator.getQueueSnapshot()
-      aiTurnTrace()('presentation.unlock', {
-        queuedKinds: snap.map((item) => item.kind),
-        isHumanTurn: isHumanTurn.value,
-        activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
-      })
-    }
-    scheduleAiTurnIfReady()
-    scheduleHumanAutoResolveIfReady()
-  }
-  presentationInputWasLocked = locked
-  if (presentationTraceEnabled()) {
-    const a = activePresentation.value
-    const key = a ? `${a.id}:${a.kind}` : 'idle'
-    if (key !== lastPresentationTraceKey) {
-      lastPresentationTraceKey = key
-      const snap = presentationOrchestrator.getQueueSnapshot()
-      const d = match.value?.state?.dungeon
-      console.log('[DungeonRunner][presentation] active', a?.kind ?? 'idle', {
-        ms: a?.remainingMs ?? null,
-        queued: snap.map((x) => x.kind),
-        inputLocked: gameplayInputLocked.value,
-        engineDungeonCurrentMonster: d?.currentMonster ?? null,
-        engineDungeonSubphase: d?.subphase ?? null,
-        viewMonsterVisibility: showDungeonStage.value ? dungeonStageView.value.monster.visibility : null,
-        viewMonsterSpecies: showDungeonStage.value ? dungeonStageView.value.monster.species : null,
-      })
-    }
-  }
-}
-
-function humanDungeonAutoRevealGapMs() {
-  const pace = presentationSpeedProfile.value
-  const profile = SPEED_PROFILES[pace] ?? SPEED_PROFILES.cinematic
-  return Math.max(0, profile.dungeonContinueMs)
-}
-
-function scheduleAiTurnIfReady() {
-  if (!match.value || isHumanTurn.value) {
-    return
-  }
-  const runToken = buildAiTurnRunToken({ matchId: match.value.id, state: match.value.state })
-  const gate = evaluatePageAiTurnPipelineGate({ runToken, timerPending: !!aiTurnTimerId })
-  if (!gate.maySchedule) {
-    const skipTrace = buildAiTurnScheduleSkipTrace(gate, {
-      runToken,
-      phase: match.value?.state?.phase ?? null,
-      activeSeatId: match.value?.state?.turn?.activeSeatId ?? null,
-      presentationQueueSnapshot: presentationOrchestrator.getQueueSnapshot(),
-    })
-    if (skipTrace) {
-      logAiTurnScheduleSkip(skipTrace.reason, skipTrace.detail)
-    }
-    if (gate.mayPrefetch) {
-      primeAiTurnPrefetch(gate)
-    }
-    if (gate.scheduleSkipReason === 'model-recovering' || gate.scheduleSkipReason === 'gameplay-locked') {
-      if (aiTurnTimerId) {
-        window.clearTimeout(aiTurnTimerId)
-        aiTurnTimerId = null
-      }
-    }
-    return
-  }
-  primeAiTurnPrefetch(gate)
-  if (debugMode.value) {
-    aiTurnTrace()('schedule.timer-armed', { runToken, delayMs: AI_TURN_SCHEDULE_DELAY_MS })
-  }
-  aiTurnTimerId = window.setTimeout(() => {
-    aiTurnTimerId = null
-    if (debugMode.value) aiTurnTrace()('schedule.timer-fired', { runToken })
-    void runAiTurn()
-  }, AI_TURN_SCHEDULE_DELAY_MS)
-}
-
-function scheduleHumanAutoResolveIfReady() {
-  if (!match.value) {
-    return
-  }
-  if (humanGameplayBlocked.value) {
-    return
-  }
-  if (!isHumanTurn.value) {
-    return
-  }
-  if (match.value.state.phase !== 'dungeon') {
-    return
-  }
-  if (equipmentModalOpen.value || autoResolveTimerId) {
-    return
-  }
-  const action = dungeonResolutionView.value.autoAdvanceAction
-  const gate = {
-    phase: match.value.state.phase,
-    gameplayInputLocked: gameplayInputLocked.value,
-    isHumanTurn: isHumanTurn.value,
-    legalActions: legalActions.value,
-    autoAdvanceAction: action,
-    resolutionStatus: dungeonResolutionView.value.resolutionStatus,
-    activeAnimationKind: activePresentation.value?.kind ?? null,
-  }
-  if (!shouldAutoResolveDungeonAdvance(gate)) {
-    return
-  }
-  autoResolveTimerId = window.setTimeout(() => {
-    autoResolveTimerId = null
-    const execGate = {
-      phase: match.value?.state?.phase ?? null,
-      gameplayInputLocked: gameplayInputLocked.value,
-      isHumanTurn: isHumanTurn.value,
-      equipmentModalOpen: equipmentModalOpen.value,
-      autoAdvanceAction: action,
-      legalActions: legalActions.value,
-      resolutionStatus: dungeonResolutionView.value.resolutionStatus,
-      activeAnimationKind: activePresentation.value?.kind ?? null,
-    }
-    const ok = shouldExecuteScheduledAutoResolve(execGate)
-    if (!ok) return
-    takeHumanAction(action)
-  }, humanDungeonAutoRevealGapMs())
-}
-
-function nnRuntimeOptions(modelId) {
-  if (!debugMode.value) return { modelId }
-  return {
-    modelId,
-    pipelineTrace: true,
-    debugTrace: true,
-    debugLogger(trace) {
-      const payload = {
-        at: new Date().toISOString(),
-        modelId,
-        seatId: match.value?.state?.turn?.activeSeatId ?? null,
-        trace,
-      }
-      nnDebugTraceHistory.value = [payload, ...nnDebugTraceHistory.value].slice(0, 20)
-      nnDebugTraceText.value = JSON.stringify(payload, null, 2)
-    },
-  }
-}
-
-function actionLabel(action) {
-  return legalActionBoardLabel(action)
-}
-
-function actionKey(action) {
-  const id = [action.equipmentId, action.hero, action.species].filter((x) => x != null && x !== '').join('-')
-  return id ? `${action.type}-${id}` : action.type
-}
-
-function skipActivePresentation() {
-  presentationOrchestrator.skipActiveAnimation()
-  syncPresentationLabel()
-}
-
-function cloneSetup(source = setup) {
-  return {
-    totalSeats: source.totalSeats,
-    opponents: source.opponents.map((opponent) => ({ ...opponent })),
-  }
+function onMemoryAidToggle(enabled) {
+  dungeonRunnerSettingsStore.setMemoryAidEnabled(enabled === true)
 }
 
 async function loadModelCatalog() {
   const catalog = await fetchModelCatalog()
   modelOptions.value = catalog.models
-  const defaultModel = pickDefaultModelId(catalog.models)
-  if (!defaultModel) return
-  for (const opponent of setup.opponents) {
-    if (opponent.type === 'nn' && !opponent.modelId) {
-      opponent.modelId = defaultModel
-    }
-  }
-}
-
-function exportReplay() {
-  if (!match.value) return
-  const payload = exportReplayEnvelope({
-    seed: match.value.state.rng.seed,
-    setup: match.value.setup,
-    history: match.value.state.history,
-    presentationSpeedProfile: match.value.presentationSpeedProfile,
-  })
-  replayExportText.value = JSON.stringify(payload, null, 2)
-}
-
-function importReplay() {
-  if (!replayImportText.value.trim()) return
-  try {
-    const parsed = JSON.parse(replayImportText.value)
-    const imported = importReplayEnvelope(parsed)
-    if (!imported.ok) {
-      $q.notify({ type: 'negative', message: 'Replay payload is invalid.' })
-      return
-    }
-    const replayResult = buildStateFromReplayEnvelope(imported.replay)
-    if (!replayResult.ok) {
-      $q.notify({ type: 'negative', message: 'Replay actions are invalid for this seed/setup.' })
-      return
-    }
-    const pace =
-      imported.replay.presentationSpeedProfile === 'brisk' ||
-      imported.replay.presentationSpeedProfile === 'cinematic'
-        ? imported.replay.presentationSpeedProfile
-        : 'cinematic'
-    dungeonRunnerSettingsStore.setAnimationPace(pace)
-    match.value = {
-      schemaVersion: CURRENT_MATCH_SCHEMA_VERSION,
-      id: `match-${Date.now()}`,
-      setup: imported.replay.setup,
-      state: replayResult.state,
-      history: [],
-      presentationSpeedProfile: pace,
-    }
-    deferredPostDungeonState.value = null
-    presentationSpeedProfile.value = pace
-    presentationOrchestrator.setSpeedProfile(pace)
-    presentationOrchestrator.clear()
-    syncPresentationLabel()
-  } catch {
-    $q.notify({ type: 'negative', message: 'Replay payload must be valid JSON.' })
-  }
+  applyNnDefaultModelIds(setup, catalog.models)
 }
 </script>
 
@@ -2341,18 +347,6 @@ function importReplay() {
   min-height: 0;
 }
 
-.dr-board-shell {
-  position: relative;
-}
-
-.dr-presentation-flight-layer {
-  position: absolute;
-  inset: 0;
-  z-index: 40;
-  pointer-events: none;
-  overflow: visible;
-}
-
 .dr-header {
   flex-shrink: 0;
   position: relative;
@@ -2364,350 +358,5 @@ function importReplay() {
   left: 50%;
   transform: translateX(-50%);
   pointer-events: none;
-}
-
-.dr-hero-pick-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-}
-
-.dr-hero-pick-grid__btn {
-  min-height: 3rem;
-}
-
-.dr-bidding-board {
-  position: relative;
-  z-index: 0;
-  isolation: isolate;
-  border-radius: 10px;
-  overflow: hidden;
-}
-
-.dr-dungeon-hp-bar {
-  border: 1px solid rgba(244, 67, 54, 0.35);
-  border-radius: 10px;
-  padding: 8px 10px;
-  background: rgba(31, 13, 13, 0.86);
-}
-
-.dr-dungeon-hp-bar__track {
-  height: 10px;
-  overflow: hidden;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
-}
-
-.dr-dungeon-hp-bar__fill {
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, #b71c1c, #f44336);
-  transition: width 180ms ease;
-}
-
-.dr-pile-badge {
-  background-image: linear-gradient(180deg, rgba(42, 42, 42, 0.92), rgba(58, 58, 58, 0.9)), var(--dr-pile);
-  background-size: auto, 150% auto;
-  background-position: center, 50% 45%;
-  background-repeat: no-repeat;
-}
-
-.dr-equip-token {
-  position: relative;
-  width: 64px;
-  height: 64px;
-  flex-shrink: 0;
-  border-radius: 50%;
-  outline: none;
-}
-
-.dr-equip-token__plate,
-.dr-equip-token__symbol {
-  position: absolute;
-  pointer-events: none;
-  user-select: none;
-}
-
-.dr-equip-token__plate {
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.dr-equip-token__symbol {
-  width: 72%;
-  height: 72%;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  object-fit: contain;
-  filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.35));
-}
-
-.dr-equip-token__overlay {
-  position: absolute;
-  right: 0;
-  bottom: 2px;
-  font-size: 18px;
-  font-weight: 900;
-  line-height: 1;
-  letter-spacing: -0.02em;
-  -webkit-text-stroke: 0.85px rgba(18, 18, 18, 0.92);
-  paint-order: stroke fill;
-  color: rgba(18, 18, 18, 0.92);
-  text-shadow:
-    0 0 12px rgba(255, 255, 255, 0.98),
-    0 0 6px rgba(255, 255, 255, 0.95);
-  pointer-events: none;
-}
-
-.dr-equip-token--spent {
-  opacity: 0.55;
-}
-
-.dr-equip-token--interactive {
-  cursor: pointer;
-}
-
-.dr-board-primary {
-  width: 100%;
-  isolation: isolate;
-}
-
-.dr-hero-card-slot {
-  width: 100%;
-  position: relative;
-}
-
-.dr-hero-card-control {
-  width: 100%;
-  display: block;
-}
-
-.dr-dungeon-card-motion-wrap {
-  width: 100%;
-  display: block;
-}
-
-.dr-hero-card-control :deep(.dr-monster-card) {
-  width: 100%;
-  max-width: none;
-  margin: 0;
-}
-
-.dr-seat-strip {
-  width: 100%;
-}
-
-.dr-seat-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.dr-seat-progress-cell {
-  min-height: 1.25rem;
-  padding: 0 4px;
-  letter-spacing: 0.05em;
-  white-space: nowrap;
-}
-
-.dr-seat-progress-marker {
-  font-weight: 700;
-  margin-right: 2px;
-}
-
-.dr-seat-progress-marker--success {
-  color: #66bb6a;
-}
-
-.dr-seat-progress-marker--failure {
-  color: #ef5350;
-}
-
-@keyframes dr-token-pulse {
-  from {
-    transform: scale(1);
-  }
-  to {
-    transform: scale(1.03);
-  }
-}
-
-.dr-card-preview {
-  width: 100%;
-  max-width: 140px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  border-radius: 6px;
-}
-
-.dr-token-glow {
-  box-shadow:
-    0 0 0 2px rgba(255, 193, 7, 0.95),
-    0 0 0 4px rgba(255, 152, 0, 0.45),
-    0 0 22px rgba(255, 193, 7, 0.75),
-    0 0 40px rgba(255, 160, 0, 0.35);
-}
-
-.dr-token-pulse {
-  animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
-}
-
-.dr-equip-token--deemphasized {
-  opacity: 0.5;
-  filter: saturate(0.7);
-}
-
-.dr-dungeon-stage .dr-hero-card-control {
-  transform-origin: center;
-}
-
-.dr-dungeon-stage__hp-chip {
-  position: absolute;
-  right: 10px;
-  top: 10px;
-  z-index: 2;
-}
-
-.dr-token-icon {
-  flex-shrink: 0;
-  object-fit: contain;
-  filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.5));
-}
-
-.dr-deck-badge {
-  user-select: none;
-}
-
-.dr-deck-badge--interactive {
-  cursor: pointer;
-}
-
-.dr-deck-splay-panel {
-  width: min(960px, 100vw);
-  height: 100dvh;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-}
-
-.dr-deck-splay-scroll {
-  overflow-y: auto;
-}
-
-.dr-hero--warrior {
-  box-shadow: inset 0 0 0 2px rgba(63, 81, 181, 0.45);
-}
-
-.dr-hero--barbarian {
-  box-shadow: inset 0 0 0 2px rgba(255, 87, 34, 0.5);
-}
-
-.dr-hero--mage {
-  box-shadow: inset 0 0 0 2px rgba(103, 58, 183, 0.5);
-}
-
-.dr-hero--rogue {
-  box-shadow: inset 0 0 0 2px rgba(46, 125, 50, 0.5);
-}
-
-.dr-turn-hero-row {
-  gap: 6px;
-}
-
-.dr-hero-interstitial {
-  position: fixed;
-  inset: 0;
-  border: 0;
-  width: 100%;
-  background: rgba(12, 12, 18, 0.9);
-  color: #fff;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  z-index: 20;
-  cursor: pointer;
-}
-
-.dr-hero-interstitial__headline {
-  margin: 0;
-  font-size: 1.15rem;
-  font-weight: 500;
-  text-align: center;
-}
-
-.dr-hero-interstitial__avatar {
-  animation: dr-hero-interstitial-pop 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-
-@keyframes dr-hero-interstitial-pop {
-  from {
-    transform: scale(0.72);
-    opacity: 0.35;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-.dr-hero-interstitial__hint {
-  font-size: 0.85rem;
-  opacity: 0.75;
-}
-
-.dr-dungeon-outcome-dialog,
-.dr-match-over-dialog {
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 14px;
-  box-shadow:
-    0 12px 34px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.05) inset;
-}
-
-.dr-outcome--success {
-  background:
-    radial-gradient(120% 100% at 0% 0%, rgba(102, 187, 106, 0.22), rgba(102, 187, 106, 0) 60%),
-    radial-gradient(120% 120% at 100% 100%, rgba(41, 182, 246, 0.2), rgba(41, 182, 246, 0) 62%),
-    #171b1f;
-}
-
-.dr-outcome--failure {
-  background:
-    radial-gradient(120% 100% at 0% 0%, rgba(239, 83, 80, 0.24), rgba(239, 83, 80, 0) 58%),
-    radial-gradient(120% 120% at 100% 100%, rgba(171, 71, 188, 0.2), rgba(171, 71, 188, 0) 62%),
-    #1b161c;
-}
-
-.dr-outcome-kicker {
-  letter-spacing: 0.18em;
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.dr-outcome-title {
-  text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
-}
-
-.dr-outcome-message {
-  color: rgba(255, 255, 255, 0.86);
-}
-
-.dr-outcome-btn {
-  letter-spacing: 0.03em;
-}
-
-.dr-outcome-btn-secondary {
-  color: rgba(255, 255, 255, 0.86);
-}
-</style>
-
-<style>
-/* Quasar portals dialogs outside scoped tree; above presentation ghost flights (z-index 10050) */
-.dr-equipment-dialog .q-dialog__inner {
-  z-index: 10100 !important;
 }
 </style>


### PR DESCRIPTION
## Summary

- Introduces a pure **play shell resolver** and routes the play page through three focused shells: **play setup surface**, **live match shell**, and **match-over shell**.
- Shrinks `DungeonRunnerPage.vue` to **play route chrome**, bootstrap, shared session state, and shell routing; live play wiring moves into `LiveMatchShell` / `useLiveMatchShell`.
- Relocates **completed match replay** upload to **match-over shell** activation (background, idempotent) and gates AI/presentation/recovery lifecycle to periods when the live match shell is active.

Closes #212

## Test plan

- [ ] Open `/projects/dungeon-runner` — **play setup surface** shows (no board)
- [ ] **Start match** — **live match shell** loads with board and controls
- [ ] Abandon via header refresh → confirm → returns to **play setup surface**
- [ ] Play through to **match over** — **match-over shell** shows outcome without board behind it
- [ ] **Rematch** succeeds without flashing setup; **Back to setup** restores prior setup
- [ ] `npm test` — dungeon-runner suite green