### PR TITLE
Bidding sacrifice mode: tile-based selection with confirmation

### DIFF
--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -252,6 +252,12 @@ On **completed match outcome**, the number of canonical `SACRIFICE` actions in *
 
 _Avoid_: Counting equipment merely played or discarded in **dungeon runs**; inferring from **scoreboard** alone.
 
+### Sacrifice mode (bidding)
+
+Transient human-player UI during **bidding**, after a **draw** reveals a monster only to the drawer. Entered via **Sacrifice equipment**; highlights only center-table **equipment** that is legally sacrificable right now with a red border and subtle pulse (distinct from dungeon-phase usability glow); tile selection opens the usual **equipment** description with an explicit **Sacrifice** confirmation (no further confirmation dialog). Dismissing that modal via **Continue** without **Sacrifice** leaves sacrifice mode active. Always used for human sacrifice—even when only one piece is legal—replacing name-based sacrifice buttons or dropdowns. While active, the only **bidding** game actions are confirming a sacrifice or **Cancel** (exit sacrifice mode without discarding)—the drawer must exit sacrifice mode before **Add to dungeon** or other turn actions. **Cancel** also closes any open **equipment** description modal. Spent or removed **equipment** tiles stay readable but are not highlighted and cannot be confirmed for sacrifice; tapping them during sacrifice mode still opens the description modal, and dismissing that modal leaves sacrifice mode active. **Play route chrome** affordances (settings, help, and similar system surfaces) stay available. Entering or using sacrifice mode follows the same human gameplay interactability rules as other **bidding** turn actions (e.g. **Draw**, **Add to dungeon**): blocked while presentation locks gameplay input. Human **live match shell** presentation only; **opponent** sacrifice behavior and the legal **SACRIFICE** action space are unchanged.
+
+_Avoid_: “Sacrifice picker,” dropdown-by-name as the primary sacrifice UX; red highlight on tiles that rules do not allow sacrificing; treating sacrifice mode as a separate **match** phase; leaving **Add to dungeon** enabled alongside sacrifice mode; one-tap human sacrifice shortcuts that bypass tile selection and confirmation; changing how **neural opponent** or **Randombot** choose sacrifices; persisting sacrifice mode across reload (ephemeral **live match shell** UI only).
+
 ### Game data catalog
 
 The single source of truth for static **equipment** and **monster** definitions shared by rules resolution and presentation.
@@ -345,6 +351,8 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - **Equipment** optional use/decline action types are **catalog rules**; effect help prose lives in **ui** `details`.
 - **Adventurer identity** fields are **ui** only; the engine/kernel consumes **catalog rules** only, not **ui**.
 - **Equipment** and **monster** definitions are consulted during **dungeon runs** and bidding within a **match**.
+- After a bidding **draw**, the drawer may **Add to dungeon** or enter **sacrifice mode (bidding)** to discard one legally sacrificable center-table **equipment** piece instead; only highlighted tiles accept sacrifice confirmation. While sacrifice mode is active, **Add to dungeon** and other turn actions are unavailable until **Cancel** or a confirmed sacrifice resolves the choice.
+- **Sacrifice mode (bidding)** is **human player seat** UX in **live match shell** only; **opponent** sacrifice is unchanged. Ephemeral—clears on reload; not part of **current match** persistence. Bidding help copy describes enter → pick highlighted tile → confirm → **Cancel**.
 - A **match** contains one or more **dungeon runs** before **match over**.
 - **Elimination end (human)** and **Defeat (human, not eliminated)** use different end-dialog copy; only the latter names the winning seat.
 - Headless completion of remaining **opponent** play after human **elimination** uses the same action choosers as live play (not a simplified bot).

--- a/src/features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue
+++ b/src/features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue
@@ -39,6 +39,12 @@
           lane the runner will face) or <strong>sacrifice equipment</strong> to discard that card instead, giving up the
           gear permanently.
         </p>
+        <p class="q-ma-none q-mb-sm">
+          To sacrifice, tap <strong>Sacrifice equipment</strong>. Legally sacrificable pieces on the table highlight with a
+          red border. Tap a highlighted piece to read its full description, then tap <strong>Sacrifice</strong> to confirm.
+          Tap <strong>Cancel</strong> to leave sacrifice mode without discarding, or <strong>Continue</strong> in the
+          description to compare other pieces. You must cancel sacrifice mode before you can add the monster to the dungeon.
+        </p>
         <p class="q-ma-none q-mb-md">
           Passing drops you out for this round. When every active player except one has passed, the remaining player
           becomes the <strong>runner</strong> and the match moves to the dungeon phase. The dungeon pile is whatever

--- a/src/features/dungeon-runner/ui/biddingSacrificeInteractions.js
+++ b/src/features/dungeon-runner/ui/biddingSacrificeInteractions.js
@@ -1,0 +1,93 @@
+import { ACTION_TYPES } from '../engine/kernel.js'
+import { equipment, getEquipmentShortName } from '../data/gameDataCatalog.js'
+import { createDungeonEquipmentModalView } from './dungeonEquipmentInteractions.js'
+
+export function legalSacrificeEquipmentIds(legalActions = []) {
+  return legalActions
+    .filter((action) => action.type === ACTION_TYPES.SACRIFICE && typeof action.equipmentId === 'string')
+    .map((action) => action.equipmentId)
+}
+
+export function isBiddingPostDrawContext({ phase, revealedMonsterCard, legalActions = [] }) {
+  if (phase !== 'bidding' || revealedMonsterCard == null) return false
+  return legalSacrificeEquipmentIds(legalActions).length > 0
+}
+
+export function canEnterBiddingSacrificeMode({
+  isHumanTurn = false,
+  phase = null,
+  revealedMonsterCard = null,
+  legalActions = [],
+  humanGameplayBlocked = false,
+} = {}) {
+  if (humanGameplayBlocked || !isHumanTurn) return false
+  return isBiddingPostDrawContext({ phase, revealedMonsterCard, legalActions })
+}
+
+export function buildBiddingPostDrawActionPane({
+  sacrificeModeActive = false,
+  phase = null,
+  revealedMonsterCard = null,
+  legalActions = [],
+  humanGameplayBlocked = false,
+} = {}) {
+  if (!isBiddingPostDrawContext({ phase, revealedMonsterCard, legalActions })) {
+    return []
+  }
+  if (sacrificeModeActive) {
+    return [{ kind: 'cancelSacrificeMode' }]
+  }
+  const items = legalActions
+    .filter((action) => action.type === ACTION_TYPES.ADD_TO_DUNGEON)
+    .map((action) => ({ kind: 'engine', action }))
+  if (!humanGameplayBlocked) {
+    items.push({ kind: 'enterSacrificeMode' })
+  }
+  return items
+}
+
+export function buildBiddingSacrificeTokenFlags({
+  sacrificeModeActive = false,
+  equipmentId = '',
+  removed = false,
+  legalSacrificeEquipmentIds: sacrificableIds = [],
+} = {}) {
+  const sacrificable = new Set(sacrificableIds)
+  const highlight =
+    sacrificeModeActive && !removed && sacrificable.has(equipmentId)
+  return {
+    sacrificeHighlight: highlight,
+    sacrificePulse: highlight,
+  }
+}
+
+export function createBiddingSacrificeEquipmentModalView({
+  equipmentId,
+  legalActions = [],
+  sacrificeModeActive = false,
+} = {}) {
+  const entry = equipment[equipmentId]
+  const sacrificableIds = new Set(legalSacrificeEquipmentIds(legalActions))
+  const showSacrificeButton =
+    sacrificeModeActive && sacrificableIds.has(equipmentId)
+  const base = createDungeonEquipmentModalView({ equipmentId, legalActions: [] })
+  return {
+    equipmentId,
+    title: entry?.ui?.label ?? getEquipmentShortName(equipmentId),
+    details: entry?.ui?.details ?? base.details,
+    showUseButton: false,
+    useAction: null,
+    continueAction: null,
+    showSacrificeButton,
+    sacrificeAction: showSacrificeButton
+      ? { type: ACTION_TYPES.SACRIFICE, equipmentId }
+      : null,
+  }
+}
+
+export function shouldUseBiddingSacrificeEquipmentModalView({
+  phase = null,
+  sacrificeModeActive = false,
+} = {}) {
+  return phase === 'bidding' && sacrificeModeActive
+}

--- a/src/features/dungeon-runner/ui/biddingSacrificeInteractions.js
+++ b/src/features/dungeon-runner/ui/biddingSacrificeInteractions.js
@@ -1,5 +1,4 @@
 import { ACTION_TYPES } from '../engine/kernel.js'
-import { equipment, getEquipmentShortName } from '../data/gameDataCatalog.js'
 import { createDungeonEquipmentModalView } from './dungeonEquipmentInteractions.js'
 
 export function legalSacrificeEquipmentIds(legalActions = []) {
@@ -46,19 +45,14 @@ export function buildBiddingPostDrawActionPane({
   return items
 }
 
-export function buildBiddingSacrificeTokenFlags({
+export function isSacrificeTargetEquipmentToken({
   sacrificeModeActive = false,
   equipmentId = '',
   removed = false,
   legalSacrificeEquipmentIds: sacrificableIds = [],
 } = {}) {
   const sacrificable = new Set(sacrificableIds)
-  const highlight =
-    sacrificeModeActive && !removed && sacrificable.has(equipmentId)
-  return {
-    sacrificeHighlight: highlight,
-    sacrificePulse: highlight,
-  }
+  return sacrificeModeActive && !removed && sacrificable.has(equipmentId)
 }
 
 export function createBiddingSacrificeEquipmentModalView({
@@ -66,15 +60,11 @@ export function createBiddingSacrificeEquipmentModalView({
   legalActions = [],
   sacrificeModeActive = false,
 } = {}) {
-  const entry = equipment[equipmentId]
-  const sacrificableIds = new Set(legalSacrificeEquipmentIds(legalActions))
-  const showSacrificeButton =
-    sacrificeModeActive && sacrificableIds.has(equipmentId)
   const base = createDungeonEquipmentModalView({ equipmentId, legalActions: [] })
+  const showSacrificeButton =
+    sacrificeModeActive && new Set(legalSacrificeEquipmentIds(legalActions)).has(equipmentId)
   return {
-    equipmentId,
-    title: entry?.ui?.label ?? getEquipmentShortName(equipmentId),
-    details: entry?.ui?.details ?? base.details,
+    ...base,
     showUseButton: false,
     useAction: null,
     continueAction: null,

--- a/src/features/dungeon-runner/ui/biddingSacrificeInteractions.test.js
+++ b/src/features/dungeon-runner/ui/biddingSacrificeInteractions.test.js
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { createDungeonEquipmentModalView } from './dungeonEquipmentInteractions.js'
 import {
   buildBiddingPostDrawActionPane,
-  buildBiddingSacrificeTokenFlags,
   canEnterBiddingSacrificeMode,
   createBiddingSacrificeEquipmentModalView,
   isBiddingPostDrawContext,
+  isSacrificeTargetEquipmentToken,
   legalSacrificeEquipmentIds,
   shouldUseBiddingSacrificeEquipmentModalView,
 } from './biddingSacrificeInteractions.js'
@@ -42,6 +43,14 @@ test('isBiddingPostDrawContext requires bidding phase, revealed card, and legal 
       phase: 'bidding',
       revealedMonsterCard: null,
       legalActions: POST_DRAW_LEGAL,
+    }),
+    false,
+  )
+  assert.equal(
+    isBiddingPostDrawContext({
+      phase: 'bidding',
+      revealedMonsterCard: 'goblin',
+      legalActions: [{ type: 'ADD_TO_DUNGEON' }],
     }),
     false,
   )
@@ -109,32 +118,35 @@ test('buildBiddingPostDrawActionPane omits enter when gameplay blocked', () => {
   assert.deepEqual(pane, [{ kind: 'engine', action: { type: 'ADD_TO_DUNGEON' } }])
 })
 
-test('buildBiddingSacrificeTokenFlags highlights only legal center equipment in mode', () => {
+test('isSacrificeTargetEquipmentToken is true only for legal center equipment in mode', () => {
   const ids = ['W_SHIELD', 'B_AXE']
-  const shield = buildBiddingSacrificeTokenFlags({
-    sacrificeModeActive: true,
-    equipmentId: 'W_SHIELD',
-    removed: false,
-    legalSacrificeEquipmentIds: ids,
-  })
-  assert.equal(shield.sacrificeHighlight, true)
-  assert.equal(shield.sacrificePulse, true)
-
-  const spent = buildBiddingSacrificeTokenFlags({
-    sacrificeModeActive: true,
-    equipmentId: 'W_SHIELD',
-    removed: true,
-    legalSacrificeEquipmentIds: ids,
-  })
-  assert.equal(spent.sacrificeHighlight, false)
-
-  const idle = buildBiddingSacrificeTokenFlags({
-    sacrificeModeActive: false,
-    equipmentId: 'W_SHIELD',
-    removed: false,
-    legalSacrificeEquipmentIds: ids,
-  })
-  assert.equal(idle.sacrificeHighlight, false)
+  assert.equal(
+    isSacrificeTargetEquipmentToken({
+      sacrificeModeActive: true,
+      equipmentId: 'W_SHIELD',
+      removed: false,
+      legalSacrificeEquipmentIds: ids,
+    }),
+    true,
+  )
+  assert.equal(
+    isSacrificeTargetEquipmentToken({
+      sacrificeModeActive: true,
+      equipmentId: 'W_SHIELD',
+      removed: true,
+      legalSacrificeEquipmentIds: ids,
+    }),
+    false,
+  )
+  assert.equal(
+    isSacrificeTargetEquipmentToken({
+      sacrificeModeActive: false,
+      equipmentId: 'W_SHIELD',
+      removed: false,
+      legalSacrificeEquipmentIds: ids,
+    }),
+    false,
+  )
 })
 
 test('createBiddingSacrificeEquipmentModalView exposes sacrifice action for legal tiles in mode', () => {
@@ -146,6 +158,17 @@ test('createBiddingSacrificeEquipmentModalView exposes sacrifice action for lega
   assert.equal(modal.showSacrificeButton, true)
   assert.deepEqual(modal.sacrificeAction, { type: 'SACRIFICE', equipmentId: 'W_SHIELD' })
   assert.equal(modal.showUseButton, false)
+})
+
+test('createBiddingSacrificeEquipmentModalView reuses dungeon modal title and details', () => {
+  const base = createDungeonEquipmentModalView({ equipmentId: 'W_SHIELD', legalActions: [] })
+  const modal = createBiddingSacrificeEquipmentModalView({
+    equipmentId: 'W_SHIELD',
+    legalActions: POST_DRAW_LEGAL,
+    sacrificeModeActive: false,
+  })
+  assert.equal(modal.title, base.title)
+  assert.equal(modal.details, base.details)
 })
 
 test('createBiddingSacrificeEquipmentModalView is read-only for non-sacrificable tiles in mode', () => {

--- a/src/features/dungeon-runner/ui/biddingSacrificeInteractions.test.js
+++ b/src/features/dungeon-runner/ui/biddingSacrificeInteractions.test.js
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  buildBiddingPostDrawActionPane,
+  buildBiddingSacrificeTokenFlags,
+  canEnterBiddingSacrificeMode,
+  createBiddingSacrificeEquipmentModalView,
+  isBiddingPostDrawContext,
+  legalSacrificeEquipmentIds,
+  shouldUseBiddingSacrificeEquipmentModalView,
+} from './biddingSacrificeInteractions.js'
+
+const POST_DRAW_LEGAL = [
+  { type: 'ADD_TO_DUNGEON' },
+  { type: 'SACRIFICE', equipmentId: 'W_SHIELD' },
+  { type: 'SACRIFICE', equipmentId: 'B_AXE' },
+]
+
+test('legalSacrificeEquipmentIds extracts equipment ids from SACRIFICE actions', () => {
+  assert.deepEqual(legalSacrificeEquipmentIds(POST_DRAW_LEGAL), ['W_SHIELD', 'B_AXE'])
+})
+
+test('isBiddingPostDrawContext requires bidding phase, revealed card, and legal sacrifices', () => {
+  assert.equal(
+    isBiddingPostDrawContext({
+      phase: 'bidding',
+      revealedMonsterCard: 'goblin',
+      legalActions: POST_DRAW_LEGAL,
+    }),
+    true,
+  )
+  assert.equal(
+    isBiddingPostDrawContext({
+      phase: 'dungeon',
+      revealedMonsterCard: 'goblin',
+      legalActions: POST_DRAW_LEGAL,
+    }),
+    false,
+  )
+  assert.equal(
+    isBiddingPostDrawContext({
+      phase: 'bidding',
+      revealedMonsterCard: null,
+      legalActions: POST_DRAW_LEGAL,
+    }),
+    false,
+  )
+})
+
+test('canEnterBiddingSacrificeMode blocks when not human turn or gameplay blocked', () => {
+  const base = {
+    phase: 'bidding',
+    revealedMonsterCard: 'goblin',
+    legalActions: POST_DRAW_LEGAL,
+  }
+  assert.equal(canEnterBiddingSacrificeMode({ ...base, isHumanTurn: true }), true)
+  assert.equal(canEnterBiddingSacrificeMode({ ...base, isHumanTurn: false }), false)
+  assert.equal(
+    canEnterBiddingSacrificeMode({ ...base, isHumanTurn: true, humanGameplayBlocked: true }),
+    false,
+  )
+})
+
+test('buildBiddingPostDrawActionPane idle lists add and enter without SACRIFICE rows', () => {
+  const pane = buildBiddingPostDrawActionPane({
+    sacrificeModeActive: false,
+    phase: 'bidding',
+    revealedMonsterCard: 'goblin',
+    legalActions: POST_DRAW_LEGAL,
+  })
+  assert.deepEqual(pane, [
+    { kind: 'engine', action: { type: 'ADD_TO_DUNGEON' } },
+    { kind: 'enterSacrificeMode' },
+  ])
+})
+
+test('buildBiddingPostDrawActionPane in mode lists cancel only', () => {
+  const pane = buildBiddingPostDrawActionPane({
+    sacrificeModeActive: true,
+    phase: 'bidding',
+    revealedMonsterCard: 'goblin',
+    legalActions: POST_DRAW_LEGAL,
+  })
+  assert.deepEqual(pane, [{ kind: 'cancelSacrificeMode' }])
+})
+
+test('buildBiddingPostDrawActionPane single legal target still uses enterSacrificeMode', () => {
+  const legal = [{ type: 'ADD_TO_DUNGEON' }, { type: 'SACRIFICE', equipmentId: 'W_SHIELD' }]
+  const pane = buildBiddingPostDrawActionPane({
+    sacrificeModeActive: false,
+    phase: 'bidding',
+    revealedMonsterCard: 'goblin',
+    legalActions: legal,
+  })
+  assert.deepEqual(pane, [
+    { kind: 'engine', action: { type: 'ADD_TO_DUNGEON' } },
+    { kind: 'enterSacrificeMode' },
+  ])
+})
+
+test('buildBiddingPostDrawActionPane omits enter when gameplay blocked', () => {
+  const pane = buildBiddingPostDrawActionPane({
+    sacrificeModeActive: false,
+    phase: 'bidding',
+    revealedMonsterCard: 'goblin',
+    legalActions: POST_DRAW_LEGAL,
+    humanGameplayBlocked: true,
+  })
+  assert.deepEqual(pane, [{ kind: 'engine', action: { type: 'ADD_TO_DUNGEON' } }])
+})
+
+test('buildBiddingSacrificeTokenFlags highlights only legal center equipment in mode', () => {
+  const ids = ['W_SHIELD', 'B_AXE']
+  const shield = buildBiddingSacrificeTokenFlags({
+    sacrificeModeActive: true,
+    equipmentId: 'W_SHIELD',
+    removed: false,
+    legalSacrificeEquipmentIds: ids,
+  })
+  assert.equal(shield.sacrificeHighlight, true)
+  assert.equal(shield.sacrificePulse, true)
+
+  const spent = buildBiddingSacrificeTokenFlags({
+    sacrificeModeActive: true,
+    equipmentId: 'W_SHIELD',
+    removed: true,
+    legalSacrificeEquipmentIds: ids,
+  })
+  assert.equal(spent.sacrificeHighlight, false)
+
+  const idle = buildBiddingSacrificeTokenFlags({
+    sacrificeModeActive: false,
+    equipmentId: 'W_SHIELD',
+    removed: false,
+    legalSacrificeEquipmentIds: ids,
+  })
+  assert.equal(idle.sacrificeHighlight, false)
+})
+
+test('createBiddingSacrificeEquipmentModalView exposes sacrifice action for legal tiles in mode', () => {
+  const modal = createBiddingSacrificeEquipmentModalView({
+    equipmentId: 'W_SHIELD',
+    legalActions: POST_DRAW_LEGAL,
+    sacrificeModeActive: true,
+  })
+  assert.equal(modal.showSacrificeButton, true)
+  assert.deepEqual(modal.sacrificeAction, { type: 'SACRIFICE', equipmentId: 'W_SHIELD' })
+  assert.equal(modal.showUseButton, false)
+})
+
+test('createBiddingSacrificeEquipmentModalView is read-only for non-sacrificable tiles in mode', () => {
+  const modal = createBiddingSacrificeEquipmentModalView({
+    equipmentId: 'M_POLY',
+    legalActions: POST_DRAW_LEGAL,
+    sacrificeModeActive: true,
+  })
+  assert.equal(modal.showSacrificeButton, false)
+  assert.equal(modal.sacrificeAction, null)
+})
+
+test('shouldUseBiddingSacrificeEquipmentModalView is true only during bidding sacrifice mode', () => {
+  assert.equal(
+    shouldUseBiddingSacrificeEquipmentModalView({ phase: 'bidding', sacrificeModeActive: true }),
+    true,
+  )
+  assert.equal(
+    shouldUseBiddingSacrificeEquipmentModalView({ phase: 'bidding', sacrificeModeActive: false }),
+    false,
+  )
+  assert.equal(
+    shouldUseBiddingSacrificeEquipmentModalView({ phase: 'dungeon', sacrificeModeActive: true }),
+    false,
+  )
+})

--- a/src/features/dungeon-runner/ui/dungeonEquipmentInteractions.test.js
+++ b/src/features/dungeon-runner/ui/dungeonEquipmentInteractions.test.js
@@ -75,7 +75,7 @@ test('dungeon phase keeps continue-skip actions visible in flat button row', () 
   assert.deepEqual(visible, [{ type: 'DECLINE_FIRE_AXE' }, { type: 'DECLINE_POLYMORPH' }])
 })
 
-test('bidding phase still lists sacrifice alongside other non-vorpal actions', () => {
+test('bidding phase filterVisibleLegalActions still passes sacrifice through for engine visibility', () => {
   const legal = [
     { type: 'ADD_TO_DUNGEON' },
     { type: 'SACRIFICE', equipmentId: 'W_SHIELD' },

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -157,6 +157,8 @@
               'dr-equip-token--spent': token.removed,
               'dr-token-glow': token.glow,
               'dr-token-pulse': token.pulse,
+              'dr-equip-token--sacrifice-highlight': token.sacrificeHighlight,
+              'dr-equip-token--sacrifice-pulse': token.sacrificePulse,
               'dr-equip-token--deemphasized': token.deemphasized,
               'dr-equip-token--interactive': token.hasModal,
             }"
@@ -191,41 +193,42 @@
     <q-card v-if="session.board.showActionPane" flat bordered class="q-pa-sm q-mb-md">
       <div v-if="session.board.activePresentationLabel" class="text-body2 text-grey-6 q-mb-xs">{{ session.board.activePresentationLabel }}</div>
       <div v-if="session.board.isHumanTurn" class="row q-col-gutter-sm q-gutter-y-sm">
-        <template v-if="session.board.match?.state?.phase === 'bidding' && session.board.biddingSacrificeActions.length > 1">
-          <q-btn
-            v-for="action in session.board.biddingNonSacrificeActions"
-            :key="session.board.actionKey(action)"
-            :color="session.board.biddingBoard.heroCue.buttonColor"
-            unelevated
-            no-caps
-            size="lg"
-            class="col-12 col-sm-auto"
-            :label="session.board.actionLabel(action)"
-            :disable="session.board.humanGameplayBlocked"
-            @click="session.board.takeHumanAction(action)"
-          />
-          <q-btn-dropdown
-            :color="session.board.biddingBoard.heroCue.buttonColor"
-            unelevated
-            no-caps
-            dense
-            size="lg"
-            class="col-12 col-sm-auto"
-            label="Sacrifice equipment"
-            :disable="session.board.humanGameplayBlocked"
-          >
-            <q-list dense>
-              <q-item
-                v-for="action in session.board.biddingSacrificeActions"
-                :key="session.board.actionKey(action)"
-                v-close-popup
-                clickable
-                @click="session.board.takeHumanAction(action)"
-              >
-                <q-item-section>{{ session.board.actionLabel(action) }}</q-item-section>
-              </q-item>
-            </q-list>
-          </q-btn-dropdown>
+        <template v-if="session.board.showBiddingPostDrawActionPane">
+          <template v-for="item in session.board.biddingPostDrawActionPane" :key="session.board.biddingPostDrawActionPaneKey(item)">
+            <q-btn
+              v-if="item.kind === 'engine'"
+              :color="session.board.biddingBoard.heroCue.buttonColor"
+              unelevated
+              no-caps
+              size="lg"
+              class="col-12 col-sm-auto"
+              :label="session.board.actionLabel(item.action)"
+              :disable="session.board.humanGameplayBlocked"
+              @click="session.board.takeHumanAction(item.action)"
+            />
+            <q-btn
+              v-else-if="item.kind === 'enterSacrificeMode'"
+              :color="session.board.biddingBoard.heroCue.buttonColor"
+              unelevated
+              no-caps
+              size="lg"
+              class="col-12 col-sm-auto"
+              label="Sacrifice equipment"
+              :disable="session.board.humanGameplayBlocked"
+              @click="session.board.enterSacrificeMode"
+            />
+            <q-btn
+              v-else-if="item.kind === 'cancelSacrificeMode'"
+              :color="session.board.biddingBoard.heroCue.buttonColor"
+              unelevated
+              no-caps
+              size="lg"
+              class="col-12 col-sm-auto"
+              label="Cancel"
+              :disable="session.board.humanGameplayBlocked"
+              @click="session.board.cancelSacrificeMode"
+            />
+          </template>
         </template>
         <template v-else>
           <template v-if="session.board.showHeroPickActionGrid">
@@ -365,6 +368,14 @@
         <div class="text-subtitle1 q-mb-xs">{{ session.dialogs.selectedEquipmentModalView?.title }}</div>
         <div class="text-body2 q-mb-md">{{ session.dialogs.selectedEquipmentModalView?.details }}</div>
         <div class="row justify-end q-gutter-sm">
+          <q-btn
+            v-if="session.dialogs.selectedEquipmentModalView?.showSacrificeButton"
+            color="negative"
+            unelevated
+            label="Sacrifice"
+            :disable="session.dialogs.equipmentModalActionsDisabled"
+            @click="session.dialogs.takeEquipmentSacrificeAction"
+          />
           <q-btn
             v-if="session.dialogs.selectedEquipmentModalView?.showUseButton"
             color="primary"
@@ -671,7 +682,7 @@ const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
   border-radius: 6px;
 }
 
-.dr-token-glow {
+.dr-token-glow:not(.dr-equip-token) {
   box-shadow:
     0 0 0 2px rgba(255, 193, 7, 0.95),
     0 0 0 4px rgba(255, 152, 0, 0.45),
@@ -679,7 +690,37 @@ const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
     0 0 40px rgba(255, 160, 0, 0.35);
 }
 
-.dr-token-pulse {
+.dr-equip-token.dr-token-glow::after {
+  content: '';
+  position: absolute;
+  inset: 7px;
+  border-radius: 50%;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 2px rgba(255, 193, 7, 0.95),
+    0 0 0 4px rgba(255, 152, 0, 0.45),
+    0 0 22px rgba(255, 193, 7, 0.75),
+    0 0 40px rgba(255, 160, 0, 0.35);
+}
+
+.dr-equip-token.dr-token-pulse::after {
+  animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
+}
+
+.dr-equip-token--sacrifice-highlight::after {
+  content: '';
+  position: absolute;
+  inset: 7px;
+  border-radius: 50%;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 2px rgba(239, 83, 80, 0.95),
+    0 0 0 4px rgba(229, 57, 53, 0.45),
+    0 0 18px rgba(239, 83, 80, 0.65),
+    0 0 32px rgba(229, 57, 53, 0.3);
+}
+
+.dr-equip-token--sacrifice-pulse::after {
   animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
 }
 

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -157,8 +157,7 @@
               'dr-equip-token--spent': token.removed,
               'dr-token-glow': token.glow,
               'dr-token-pulse': token.pulse,
-              'dr-equip-token--sacrifice-highlight': token.sacrificeHighlight,
-              'dr-equip-token--sacrifice-pulse': token.sacrificePulse,
+              'dr-equip-token--sacrifice-target': token.isSacrificeTarget,
               'dr-equip-token--deemphasized': token.deemphasized,
               'dr-equip-token--interactive': token.hasModal,
             }"
@@ -707,7 +706,7 @@ const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
   animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
 }
 
-.dr-equip-token--sacrifice-highlight::after {
+.dr-equip-token--sacrifice-target::after {
   content: '';
   position: absolute;
   inset: 7px;
@@ -718,9 +717,6 @@ const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
     0 0 0 4px rgba(229, 57, 53, 0.45),
     0 0 18px rgba(239, 83, 80, 0.65),
     0 0 32px rgba(229, 57, 53, 0.3);
-}
-
-.dr-equip-token--sacrifice-pulse::after {
   animation: dr-token-pulse 0.85s ease-in-out infinite alternate;
 }
 

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -30,6 +30,15 @@ import {
   createVorpalDeclarationPromptView,
   filterVisibleLegalActions,
 } from '../dungeonEquipmentInteractions.js'
+import {
+  buildBiddingPostDrawActionPane,
+  buildBiddingSacrificeTokenFlags,
+  canEnterBiddingSacrificeMode,
+  createBiddingSacrificeEquipmentModalView,
+  isBiddingPostDrawContext,
+  legalSacrificeEquipmentIds,
+  shouldUseBiddingSacrificeEquipmentModalView,
+} from '../biddingSacrificeInteractions.js'
 import { createBiddingBoardViewModel } from '../biddingBoardViewModel.js'
 import {
   viewerMaySeeAddToDungeonFlipDown,
@@ -429,6 +438,10 @@ export function useLiveMatchShell(deps) {
       humanSeatId.value != null &&
       match.value.state.turn.activeSeatId === humanSeatId.value,
   )
+  const humanBiddingRevealedMonsterCard = computed(() => {
+    if (!isHumanTurn.value || !match.value) return null
+    return match.value.state.bidding?.revealedMonsterCard ?? null
+  })
   const legalActions = computed(() => {
     if (!match.value || !isHumanTurn.value) return []
     return getLegalActions(match.value.state, { seatId: humanSeatId.value })
@@ -439,9 +452,19 @@ export function useLiveMatchShell(deps) {
       legalActions: legalActions.value,
     }),
   )
-  const visiblePrimaryActions = computed(() =>
-    visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE'),
-  )
+  const visiblePrimaryActions = computed(() => {
+    const actions = visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE')
+    if (
+      isBiddingPostDrawContext({
+        phase: match.value?.state?.phase ?? null,
+        revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+        legalActions: legalActions.value,
+      })
+    ) {
+      return actions.filter((action) => action.type !== 'SACRIFICE')
+    }
+    return actions
+  })
   /** Matches engine pick-adventurer legal action order. */
   const HERO_CHOICE_ACTION_ORDER = ['WARRIOR', 'BARBARIAN', 'MAGE', 'ROGUE']
   const showHeroPickActionGrid = computed(() => {
@@ -454,19 +477,7 @@ export function useLiveMatchShell(deps) {
     const byHero = new Map(visiblePrimaryActions.value.map((a) => [a.hero, a]))
     return HERO_CHOICE_ACTION_ORDER.map((hero) => byHero.get(hero)).filter(Boolean)
   })
-  const showActionPane = computed(
-    () =>
-      !!activePresentationLabel.value ||
-      (isHumanTurn.value &&
-        (visiblePrimaryActions.value.length > 0 ||
-          dungeonOutcomeTransitionControls.value.length > 0)),
-  )
-  const biddingSacrificeActions = computed(() =>
-    visibleLegalActions.value.filter((a) => a.type === 'SACRIFICE'),
-  )
-  const biddingNonSacrificeActions = computed(() =>
-    visibleLegalActions.value.filter((a) => a.type !== 'SACRIFICE'),
-  )
+  const sacrificeModeActive = ref(false)
   const gameplayInputLocked = ref(false)
   const headlessCompletionInFlight = ref(false)
   const visibleState = computed(() => {
@@ -527,6 +538,7 @@ export function useLiveMatchShell(deps) {
     )
     const isDungeonPhase = match.value?.state?.phase === 'dungeon'
     const hasActionable = actionableEquipmentIds.value.size > 0
+    const sacrificableIds = legalSacrificeEquipmentIds(legalActions.value)
     return biddingBoard.value.secondary.equipment.map((equipment) => {
       const dungeonToken = dungeonTokenById.get(equipment.equipmentId)
       const removed =
@@ -535,6 +547,12 @@ export function useLiveMatchShell(deps) {
         (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
       const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
       const appearance = equipmentTokenAppearance(equipment.equipmentId)
+      const sacrificeFlags = buildBiddingSacrificeTokenFlags({
+        sacrificeModeActive: sacrificeModeActive.value,
+        equipmentId: equipment.equipmentId,
+        removed,
+        legalSacrificeEquipmentIds: sacrificableIds,
+      })
       return {
         equipmentId: equipment.equipmentId,
         ariaLabel: equipmentShortName(equipment.equipmentId),
@@ -546,11 +564,21 @@ export function useLiveMatchShell(deps) {
         deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
         canUseNow: dungeonToken?.canUseNow ?? false,
         hasModal: true,
+        sacrificeHighlight: sacrificeFlags.sacrificeHighlight,
+        sacrificePulse: sacrificeFlags.sacrificePulse,
       }
     })
   })
   const selectedEquipmentModalView = computed(() => {
     if (!selectedEquipmentTokenId.value) return null
+    const phase = match.value?.state?.phase ?? null
+    if (shouldUseBiddingSacrificeEquipmentModalView({ phase, sacrificeModeActive: sacrificeModeActive.value })) {
+      return createBiddingSacrificeEquipmentModalView({
+        equipmentId: selectedEquipmentTokenId.value,
+        legalActions: legalActions.value,
+        sacrificeModeActive: sacrificeModeActive.value,
+      })
+    }
     return createDungeonEquipmentModalView({
       equipmentId: selectedEquipmentTokenId.value,
       legalActions: legalActions.value,
@@ -706,6 +734,30 @@ export function useLiveMatchShell(deps) {
       isHumanTurn: isHumanTurn.value,
     }),
   )
+  const showBiddingPostDrawActionPane = computed(() =>
+    isBiddingPostDrawContext({
+      phase: match.value?.state?.phase ?? null,
+      revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+      legalActions: legalActions.value,
+    }),
+  )
+  const biddingPostDrawActionPane = computed(() =>
+    buildBiddingPostDrawActionPane({
+      sacrificeModeActive: sacrificeModeActive.value,
+      phase: match.value?.state?.phase ?? null,
+      revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+      legalActions: legalActions.value,
+      humanGameplayBlocked: humanGameplayBlocked.value,
+    }),
+  )
+  const showActionPane = computed(
+    () =>
+      !!activePresentationLabel.value ||
+      (isHumanTurn.value &&
+        (visiblePrimaryActions.value.length > 0 ||
+          biddingPostDrawActionPane.value.length > 0 ||
+          dungeonOutcomeTransitionControls.value.length > 0)),
+  )
   function applyBootstrappedMatchSession(matchEnvelope, pace) {
     dungeonRunnerSettingsStore.setAnimationPace(pace)
     match.value = matchEnvelope
@@ -785,6 +837,25 @@ export function useLiveMatchShell(deps) {
         !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)
       ) {
         selectedVorpalSpecies.value = firstSpecies
+      }
+    },
+  )
+
+  watch(
+    () => [
+      match.value?.state?.phase ?? null,
+      match.value?.state?.turn?.activeSeatId ?? null,
+      humanBiddingRevealedMonsterCard.value,
+    ],
+    () => {
+      if (
+        !isBiddingPostDrawContext({
+          phase: match.value?.state?.phase ?? null,
+          revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+          legalActions: legalActions.value,
+        })
+      ) {
+        sacrificeModeActive.value = false
       }
     },
   )
@@ -877,6 +948,7 @@ export function useLiveMatchShell(deps) {
       autoResolveTimerId = null
     }
     if (equipmentModalOpen.value) equipmentModalOpen.value = false
+    if (action.type === 'SACRIFICE') sacrificeModeActive.value = false
     const prevState = match.value.state
     previousVisibleState.value = getPlayerView(prevState, { seatId: humanSeatId.value })
     const result = applyAction(prevState, action, { seatId: humanSeatId.value })
@@ -935,6 +1007,33 @@ export function useLiveMatchShell(deps) {
 
   function onConfirmationDialogCancel() {
     settleConfirmationDialog(false)
+  }
+
+  function enterSacrificeMode() {
+    if (
+      !canEnterBiddingSacrificeMode({
+        isHumanTurn: isHumanTurn.value,
+        phase: match.value?.state?.phase ?? null,
+        revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+        legalActions: legalActions.value,
+        humanGameplayBlocked: humanGameplayBlocked.value,
+      })
+    ) {
+      return
+    }
+    sacrificeModeActive.value = true
+  }
+
+  function cancelSacrificeMode() {
+    sacrificeModeActive.value = false
+    equipmentModalOpen.value = false
+  }
+
+  function takeEquipmentSacrificeAction() {
+    if (equipmentModalActionsDisabled.value || !selectedEquipmentModalView.value?.sacrificeAction) {
+      return
+    }
+    takeHumanAction(selectedEquipmentModalView.value.sacrificeAction)
   }
 
   function openEquipmentModal(token) {
@@ -1482,6 +1581,11 @@ export function useLiveMatchShell(deps) {
     return id ? `${action.type}-${id}` : action.type
   }
 
+  function biddingPostDrawActionPaneKey(item) {
+    if (item.kind === 'engine') return actionKey(item.action)
+    return item.kind
+  }
+
   function skipActivePresentation() {
     presentationOrchestrator.skipActiveAnimation()
     syncPresentationLabel()
@@ -1625,8 +1729,11 @@ export function useLiveMatchShell(deps) {
       showActionPane,
       activePresentationLabel,
       isHumanTurn,
-      biddingSacrificeActions,
-      biddingNonSacrificeActions,
+      showBiddingPostDrawActionPane,
+      biddingPostDrawActionPane,
+      biddingPostDrawActionPaneKey,
+      enterSacrificeMode,
+      cancelSacrificeMode,
       actionKey,
       actionLabel,
       humanGameplayBlocked,
@@ -1655,6 +1762,7 @@ export function useLiveMatchShell(deps) {
       selectedEquipmentModalView,
       equipmentModalActionsDisabled,
       takeEquipmentUseAction,
+      takeEquipmentSacrificeAction,
       continueFromEquipmentModal,
       confirmationDialogOpen,
       confirmationDialogTitle,

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -32,10 +32,10 @@ import {
 } from '../dungeonEquipmentInteractions.js'
 import {
   buildBiddingPostDrawActionPane,
-  buildBiddingSacrificeTokenFlags,
   canEnterBiddingSacrificeMode,
   createBiddingSacrificeEquipmentModalView,
   isBiddingPostDrawContext,
+  isSacrificeTargetEquipmentToken,
   legalSacrificeEquipmentIds,
   shouldUseBiddingSacrificeEquipmentModalView,
 } from '../biddingSacrificeInteractions.js'
@@ -446,6 +446,13 @@ export function useLiveMatchShell(deps) {
     if (!match.value || !isHumanTurn.value) return []
     return getLegalActions(match.value.state, { seatId: humanSeatId.value })
   })
+  const isHumanBiddingPostDrawContext = computed(() =>
+    isBiddingPostDrawContext({
+      phase: match.value?.state?.phase ?? null,
+      revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
+      legalActions: legalActions.value,
+    }),
+  )
   const visibleLegalActions = computed(() =>
     filterVisibleLegalActions({
       phase: match.value?.state?.phase ?? null,
@@ -454,13 +461,7 @@ export function useLiveMatchShell(deps) {
   )
   const visiblePrimaryActions = computed(() => {
     const actions = visibleLegalActions.value.filter((action) => action.type !== 'REVEAL_OR_CONTINUE')
-    if (
-      isBiddingPostDrawContext({
-        phase: match.value?.state?.phase ?? null,
-        revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
-        legalActions: legalActions.value,
-      })
-    ) {
+    if (isHumanBiddingPostDrawContext.value) {
       return actions.filter((action) => action.type !== 'SACRIFICE')
     }
     return actions
@@ -547,7 +548,7 @@ export function useLiveMatchShell(deps) {
         (isDungeonPhase && !dungeonTokenById.has(equipment.equipmentId))
       const actionable = isDungeonPhase && actionableEquipmentIds.value.has(equipment.equipmentId)
       const appearance = equipmentTokenAppearance(equipment.equipmentId)
-      const sacrificeFlags = buildBiddingSacrificeTokenFlags({
+      const isSacrificeTarget = isSacrificeTargetEquipmentToken({
         sacrificeModeActive: sacrificeModeActive.value,
         equipmentId: equipment.equipmentId,
         removed,
@@ -564,8 +565,7 @@ export function useLiveMatchShell(deps) {
         deemphasized: isDungeonPhase && hasActionable && !actionable && !removed,
         canUseNow: dungeonToken?.canUseNow ?? false,
         hasModal: true,
-        sacrificeHighlight: sacrificeFlags.sacrificeHighlight,
-        sacrificePulse: sacrificeFlags.sacrificePulse,
+        isSacrificeTarget,
       }
     })
   })
@@ -734,13 +734,7 @@ export function useLiveMatchShell(deps) {
       isHumanTurn: isHumanTurn.value,
     }),
   )
-  const showBiddingPostDrawActionPane = computed(() =>
-    isBiddingPostDrawContext({
-      phase: match.value?.state?.phase ?? null,
-      revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
-      legalActions: legalActions.value,
-    }),
-  )
+  const showBiddingPostDrawActionPane = isHumanBiddingPostDrawContext
   const biddingPostDrawActionPane = computed(() =>
     buildBiddingPostDrawActionPane({
       sacrificeModeActive: sacrificeModeActive.value,
@@ -841,24 +835,9 @@ export function useLiveMatchShell(deps) {
     },
   )
 
-  watch(
-    () => [
-      match.value?.state?.phase ?? null,
-      match.value?.state?.turn?.activeSeatId ?? null,
-      humanBiddingRevealedMonsterCard.value,
-    ],
-    () => {
-      if (
-        !isBiddingPostDrawContext({
-          phase: match.value?.state?.phase ?? null,
-          revealedMonsterCard: humanBiddingRevealedMonsterCard.value,
-          legalActions: legalActions.value,
-        })
-      ) {
-        sacrificeModeActive.value = false
-      }
-    },
-  )
+  watch(isHumanBiddingPostDrawContext, (active) => {
+    if (!active) sacrificeModeActive.value = false
+  })
 
   function resetForSetupTerminal() {
     resetLiveMatchPageState(liveMatchPageSessionSink, {


### PR DESCRIPTION
## Summary

- Replaces the human bidding sacrifice dropdown and one-tap name buttons with **Sacrifice mode (bidding)**: enter mode from the action pane, pick highlighted center-table equipment, confirm via the equipment modal, then dispatch the existing `SACRIFICE` action unchanged.
- Adds a pure `biddingSacrificeInteractions` view model (entry guards, action pane, tile flags, modal wiring) with unit tests; shell wiring holds ephemeral sacrifice mode state that clears on cancel, successful sacrifice, or post-draw context loss (not persisted on reload).
- Updates help copy for the new flow and tightens equipment-token glow rendering (red sacrifice and yellow dungeon usability) onto inset rings so adjacent halos do not overlap.

Closes #243

## Test plan

- [ ] Draw in bidding as human → **Add to dungeon** and **Sacrifice equipment** shown; no sacrifice dropdown or per-name buttons
- [ ] Enter sacrifice mode → red highlighted tiles pulse; action pane shows **Cancel** only; **Add to dungeon** hidden
- [ ] Tap highlighted tile → equipment modal **Sacrifice** confirms discard; `BIDDING_SACRIFICE` presentation runs
- [ ] Open non-sacrificable tile in mode → read-only modal; **Continue** dismisses and keeps mode active
- [ ] **Cancel** exits mode and closes any open equipment modal
- [ ] Presentation lock blocks sacrifice mode entry and confirmation same as other bidding actions
- [ ] Reload mid sacrifice mode → normal post-draw pane without highlights
- [ ] Dungeon-phase yellow usability glow still highlights correct gear without halos bleeding between tiles
- [ ] Opponent / Randombot sacrifice behavior unchanged
- [x] `node --experimental-test-module-mocks --test src/features/dungeon-runner/ui/biddingSacrificeInteractions.test.js src/features/dungeon-runner/ui/dungeonEquipmentInteractions.test.js`