### PR TITLE
Replace vorpal declaration dropdown with card-hand picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "node --experimental-test-module-mocks --test \"src/features/**/*.test.js\" \"src/features/**/*.test.mjs\" \"src/layouts/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\" \"scripts/sync-dungeon-runner-model.test.mjs\" \"scripts/dungeon-runner-model-catalog.test.mjs\" \"scripts/convert-dungeon-runner-h5.test.mjs\" \"scripts/dungeon-runner-model-artifacts.test.mjs\"",
+    "test": "node --experimental-test-module-mocks --test \"src/composables/**/*.test.js\" \"src/features/**/*.test.js\" \"src/features/**/*.test.mjs\" \"src/layouts/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\" \"scripts/sync-dungeon-runner-model.test.mjs\" \"scripts/dungeon-runner-model-catalog.test.mjs\" \"scripts/convert-dungeon-runner-h5.test.mjs\" \"scripts/dungeon-runner-model-artifacts.test.mjs\"",
     "test:database-rules": "firebase emulators:exec --only database \"node --test database.rules.test.mjs\"",
     "test:firestore-rules": "firebase emulators:exec --only firestore \"node --test firestore.rules.test.mjs\"",
     "dev": "quasar dev",

--- a/src/composables/pointerDragScrollController.js
+++ b/src/composables/pointerDragScrollController.js
@@ -1,0 +1,127 @@
+const DEFAULT_THRESHOLD_PX = 4
+
+/**
+ * @param {number} deltaX
+ * @param {number} deltaY
+ * @param {number} thresholdPx
+ * @returns {boolean}
+ */
+function isPastDragThreshold(deltaX, deltaY, thresholdPx) {
+  return Math.abs(deltaX) > thresholdPx || Math.abs(deltaY) > thresholdPx
+}
+
+/**
+ * @param {{
+ *   getScrollEl: () => { scrollTop: number, scrollLeft: number } | null
+ *   axis?: 'y' | 'both'
+ *   thresholdPx?: number
+ *   scrollBeforeThreshold?: boolean
+ *   shouldBegin?: (event: { pointerType?: string, button?: number }) => boolean
+ *   onActiveChange?: (active: boolean) => void
+ * }} options
+ */
+export function createPointerDragScrollController(options) {
+  const axis = options.axis ?? 'y'
+  const thresholdPx = options.thresholdPx ?? DEFAULT_THRESHOLD_PX
+  const scrollBeforeThreshold = options.scrollBeforeThreshold ?? false
+  const shouldBegin = options.shouldBegin ?? (() => true)
+  const onActiveChange = options.onActiveChange ?? (() => {})
+
+  let active = false
+  let panMoved = false
+  let suppressClickOnPan = false
+  let startX = 0
+  let startY = 0
+  let startScrollTop = 0
+  let startScrollLeft = 0
+
+  function setActive(nextActive) {
+    if (active === nextActive) return
+    active = nextActive
+    onActiveChange(nextActive)
+  }
+
+  /**
+   * @param {{ clientX: number, clientY: number, pointerId: number }} event
+   * @param {{ captureEl: { setPointerCapture?: (id: number) => void } | null, suppressClickOnPan?: boolean }} dragOptions
+   */
+  function beginDrag(event, dragOptions) {
+    if (!shouldBegin(event)) return
+
+    const scrollEl = options.getScrollEl()
+    const captureEl = dragOptions.captureEl
+    if (!scrollEl || !captureEl) return
+
+    setActive(true)
+    panMoved = false
+    suppressClickOnPan = dragOptions.suppressClickOnPan === true
+    startX = event.clientX
+    startY = event.clientY
+    startScrollTop = scrollEl.scrollTop
+    startScrollLeft = scrollEl.scrollLeft
+
+    if (typeof captureEl.setPointerCapture === 'function') {
+      captureEl.setPointerCapture(event.pointerId)
+    }
+  }
+
+  /** @param {{ clientX: number, clientY: number }} event */
+  function onMove(event) {
+    if (!active) return
+
+    const scrollEl = options.getScrollEl()
+    if (!scrollEl) return
+
+    const deltaX = event.clientX - startX
+    const deltaY = event.clientY - startY
+    const pastThreshold = isPastDragThreshold(deltaX, deltaY, thresholdPx)
+
+    if (pastThreshold) {
+      panMoved = true
+    }
+
+    if (!scrollBeforeThreshold && !pastThreshold) return
+
+    if (axis === 'both') {
+      scrollEl.scrollLeft = startScrollLeft - deltaX
+      scrollEl.scrollTop = startScrollTop - deltaY
+      return
+    }
+
+    scrollEl.scrollTop = startScrollTop - deltaY
+  }
+
+  function onEnd() {
+    if (!active) return
+
+    setActive(false)
+
+    if (panMoved && !suppressClickOnPan) {
+      panMoved = false
+    }
+  }
+
+  /** @returns {boolean} */
+  function consumePanClick() {
+    if (!panMoved || !suppressClickOnPan) return false
+
+    panMoved = false
+    suppressClickOnPan = false
+    return true
+  }
+
+  return {
+    beginDrag,
+    onMove,
+    onEnd,
+    consumePanClick,
+  }
+}
+
+/**
+ * @param {{ pointerType?: string, button?: number }} event
+ * @returns {boolean}
+ */
+export function filterMousePrimaryButton(event) {
+  return event.pointerType === 'mouse' && event.button === 0
+}

--- a/src/composables/pointerDragScrollController.test.js
+++ b/src/composables/pointerDragScrollController.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPointerDragScrollController } from './pointerDragScrollController.js'
+
+function createScrollEl() {
+  return {
+    scrollTop: 100,
+    scrollLeft: 50,
+  }
+}
+
+function createCaptureEl() {
+  return {
+    capturedPointerId: null,
+    setPointerCapture(pointerId) {
+      this.capturedPointerId = pointerId
+    },
+  }
+}
+
+function createEvent(overrides = {}) {
+  return {
+    clientX: 0,
+    clientY: 0,
+    pointerId: 1,
+    pointerType: 'mouse',
+    button: 0,
+    ...overrides,
+  }
+}
+
+test('background-origin pan clears stale panMoved on end', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    axis: 'y',
+    scrollBeforeThreshold: false,
+  })
+
+  controller.beginDrag(createEvent({ clientX: 10, clientY: 10 }), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: false,
+  })
+  controller.onMove(createEvent({ clientX: 10, clientY: 20 }))
+  controller.onEnd()
+
+  assert.equal(controller.consumePanClick(), false)
+})
+
+test('card-origin pan suppresses the next click once', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    axis: 'y',
+    scrollBeforeThreshold: false,
+  })
+
+  controller.beginDrag(createEvent({ clientX: 10, clientY: 10 }), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: true,
+  })
+  controller.onMove(createEvent({ clientX: 10, clientY: 20 }))
+  controller.onEnd()
+
+  assert.equal(controller.consumePanClick(), true)
+  assert.equal(controller.consumePanClick(), false)
+})
+
+test('sub-threshold movement does not suppress click', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    axis: 'y',
+    scrollBeforeThreshold: false,
+  })
+
+  controller.beginDrag(createEvent({ clientX: 10, clientY: 10 }), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: true,
+  })
+  controller.onMove(createEvent({ clientX: 10, clientY: 12 }))
+  controller.onEnd()
+
+  assert.equal(controller.consumePanClick(), false)
+})
+
+test('both-axis scroll updates before threshold when scrollBeforeThreshold is true', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    axis: 'both',
+    scrollBeforeThreshold: true,
+  })
+
+  controller.beginDrag(createEvent({ clientX: 20, clientY: 30 }), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: true,
+  })
+  controller.onMove(createEvent({ clientX: 22, clientY: 31 }))
+
+  assert.equal(scrollEl.scrollLeft, 48)
+  assert.equal(scrollEl.scrollTop, 99)
+  assert.equal(controller.consumePanClick(), false)
+})
+
+test('y-axis scroll waits for threshold when scrollBeforeThreshold is false', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    axis: 'y',
+    scrollBeforeThreshold: false,
+  })
+
+  controller.beginDrag(createEvent({ clientX: 10, clientY: 10 }), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: false,
+  })
+  controller.onMove(createEvent({ clientX: 10, clientY: 12 }))
+
+  assert.equal(scrollEl.scrollTop, 100)
+
+  controller.onMove(createEvent({ clientX: 10, clientY: 20 }))
+
+  assert.equal(scrollEl.scrollTop, 90)
+})
+
+test('shouldBegin gate blocks drag start', () => {
+  const scrollEl = createScrollEl()
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => scrollEl,
+    shouldBegin: () => false,
+  })
+
+  controller.beginDrag(createEvent(), {
+    captureEl: createCaptureEl(),
+    suppressClickOnPan: true,
+  })
+  controller.onMove(createEvent({ clientX: 0, clientY: 20 }))
+
+  assert.equal(scrollEl.scrollTop, 100)
+  assert.equal(controller.consumePanClick(), false)
+})

--- a/src/composables/usePointerDragScroll.js
+++ b/src/composables/usePointerDragScroll.js
@@ -1,0 +1,35 @@
+import { ref, unref } from 'vue'
+import {
+  createPointerDragScrollController,
+  filterMousePrimaryButton,
+} from './pointerDragScrollController.js'
+
+/**
+ * @param {{
+ *   scrollElRef: import('vue').Ref<{ scrollTop: number, scrollLeft: number } | null>
+ *   axis?: 'y' | 'both'
+ *   thresholdPx?: number
+ *   scrollBeforeThreshold?: boolean
+ *   shouldBegin?: (event: { pointerType?: string, button?: number }) => boolean
+ * }} options
+ */
+export function usePointerDragScroll(options) {
+  const dragActive = ref(false)
+
+  const controller = createPointerDragScrollController({
+    getScrollEl: () => unref(options.scrollElRef),
+    axis: options.axis,
+    thresholdPx: options.thresholdPx,
+    scrollBeforeThreshold: options.scrollBeforeThreshold,
+    shouldBegin: options.shouldBegin,
+    onActiveChange: (active) => {
+      dragActive.value = active
+    },
+  })
+
+  return {
+    dragActive,
+    handlers: controller,
+    filterMousePrimaryButton,
+  }
+}

--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -258,6 +258,18 @@ Transient human-player UI during **bidding**, after a **draw** reveals a monster
 
 _Avoid_: “Sacrifice picker,” dropdown-by-name as the primary sacrifice UX; red highlight on tiles that rules do not allow sacrificing; treating sacrifice mode as a separate **match** phase; leaving **Add to dungeon** enabled alongside sacrifice mode; one-tap human sacrifice shortcuts that bypass tile selection and confirmation; changing how **neural opponent** or **Randombot** choose sacrifices; persisting sacrifice mode across reload (ephemeral **live match shell** UI only).
 
+### Vorpal declaration (dungeon)
+
+The pre-reveal **species** choice at **dungeon run** start when the runner has Vorpal **equipment** in play (`W_VORPAL` or `R_VORP`). Mandatory whenever that gear is in play and the dungeon lane is non-empty—no skip or dismiss. The human names one **species** from the fixed roster (`DECLARE_VORPAL`); all eight roster **species** are always legal regardless of dungeon pile contents (hidden-info). If the first revealed **monster** matches that **species**, Vorpal neutralizes it. Human **live match shell** UX: a persistent near-fullscreen blocking panel (same class as **deck splay**) over a dimmed board, showing all eight **monster** card faces (one per **species**) in a vertically scrollable overlapping “hand” (cards slightly stacked; the selected card drawn larger toward center); scroll browses only—tap a card to select (enlarged toward center with a selection outline), then **Confirm** to declare—no **Cancel**, no species pre-selected on open. **Play route chrome** (help, settings, and similar system surfaces) stays usable—including while the picker is open and while presentation locks gameplay input on the board. Card taps and **Confirm** follow the same interactability gate as other human turn actions (disabled when gameplay input is locked). With **memory aid** on, each card may show how many of that **species** the human added to dungeon piles (caption only when count > 0).
+
+_Avoid_: “Vorpal target,” “vorpal weapon target,” or “vorpal blade” without clarifying it is a **species** declaration on Vorpal **equipment** in play, not picking a visible lane card; “equipment pile” when meaning bidding center table or discard piles (use **in play** for the runner’s dungeon kit); filtering the roster by pile composition; treating declaration as “which **monster** is up next” from hidden lane state; pre-selecting a default **species** when the picker opens; one-tap declaration without **Confirm**; a dismiss or **Cancel** affordance that implies the choice is optional; scroll changing the selected **species** without a tap; showing `0` own-pile counts on every card when **memory aid** is on; changing **neural opponent** or **Randombot** declaration interfaces or action spaces.
+
+### Vorpal declaration picker (human)
+
+The human-player card-hand UI for **vorpal declaration (dungeon)** in **live match shell** only. Ephemeral presentation layer over the same `DECLARE_VORPAL` action—**neural opponent** and **Randombot** interfaces unchanged.
+
+_Avoid_: “Vorpal UI,” “vorpal dialog” without **human** scope; any picker or affordance on **opponent** turns; conflating with engine legality or policy encoding; a second “are you sure?” step after **Confirm**; persisting picker or selected **species** on **current match** reload; re-tapping the selected card to deselect or to commit without **Confirm**.
+
 ### Game data catalog
 
 The single source of truth for static **equipment** and **monster** definitions shared by rules resolution and presentation.
@@ -324,15 +336,17 @@ The canonical id string for a **monster** catalog entry (e.g. `goblin`); keys de
 
 ### Strength
 
-The combat value on a **monster** entry; each strength maps to exactly one **species** (e.g. strength 2 is always skeleton, 3 always orc).
+The combat value on a **monster** entry; each strength maps to exactly one **species** (e.g. strength 2 is always skeleton, 3 always orc). Catalog strengths run 1–7 then 9 (dragon)—there is no strength-8 **monster**.
 
 ### Monster deck
 
-The standard ordered list of **monster** **species** ids (including duplicates) used to build the dungeon lane at **match** start.
+The standard ordered list of **monster** **species** ids (including duplicates) used to build the dungeon lane at **match** start. Distinct from **policy species order** (unique roster, ascending **strength**).
 
 ### Policy species order
 
-The canonical ordering of **monster** **species** ids for neural observation encoding; fixed in the **game data catalog** and stable across balance edits unless models are retrained.
+The canonical ascending-**strength** ordering of all eight **monster** **species** in the **game data catalog**: goblin (1), skeleton (2), orc (3), vampire (4), golem (5), lich (6), demon (7), dragon (9). Shared roster for `DECLARE_VORPAL` legal actions, **vorpal declaration picker (human)** card-hand layout, and **neural opponent** observation slots—fixed unless models are retrained.
+
+_Avoid_: Confusing with **monster deck** deal order; alphabetical order; assuming contiguous strengths 1–8; re-sorting the roster in human UI only.
 
 ### TF.js model sync
 
@@ -353,6 +367,12 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - **Equipment** and **monster** definitions are consulted during **dungeon runs** and bidding within a **match**.
 - After a bidding **draw**, the drawer may **Add to dungeon** or enter **sacrifice mode (bidding)** to discard one legally sacrificable center-table **equipment** piece instead; only highlighted tiles accept sacrifice confirmation. While sacrifice mode is active, **Add to dungeon** and other turn actions are unavailable until **Cancel** or a confirmed sacrifice resolves the choice.
 - **Sacrifice mode (bidding)** is **human player seat** UX in **live match shell** only; **opponent** sacrifice is unchanged. Ephemeral—clears on reload; not part of **current match** persistence. Bidding help copy describes enter → pick highlighted tile → confirm → **Cancel**.
+- **Vorpal declaration (dungeon)** is a hidden-info **species** pick from the full roster, not a choice among visible lane **monsters**; optional memory-aid own-pile counts are supplementary hints only.
+- **Vorpal declaration picker (human)** is **human player seat** UX in **live match shell** only; **neural opponent** and **Randombot** `DECLARE_VORPAL` behavior and interfaces are unchanged. Ephemeral—clears on reload; not part of **current match** persistence.
+- **Vorpal declaration picker (human)** lists cards in **policy species order** (ascending **strength**), same roster order as `DECLARE_VORPAL` legality and the former dropdown.
+- Dungeon-run help copy describes **vorpal declaration picker (human)** flow (mandatory picker → tap card → **Confirm**; memory-aid counts when enabled).
+- **Vorpal declaration picker (human)** follows the same presentation-lock interactability rules as **sacrifice mode (bidding)**; **play route chrome** is never blocked by the picker or by gameplay-input locks.
+- **Policy species order** is not **monster deck** order—the deck includes duplicates and follows deal composition, not the unique strength ladder.
 - A **match** contains one or more **dungeon runs** before **match over**.
 - **Elimination end (human)** and **Defeat (human, not eliminated)** use different end-dialog copy; only the latter names the winning seat.
 - Headless completion of remaining **opponent** play after human **elimination** uses the same action choosers as live play (not a simplified bot).

--- a/src/features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue
+++ b/src/features/dungeon-runner/ui/DungeonRunnerHelpDialog.vue
@@ -57,6 +57,13 @@
           adventurer's starting HP and the equipment you have in play.
         </p>
         <p class="q-ma-none q-mb-sm">
+          If you have Vorpal equipment in play when the dungeon run starts, you must declare a species before the
+          first monster is revealed. A card picker shows every roster species—tap a card to select it, then tap
+          <strong>Confirm</strong> to declare. With memory aid on, cards may show how many of that species you added
+          to dungeon piles during bidding (only when the count is greater than zero). You cannot dismiss this picker;
+          see the Vorpal Sword or Dagger description for the full rules.
+        </p>
+        <p class="q-ma-none q-mb-sm">
           Reveal and resolve each monster in order. Most of the time, advancing through the dungeon is automatic. However, 
           sometimes you'll have the option (or be required) to choose an action from the equipment buttons at the bottom.
         </p>

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -417,29 +417,62 @@
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.dialogs.vorpalDialogOpen" persistent>
-      <q-card class="q-pa-md" style="min-width: 320px">
-        <div class="text-subtitle1 q-mb-xs">Vorpal target</div>
-        <div class="text-body2 q-mb-md">Choose a species before entering the dungeon.</div>
-        <q-select
-          v-model="session.dialogs.selectedVorpalSpecies"
-          :options="session.dialogs.vorpalSelectOptions"
-          emit-value
-          map-options
-          option-value="value"
-          option-label="label"
-          label="Species"
-          behavior="menu"
-          outlined
-          dense
-          class="q-mb-md"
-        />
-        <div class="row justify-end">
+    <q-dialog v-model="session.dialogs.vorpalDialogOpen" maximized persistent>
+      <q-card class="dr-deck-splay-panel dr-vorpal-picker-panel">
+        <div class="q-px-md q-pt-md q-pb-sm">
+          <div class="text-subtitle1">Vorpal declaration</div>
+          <div class="text-body2 q-mt-xs">
+            Choose a species before the first monster is revealed.
+          </div>
+        </div>
+        <q-separator />
+        <div
+          ref="vorpalPickerScrollEl"
+          class="q-pa-md dr-deck-splay-scroll dr-vorpal-picker-scroll"
+        >
+          <div
+            class="dr-vorpal-picker-hand"
+            :class="{
+              'dr-vorpal-picker-hand--has-selection': session.dialogs.vorpalPickerView.handCards.some(
+                (card) => card.layoutRole === 'selected',
+              ),
+            }"
+          >
+            <button
+              v-for="card in session.dialogs.vorpalPickerView.handCards"
+              :key="`vorpal-picker-${card.species}`"
+              type="button"
+              class="dr-vorpal-picker-card"
+              :class="{
+                'dr-vorpal-picker-card--selected': card.layoutRole === 'selected',
+                'dr-vorpal-picker-card--isolated': card.layoutRole === 'selected',
+                'dr-vorpal-picker-card--below-break': card.layoutRole === 'below-break',
+                'dr-vorpal-picker-card--below': card.layoutRole === 'below',
+              }"
+              :disabled="!card.selectable"
+              :data-testid="`${LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerCard}-${card.species}`"
+              @click="session.dialogs.onVorpalPickerCardTap(card.species)"
+            >
+              <div class="dr-vorpal-picker-card-stack">
+                <MonsterCardFace class="dr-vorpal-picker-card-face" :species="card.species" />
+                <div
+                  v-if="card.memoryAidCaption"
+                  class="text-caption text-center dr-vorpal-picker-caption"
+                >
+                  Added to dungeon: {{ card.memoryAidCaption }}
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+        <q-separator />
+        <div class="row justify-end q-pa-md dr-vorpal-picker-footer">
           <q-btn
             color="primary"
             unelevated
             label="Confirm"
-            :disable="!session.dialogs.selectedVorpalSpecies || session.board.humanGameplayBlocked"
+            :disable="!session.dialogs.vorpalPickerView.confirmEnabled"
+            :data-testid="LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerConfirm"
             @click="session.dialogs.confirmVorpalDeclaration"
           />
         </div>
@@ -482,12 +515,51 @@
 </template>
 
 <script setup>
-import { inject } from 'vue'
+import { inject, nextTick, ref, watch } from 'vue'
 import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
 import { LIVE_MATCH_SHELL_SESSION_KEY } from './liveMatchShellSessionKey.js'
 import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
 
 const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
+const vorpalPickerScrollEl = ref(null)
+
+function waitForNextFrame() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+function centerVorpalPickerSelection() {
+  const scrollEl = vorpalPickerScrollEl.value
+  if (!scrollEl) return
+
+  const selectedEl = scrollEl.querySelector('.dr-vorpal-picker-card--selected')
+  if (!(selectedEl instanceof HTMLElement)) return
+
+  const scrollRect = scrollEl.getBoundingClientRect()
+  const selectedRect = selectedEl.getBoundingClientRect()
+  const delta =
+    selectedRect.top + selectedRect.height / 2 - (scrollRect.top + scrollRect.height / 2)
+
+  scrollEl.scrollTo({
+    top: scrollEl.scrollTop + delta,
+    behavior: 'smooth',
+  })
+}
+
+watch(
+  () => {
+    const handCards = session?.dialogs?.vorpalPickerView?.handCards ?? []
+    const selected = handCards.find((card) => card.layoutRole === 'selected')
+    return selected?.species ?? null
+  },
+  async (species) => {
+    if (!species) return
+    await nextTick()
+    await waitForNextFrame()
+    centerVorpalPickerSelection()
+  },
+)
 </script>
 
 <style scoped>
@@ -760,6 +832,126 @@ const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
 
 .dr-deck-splay-scroll {
   overflow-y: auto;
+}
+
+.dr-vorpal-picker-panel {
+  max-width: min(960px, 100vw);
+}
+
+.dr-vorpal-picker-scroll {
+  flex: 1;
+  min-height: 0;
+}
+
+.dr-vorpal-picker-hand {
+  --dr-vorpal-picker-card-width: min(400px, 94vw);
+  --dr-vorpal-picker-card-height: calc(var(--dr-vorpal-picker-card-width) * 245 / 384);
+  --dr-vorpal-picker-peek: 76px;
+  --dr-vorpal-picker-hand-tail: calc(
+    var(--dr-vorpal-picker-card-height) - var(--dr-vorpal-picker-peek) + 8px
+  );
+  --dr-vorpal-picker-below-gap: 0px;
+  --dr-vorpal-picker-selection-inset: 7cqw;
+  container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  margin: 0 auto;
+  padding: 8px 0 calc(24px + var(--dr-vorpal-picker-hand-tail));
+  width: var(--dr-vorpal-picker-card-width);
+}
+
+.dr-vorpal-picker-card {
+  appearance: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  height: var(--dr-vorpal-picker-peek);
+  overflow: visible;
+  padding: 0;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.dr-vorpal-picker-card-stack {
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card-face {
+  display: block;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card-face :deep(.dr-monster-card) {
+  margin: 0;
+  max-width: none;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card--isolated {
+  height: auto;
+  overflow: visible;
+  position: relative;
+  z-index: 2;
+}
+
+.dr-vorpal-picker-card--isolated .dr-vorpal-picker-card-stack {
+  position: static;
+}
+
+.dr-vorpal-picker-card--below-break {
+  margin-top: var(--dr-vorpal-picker-below-gap);
+  overflow: visible;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card--below {
+  overflow: visible;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face {
+  isolation: isolate;
+  position: relative;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face::before {
+  border-radius: var(--dr-vorpal-picker-selection-inset);
+  box-shadow:
+    0 0 0 3px rgba(100, 181, 246, 0.8),
+    0 0 0 6px rgba(66, 165, 245, 0.45),
+    0 0 40px rgba(100, 181, 246, 0.55),
+    0 0 60px rgba(66, 165, 245, 0.3);
+  content: '';
+  inset: var(--dr-vorpal-picker-selection-inset);
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face :deep(.dr-monster-card) {
+  position: relative;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-caption {
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 4px;
+}
+
+.dr-vorpal-picker-footer {
+  flex-shrink: 0;
 }
 
 .dr-hero--warrior {

--- a/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
+++ b/src/features/dungeon-runner/ui/shells/LiveMatchShell.vue
@@ -417,67 +417,12 @@
       </q-card>
     </q-dialog>
     
-    <q-dialog v-model="session.dialogs.vorpalDialogOpen" maximized persistent>
-      <q-card class="dr-deck-splay-panel dr-vorpal-picker-panel">
-        <div class="q-px-md q-pt-md q-pb-sm">
-          <div class="text-subtitle1">Vorpal declaration</div>
-          <div class="text-body2 q-mt-xs">
-            Choose a species before the first monster is revealed.
-          </div>
-        </div>
-        <q-separator />
-        <div
-          ref="vorpalPickerScrollEl"
-          class="q-pa-md dr-deck-splay-scroll dr-vorpal-picker-scroll"
-        >
-          <div
-            class="dr-vorpal-picker-hand"
-            :class="{
-              'dr-vorpal-picker-hand--has-selection': session.dialogs.vorpalPickerView.handCards.some(
-                (card) => card.layoutRole === 'selected',
-              ),
-            }"
-          >
-            <button
-              v-for="card in session.dialogs.vorpalPickerView.handCards"
-              :key="`vorpal-picker-${card.species}`"
-              type="button"
-              class="dr-vorpal-picker-card"
-              :class="{
-                'dr-vorpal-picker-card--selected': card.layoutRole === 'selected',
-                'dr-vorpal-picker-card--isolated': card.layoutRole === 'selected',
-                'dr-vorpal-picker-card--below-break': card.layoutRole === 'below-break',
-                'dr-vorpal-picker-card--below': card.layoutRole === 'below',
-              }"
-              :disabled="!card.selectable"
-              :data-testid="`${LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerCard}-${card.species}`"
-              @click="session.dialogs.onVorpalPickerCardTap(card.species)"
-            >
-              <div class="dr-vorpal-picker-card-stack">
-                <MonsterCardFace class="dr-vorpal-picker-card-face" :species="card.species" />
-                <div
-                  v-if="card.memoryAidCaption"
-                  class="text-caption text-center dr-vorpal-picker-caption"
-                >
-                  Added to dungeon: {{ card.memoryAidCaption }}
-                </div>
-              </div>
-            </button>
-          </div>
-        </div>
-        <q-separator />
-        <div class="row justify-end q-pa-md dr-vorpal-picker-footer">
-          <q-btn
-            color="primary"
-            unelevated
-            label="Confirm"
-            :disable="!session.dialogs.vorpalPickerView.confirmEnabled"
-            :data-testid="LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerConfirm"
-            @click="session.dialogs.confirmVorpalDeclaration"
-          />
-        </div>
-      </q-card>
-    </q-dialog>
+    <VorpalDeclarationPickerDialog
+      :open="session.dialogs.vorpalPickerView.open"
+      :picker-view="session.dialogs.vorpalPickerView"
+      @card-tap="session.dialogs.onVorpalPickerCardTap"
+      @confirm="session.dialogs.confirmVorpalDeclaration"
+    />
     <q-dialog v-model="session.dialogs.deckSplayOpen" maximized>
       <q-card class="dr-deck-splay-panel">
         <div class="row items-center q-px-md q-pt-md q-pb-sm">
@@ -515,51 +460,13 @@
 </template>
 
 <script setup>
-import { inject, nextTick, ref, watch } from 'vue'
+import { inject } from 'vue'
 import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
 import { LIVE_MATCH_SHELL_SESSION_KEY } from './liveMatchShellSessionKey.js'
 import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
+import VorpalDeclarationPickerDialog from './VorpalDeclarationPickerDialog.vue'
 
 const session = inject(LIVE_MATCH_SHELL_SESSION_KEY)
-const vorpalPickerScrollEl = ref(null)
-
-function waitForNextFrame() {
-  return new Promise((resolve) => {
-    requestAnimationFrame(() => resolve())
-  })
-}
-
-function centerVorpalPickerSelection() {
-  const scrollEl = vorpalPickerScrollEl.value
-  if (!scrollEl) return
-
-  const selectedEl = scrollEl.querySelector('.dr-vorpal-picker-card--selected')
-  if (!(selectedEl instanceof HTMLElement)) return
-
-  const scrollRect = scrollEl.getBoundingClientRect()
-  const selectedRect = selectedEl.getBoundingClientRect()
-  const delta =
-    selectedRect.top + selectedRect.height / 2 - (scrollRect.top + scrollRect.height / 2)
-
-  scrollEl.scrollTo({
-    top: scrollEl.scrollTop + delta,
-    behavior: 'smooth',
-  })
-}
-
-watch(
-  () => {
-    const handCards = session?.dialogs?.vorpalPickerView?.handCards ?? []
-    const selected = handCards.find((card) => card.layoutRole === 'selected')
-    return selected?.species ?? null
-  },
-  async (species) => {
-    if (!species) return
-    await nextTick()
-    await waitForNextFrame()
-    centerVorpalPickerSelection()
-  },
-)
 </script>
 
 <style scoped>
@@ -832,126 +739,6 @@ watch(
 
 .dr-deck-splay-scroll {
   overflow-y: auto;
-}
-
-.dr-vorpal-picker-panel {
-  max-width: min(960px, 100vw);
-}
-
-.dr-vorpal-picker-scroll {
-  flex: 1;
-  min-height: 0;
-}
-
-.dr-vorpal-picker-hand {
-  --dr-vorpal-picker-card-width: min(400px, 94vw);
-  --dr-vorpal-picker-card-height: calc(var(--dr-vorpal-picker-card-width) * 245 / 384);
-  --dr-vorpal-picker-peek: 76px;
-  --dr-vorpal-picker-hand-tail: calc(
-    var(--dr-vorpal-picker-card-height) - var(--dr-vorpal-picker-peek) + 8px
-  );
-  --dr-vorpal-picker-below-gap: 0px;
-  --dr-vorpal-picker-selection-inset: 7cqw;
-  container-type: inline-size;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0;
-  margin: 0 auto;
-  padding: 8px 0 calc(24px + var(--dr-vorpal-picker-hand-tail));
-  width: var(--dr-vorpal-picker-card-width);
-}
-
-.dr-vorpal-picker-card {
-  appearance: none;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  flex-shrink: 0;
-  height: var(--dr-vorpal-picker-peek);
-  overflow: visible;
-  padding: 0;
-  position: relative;
-  width: 100%;
-  z-index: 1;
-}
-
-.dr-vorpal-picker-card:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-}
-
-.dr-vorpal-picker-card-stack {
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.dr-vorpal-picker-card-face {
-  display: block;
-  width: 100%;
-}
-
-.dr-vorpal-picker-card-face :deep(.dr-monster-card) {
-  margin: 0;
-  max-width: none;
-  width: 100%;
-}
-
-.dr-vorpal-picker-card--isolated {
-  height: auto;
-  overflow: visible;
-  position: relative;
-  z-index: 2;
-}
-
-.dr-vorpal-picker-card--isolated .dr-vorpal-picker-card-stack {
-  position: static;
-}
-
-.dr-vorpal-picker-card--below-break {
-  margin-top: var(--dr-vorpal-picker-below-gap);
-  overflow: visible;
-  z-index: 1;
-}
-
-.dr-vorpal-picker-card--below {
-  overflow: visible;
-  z-index: 1;
-}
-
-.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face {
-  isolation: isolate;
-  position: relative;
-}
-
-.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face::before {
-  border-radius: var(--dr-vorpal-picker-selection-inset);
-  box-shadow:
-    0 0 0 3px rgba(100, 181, 246, 0.8),
-    0 0 0 6px rgba(66, 165, 245, 0.45),
-    0 0 40px rgba(100, 181, 246, 0.55),
-    0 0 60px rgba(66, 165, 245, 0.3);
-  content: '';
-  inset: var(--dr-vorpal-picker-selection-inset);
-  pointer-events: none;
-  position: absolute;
-  z-index: 0;
-}
-
-.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face :deep(.dr-monster-card) {
-  position: relative;
-  z-index: 1;
-}
-
-.dr-vorpal-picker-caption {
-  color: rgba(255, 255, 255, 0.75);
-  margin-top: 4px;
-}
-
-.dr-vorpal-picker-footer {
-  flex-shrink: 0;
 }
 
 .dr-hero--warrior {

--- a/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
+++ b/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
@@ -1,0 +1,251 @@
+<template>
+  <q-dialog :model-value="open" maximized persistent>
+    <q-card class="dr-deck-splay-panel dr-vorpal-picker-panel">
+      <div class="q-px-md q-pt-md q-pb-sm">
+        <div class="text-subtitle1">Vorpal declaration</div>
+        <div class="text-body2 q-mt-xs">
+          Choose a species before the first monster is revealed.
+        </div>
+      </div>
+      <q-separator />
+      <div
+        ref="vorpalPickerScrollEl"
+        class="q-pa-md dr-deck-splay-scroll dr-vorpal-picker-scroll"
+      >
+        <div
+          class="dr-vorpal-picker-hand"
+          :class="{
+            'dr-vorpal-picker-hand--has-selection': pickerView.hasSelection,
+          }"
+        >
+          <button
+            v-for="card in pickerView.handCards"
+            :key="`vorpal-picker-${card.species}`"
+            type="button"
+            class="dr-vorpal-picker-card"
+            :class="{
+              'dr-vorpal-picker-card--selected': card.layoutRole === 'selected',
+              'dr-vorpal-picker-card--isolated': card.layoutRole === 'selected',
+              'dr-vorpal-picker-card--below-break': card.layoutRole === 'below-break',
+              'dr-vorpal-picker-card--below': card.layoutRole === 'below',
+            }"
+            :disabled="!card.selectable"
+            :data-testid="`${LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerCard}-${card.species}`"
+            @click="emit('card-tap', card.species)"
+          >
+            <div class="dr-vorpal-picker-card-stack">
+              <MonsterCardFace class="dr-vorpal-picker-card-face" :species="card.species" />
+              <div
+                v-if="card.memoryAidCaption"
+                class="text-caption text-center dr-vorpal-picker-caption"
+              >
+                Added to dungeon: {{ card.memoryAidCaption }}
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+      <q-separator />
+      <div class="row justify-end q-pa-md dr-vorpal-picker-footer">
+        <q-btn
+          color="primary"
+          unelevated
+          label="Confirm"
+          :disable="!pickerView.confirmEnabled"
+          :data-testid="LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerConfirm"
+          @click="emit('confirm')"
+        />
+      </div>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { nextTick, ref, toRef, watch } from 'vue'
+import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
+import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    required: true,
+  },
+  pickerView: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['card-tap', 'confirm'])
+
+const pickerView = toRef(props, 'pickerView')
+const vorpalPickerScrollEl = ref(null)
+
+function waitForNextFrame() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+function centerVorpalPickerSelection() {
+  const scrollEl = vorpalPickerScrollEl.value
+  if (!scrollEl) return
+
+  const selectedEl = scrollEl.querySelector('.dr-vorpal-picker-card--selected')
+  if (!(selectedEl instanceof HTMLElement)) return
+
+  const scrollRect = scrollEl.getBoundingClientRect()
+  const selectedRect = selectedEl.getBoundingClientRect()
+  const delta =
+    selectedRect.top + selectedRect.height / 2 - (scrollRect.top + scrollRect.height / 2)
+
+  scrollEl.scrollTo({
+    top: scrollEl.scrollTop + delta,
+    behavior: 'smooth',
+  })
+}
+
+watch(
+  () => pickerView.value.selectedSpecies,
+  async (species) => {
+    if (!species) return
+    await nextTick()
+    await waitForNextFrame()
+    centerVorpalPickerSelection()
+  },
+)
+</script>
+
+<style scoped>
+.dr-deck-splay-panel {
+  width: min(960px, 100vw);
+  height: 100dvh;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.dr-deck-splay-scroll {
+  overflow-y: auto;
+}
+
+.dr-vorpal-picker-panel {
+  max-width: min(960px, 100vw);
+}
+
+.dr-vorpal-picker-scroll {
+  flex: 1;
+  min-height: 0;
+}
+
+.dr-vorpal-picker-hand {
+  --dr-vorpal-picker-card-width: min(400px, 94vw);
+  --dr-vorpal-picker-card-height: calc(var(--dr-vorpal-picker-card-width) * 245 / 384);
+  --dr-vorpal-picker-peek: 76px;
+  --dr-vorpal-picker-hand-tail: calc(
+    var(--dr-vorpal-picker-card-height) - var(--dr-vorpal-picker-peek) + 8px
+  );
+  --dr-vorpal-picker-below-gap: 0px;
+  --dr-vorpal-picker-selection-inset: 7cqw;
+  container-type: inline-size;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  margin: 0 auto;
+  padding: 8px 0 calc(24px + var(--dr-vorpal-picker-hand-tail));
+  width: var(--dr-vorpal-picker-card-width);
+}
+
+.dr-vorpal-picker-card {
+  appearance: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  height: var(--dr-vorpal-picker-peek);
+  overflow: visible;
+  padding: 0;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.dr-vorpal-picker-card-stack {
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card-face {
+  display: block;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card-face :deep(.dr-monster-card) {
+  margin: 0;
+  max-width: none;
+  width: 100%;
+}
+
+.dr-vorpal-picker-card--isolated {
+  height: auto;
+  overflow: visible;
+  position: relative;
+  z-index: 2;
+}
+
+.dr-vorpal-picker-card--isolated .dr-vorpal-picker-card-stack {
+  position: static;
+}
+
+.dr-vorpal-picker-card--below-break {
+  margin-top: var(--dr-vorpal-picker-below-gap);
+  overflow: visible;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card--below {
+  overflow: visible;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face {
+  isolation: isolate;
+  position: relative;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face::before {
+  border-radius: var(--dr-vorpal-picker-selection-inset);
+  box-shadow:
+    0 0 0 3px rgba(100, 181, 246, 0.8),
+    0 0 0 6px rgba(66, 165, 245, 0.45),
+    0 0 40px rgba(100, 181, 246, 0.55),
+    0 0 60px rgba(66, 165, 245, 0.3);
+  content: '';
+  inset: var(--dr-vorpal-picker-selection-inset);
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+}
+
+.dr-vorpal-picker-card--selected .dr-vorpal-picker-card-face :deep(.dr-monster-card) {
+  position: relative;
+  z-index: 1;
+}
+
+.dr-vorpal-picker-caption {
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 4px;
+}
+
+.dr-vorpal-picker-footer {
+  flex-shrink: 0;
+}
+</style>

--- a/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
+++ b/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
@@ -20,9 +20,9 @@
         class="q-pa-md dr-deck-splay-scroll dr-vorpal-picker-scroll"
         :class="{ 'dr-vorpal-picker-scroll--dragging': vorpalPickerDragActive }"
         @pointerdown="onVorpalPickerPointerDown"
-        @pointermove="onVorpalPickerPointerMove"
-        @pointerup="onVorpalPickerPointerEnd"
-        @pointercancel="onVorpalPickerPointerEnd"
+        @pointermove="vorpalPickerDragHandlers.onMove"
+        @pointerup="vorpalPickerDragHandlers.onEnd"
+        @pointercancel="vorpalPickerDragHandlers.onEnd"
       >
         <div
           class="dr-vorpal-picker-hand"
@@ -77,6 +77,8 @@
 <script setup>
 import { computed, nextTick, ref, toRef, watch } from 'vue'
 import { useQuasar } from 'quasar'
+import { filterMousePrimaryButton } from '../../../../composables/pointerDragScrollController.js'
+import { usePointerDragScroll } from '../../../../composables/usePointerDragScroll.js'
 import { getDesktopPhoneFrameLayout } from '../../../../layouts/projects/desktopPhoneFrame.js'
 import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
 import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
@@ -119,67 +121,34 @@ const emit = defineEmits(['card-tap', 'confirm'])
 
 const pickerView = toRef(props, 'pickerView')
 const vorpalPickerScrollEl = ref(null)
-const vorpalPickerDragActive = ref(false)
-const vorpalPickerPanMoved = ref(false)
-const vorpalPickerDragStart = {
-  x: 0,
-  y: 0,
-  scrollTop: 0,
-}
-
-const VORPAL_PICKER_DRAG_THRESHOLD_PX = 4
-
-function beginVorpalPickerDrag(event, captureEl) {
-  const scrollEl = vorpalPickerScrollEl.value
-  if (!scrollEl || !(captureEl instanceof Element)) return
-
-  vorpalPickerDragActive.value = true
-  vorpalPickerPanMoved.value = false
-  vorpalPickerDragStart.x = event.clientX
-  vorpalPickerDragStart.y = event.clientY
-  vorpalPickerDragStart.scrollTop = scrollEl.scrollTop
-
-  captureEl.setPointerCapture(event.pointerId)
-}
+const { dragActive: vorpalPickerDragActive, handlers: vorpalPickerDragHandlers } = usePointerDragScroll({
+  scrollElRef: vorpalPickerScrollEl,
+  axis: 'y',
+  scrollBeforeThreshold: false,
+  shouldBegin: filterMousePrimaryButton,
+})
 
 function onVorpalPickerPointerDown(event) {
-  if (event.pointerType !== 'mouse' || event.button !== 0) return
-
   const scrollEl = vorpalPickerScrollEl.value
   if (!scrollEl) return
 
-  beginVorpalPickerDrag(event, scrollEl)
+  vorpalPickerDragHandlers.beginDrag(event, {
+    captureEl: scrollEl,
+    suppressClickOnPan: false,
+  })
 }
 
 function onVorpalPickerCardPointerDown(event) {
-  if (event.pointerType !== 'mouse' || event.button !== 0) return
   if (!(event.currentTarget instanceof HTMLButtonElement)) return
 
-  beginVorpalPickerDrag(event, event.currentTarget)
-}
-
-function onVorpalPickerPointerMove(event) {
-  if (!vorpalPickerDragActive.value) return
-
-  const scrollEl = vorpalPickerScrollEl.value
-  if (!scrollEl) return
-
-  const deltaY = event.clientY - vorpalPickerDragStart.y
-  if (Math.abs(deltaY) <= VORPAL_PICKER_DRAG_THRESHOLD_PX) return
-
-  vorpalPickerPanMoved.value = true
-  scrollEl.scrollTop = vorpalPickerDragStart.scrollTop - deltaY
-}
-
-function onVorpalPickerPointerEnd() {
-  vorpalPickerDragActive.value = false
+  vorpalPickerDragHandlers.beginDrag(event, {
+    captureEl: event.currentTarget,
+    suppressClickOnPan: true,
+  })
 }
 
 function onVorpalPickerCardTap(species) {
-  if (vorpalPickerPanMoved.value) {
-    vorpalPickerPanMoved.value = false
-    return
-  }
+  if (vorpalPickerDragHandlers.consumePanClick()) return
 
   emit('card-tap', species)
 }

--- a/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
+++ b/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
@@ -1,5 +1,12 @@
 <template>
-  <q-dialog :model-value="open" maximized persistent>
+  <q-dialog
+    :model-value="open"
+    class="dr-vorpal-picker-dialog"
+    :class="{ 'dr-vorpal-picker-dialog--desktop-frame': desktopFramePresentation.framed }"
+    :style="desktopFramePresentation.dialogStyle"
+    maximized
+    persistent
+  >
     <q-card class="dr-deck-splay-panel dr-vorpal-picker-panel">
       <div class="q-px-md q-pt-md q-pb-sm">
         <div class="text-subtitle1">Vorpal declaration</div>
@@ -61,9 +68,34 @@
 </template>
 
 <script setup>
-import { nextTick, ref, toRef, watch } from 'vue'
+import { computed, nextTick, ref, toRef, watch } from 'vue'
+import { useQuasar } from 'quasar'
+import { getDesktopPhoneFrameLayout } from '../../../../layouts/projects/desktopPhoneFrame.js'
 import { LIVE_MATCH_SHELL_TEST_IDS } from './liveMatchShellTestIds.js'
 import MonsterCardFace from '../../../../components/dungeon-runner/MonsterCardFace.vue'
+
+const $q = useQuasar()
+
+const desktopFramePresentation = computed(() => {
+  const frame = getDesktopPhoneFrameLayout({
+    viewportWidthPx: $q.screen.width,
+    viewportHeightPx: $q.screen.height,
+  })
+  if (!frame.active || frame.columnWidthPx == null || frame.columnHeightPx == null) {
+    return { framed: false, dialogStyle: undefined }
+  }
+
+  const cardWidthPx = Math.min(400, Math.round(frame.columnWidthPx * 0.94))
+
+  return {
+    framed: true,
+    dialogStyle: {
+      '--dr-vorpal-picker-frame-width': `${frame.columnWidthPx}px`,
+      '--dr-vorpal-picker-frame-height': `${frame.columnHeightPx}px`,
+      '--dr-vorpal-picker-card-outer-width': `${cardWidthPx}px`,
+    },
+  }
+})
 
 const props = defineProps({
   open: {
@@ -117,20 +149,18 @@ watch(
 </script>
 
 <style scoped>
-.dr-deck-splay-panel {
-  width: min(960px, 100vw);
-  height: 100dvh;
-  margin: 0 auto;
+.dr-deck-splay-panel.dr-vorpal-picker-panel {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  margin: 0 auto;
+  max-height: 100%;
+  max-width: 100%;
+  width: 100%;
 }
 
 .dr-deck-splay-scroll {
   overflow-y: auto;
-}
-
-.dr-vorpal-picker-panel {
-  max-width: min(960px, 100vw);
 }
 
 .dr-vorpal-picker-scroll {
@@ -139,7 +169,7 @@ watch(
 }
 
 .dr-vorpal-picker-hand {
-  --dr-vorpal-picker-card-width: min(400px, 94vw);
+  --dr-vorpal-picker-card-width: var(--dr-vorpal-picker-card-outer-width, min(400px, 94vw));
   --dr-vorpal-picker-card-height: calc(var(--dr-vorpal-picker-card-width) * 245 / 384);
   --dr-vorpal-picker-peek: 76px;
   --dr-vorpal-picker-hand-tail: calc(
@@ -247,5 +277,21 @@ watch(
 
 .dr-vorpal-picker-footer {
   flex-shrink: 0;
+}
+</style>
+
+<style>
+/* Quasar `maximized` is viewport-sized; on md+ pin the sheet to the same px box as ProjectShellLayout. */
+.dr-vorpal-picker-dialog--desktop-frame .q-dialog__inner,
+.dr-vorpal-picker-dialog--desktop-frame .q-dialog__inner--maximized {
+  bottom: auto !important;
+  height: var(--dr-vorpal-picker-frame-height) !important;
+  left: 50% !important;
+  max-height: var(--dr-vorpal-picker-frame-height) !important;
+  max-width: var(--dr-vorpal-picker-frame-width) !important;
+  right: auto !important;
+  top: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  width: var(--dr-vorpal-picker-frame-width) !important;
 }
 </style>

--- a/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
+++ b/src/features/dungeon-runner/ui/shells/VorpalDeclarationPickerDialog.vue
@@ -18,6 +18,11 @@
       <div
         ref="vorpalPickerScrollEl"
         class="q-pa-md dr-deck-splay-scroll dr-vorpal-picker-scroll"
+        :class="{ 'dr-vorpal-picker-scroll--dragging': vorpalPickerDragActive }"
+        @pointerdown="onVorpalPickerPointerDown"
+        @pointermove="onVorpalPickerPointerMove"
+        @pointerup="onVorpalPickerPointerEnd"
+        @pointercancel="onVorpalPickerPointerEnd"
       >
         <div
           class="dr-vorpal-picker-hand"
@@ -38,7 +43,9 @@
             }"
             :disabled="!card.selectable"
             :data-testid="`${LIVE_MATCH_SHELL_TEST_IDS.vorpalPickerCard}-${card.species}`"
-            @click="emit('card-tap', card.species)"
+            @dragstart.prevent
+            @pointerdown.stop="onVorpalPickerCardPointerDown"
+            @click="onVorpalPickerCardTap(card.species)"
           >
             <div class="dr-vorpal-picker-card-stack">
               <MonsterCardFace class="dr-vorpal-picker-card-face" :species="card.species" />
@@ -112,6 +119,70 @@ const emit = defineEmits(['card-tap', 'confirm'])
 
 const pickerView = toRef(props, 'pickerView')
 const vorpalPickerScrollEl = ref(null)
+const vorpalPickerDragActive = ref(false)
+const vorpalPickerPanMoved = ref(false)
+const vorpalPickerDragStart = {
+  x: 0,
+  y: 0,
+  scrollTop: 0,
+}
+
+const VORPAL_PICKER_DRAG_THRESHOLD_PX = 4
+
+function beginVorpalPickerDrag(event, captureEl) {
+  const scrollEl = vorpalPickerScrollEl.value
+  if (!scrollEl || !(captureEl instanceof Element)) return
+
+  vorpalPickerDragActive.value = true
+  vorpalPickerPanMoved.value = false
+  vorpalPickerDragStart.x = event.clientX
+  vorpalPickerDragStart.y = event.clientY
+  vorpalPickerDragStart.scrollTop = scrollEl.scrollTop
+
+  captureEl.setPointerCapture(event.pointerId)
+}
+
+function onVorpalPickerPointerDown(event) {
+  if (event.pointerType !== 'mouse' || event.button !== 0) return
+
+  const scrollEl = vorpalPickerScrollEl.value
+  if (!scrollEl) return
+
+  beginVorpalPickerDrag(event, scrollEl)
+}
+
+function onVorpalPickerCardPointerDown(event) {
+  if (event.pointerType !== 'mouse' || event.button !== 0) return
+  if (!(event.currentTarget instanceof HTMLButtonElement)) return
+
+  beginVorpalPickerDrag(event, event.currentTarget)
+}
+
+function onVorpalPickerPointerMove(event) {
+  if (!vorpalPickerDragActive.value) return
+
+  const scrollEl = vorpalPickerScrollEl.value
+  if (!scrollEl) return
+
+  const deltaY = event.clientY - vorpalPickerDragStart.y
+  if (Math.abs(deltaY) <= VORPAL_PICKER_DRAG_THRESHOLD_PX) return
+
+  vorpalPickerPanMoved.value = true
+  scrollEl.scrollTop = vorpalPickerDragStart.scrollTop - deltaY
+}
+
+function onVorpalPickerPointerEnd() {
+  vorpalPickerDragActive.value = false
+}
+
+function onVorpalPickerCardTap(species) {
+  if (vorpalPickerPanMoved.value) {
+    vorpalPickerPanMoved.value = false
+    return
+  }
+
+  emit('card-tap', species)
+}
 
 function waitForNextFrame() {
   return new Promise((resolve) => {
@@ -168,6 +239,16 @@ watch(
   min-height: 0;
 }
 
+@media (hover: hover) and (pointer: fine) {
+  .dr-vorpal-picker-scroll {
+    cursor: grab;
+  }
+
+  .dr-vorpal-picker-scroll--dragging {
+    cursor: grabbing;
+  }
+}
+
 .dr-vorpal-picker-hand {
   --dr-vorpal-picker-card-width: var(--dr-vorpal-picker-card-outer-width, min(400px, 94vw));
   --dr-vorpal-picker-card-height: calc(var(--dr-vorpal-picker-card-width) * 245 / 384);
@@ -197,8 +278,13 @@ watch(
   overflow: visible;
   padding: 0;
   position: relative;
+  user-select: none;
   width: 100%;
   z-index: 1;
+}
+
+.dr-vorpal-picker-card :deep(img) {
+  -webkit-user-drag: none;
 }
 
 .dr-vorpal-picker-card:disabled {

--- a/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.js
+++ b/src/features/dungeon-runner/ui/shells/liveMatchShellTestIds.js
@@ -3,4 +3,6 @@ export const LIVE_MATCH_SHELL_TEST_IDS = {
   finishingMatchOverlay: 'finishing-match-overlay',
   neuralRefreshTerminal: 'neural-refresh-terminal',
   neuralRefreshTerminalReload: 'neural-refresh-terminal-reload',
+  vorpalPickerConfirm: 'vorpal-picker-confirm',
+  vorpalPickerCard: 'vorpal-picker-card',
 }

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -322,7 +322,6 @@ export function useLiveMatchShell(deps) {
   const confirmationDialogOkLabel = ref('OK')
   const confirmationDialogCancelLabel = ref('Cancel')
   let confirmationDialogResolve = null
-  const vorpalDialogOpen = ref(false)
   const selectedVorpalSpecies = ref(null)
   const memoryAidState = ref(
     createMemoryAidState({ enabled: dungeonRunnerSettingsStore.memoryAidEnabled }),
@@ -814,13 +813,7 @@ export function useLiveMatchShell(deps) {
 
   watch(
     () => vorpalPickerView.value.open,
-    (open) => {
-      if (!open) {
-        vorpalDialogOpen.value = false
-        selectedVorpalSpecies.value = null
-        return
-      }
-      vorpalDialogOpen.value = true
+    () => {
       selectedVorpalSpecies.value = null
     },
   )
@@ -1748,7 +1741,6 @@ export function useLiveMatchShell(deps) {
       onConfirmationDialogOk,
       neuralRefreshTerminalOpen,
       reloadPageForNeuralRefreshTerminal,
-      vorpalDialogOpen,
       vorpalPickerView,
       onVorpalPickerCardTap,
       confirmVorpalDeclaration,

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -27,7 +27,6 @@ import { adventurerChoiceHeadline, legalActionBoardLabel } from '../dungeonRunne
 import {
   buildDungeonEquipmentTokenView,
   createDungeonEquipmentModalView,
-  createVorpalDeclarationPromptView,
   filterVisibleLegalActions,
 } from '../dungeonEquipmentInteractions.js'
 import {
@@ -39,6 +38,10 @@ import {
   legalSacrificeEquipmentIds,
   shouldUseBiddingSacrificeEquipmentModalView,
 } from '../biddingSacrificeInteractions.js'
+import {
+  applyVorpalPickerSpeciesTap,
+  createVorpalDeclarationPickerView,
+} from '../vorpalDeclarationPickerInteractions.js'
 import { createBiddingBoardViewModel } from '../biddingBoardViewModel.js'
 import {
   viewerMaySeeAddToDungeonFlipDown,
@@ -584,8 +587,8 @@ export function useLiveMatchShell(deps) {
       legalActions: legalActions.value,
     })
   })
-  const vorpalPromptView = computed(() =>
-    createVorpalDeclarationPromptView({
+  const vorpalPickerView = computed(() =>
+    createVorpalDeclarationPickerView({
       isHumanTurn: isHumanTurn.value,
       gameplayInputLocked: gameplayInputLocked.value,
       phase: match.value?.state?.phase ?? null,
@@ -593,17 +596,10 @@ export function useLiveMatchShell(deps) {
       legalActions: legalActions.value,
       memoryAidEnabled: memoryAidState.value.enabled,
       viewerOwnPileAdds: visibleState.value?.playerOwnPileAdds?.[humanSeatId.value ?? ''] ?? [],
+      selectedSpecies: selectedVorpalSpecies.value,
+      humanGameplayBlocked: humanGameplayBlocked.value,
     }),
   )
-  const vorpalSelectOptions = computed(() => {
-    const pv = vorpalPromptView.value
-    const counts = pv.vorpalSpeciesOwnPileCounts
-    return pv.speciesOptions.map((species) => {
-      const n = counts?.[species] ?? 0
-      const label = n > 0 ? `${species} (${n})` : species
-      return { label, value: species }
-    })
-  })
   const biddingBoard = computed(() =>
     createBiddingBoardViewModel({
       state: match.value?.state ?? null,
@@ -817,7 +813,7 @@ export function useLiveMatchShell(deps) {
   )
 
   watch(
-    () => vorpalPromptView.value.open,
+    () => vorpalPickerView.value.open,
     (open) => {
       if (!open) {
         vorpalDialogOpen.value = false
@@ -825,13 +821,7 @@ export function useLiveMatchShell(deps) {
         return
       }
       vorpalDialogOpen.value = true
-      const firstSpecies = vorpalPromptView.value.speciesOptions[0] ?? null
-      if (
-        !selectedVorpalSpecies.value ||
-        !vorpalPromptView.value.speciesOptions.includes(selectedVorpalSpecies.value)
-      ) {
-        selectedVorpalSpecies.value = firstSpecies
-      }
+      selectedVorpalSpecies.value = null
     },
   )
 
@@ -1120,12 +1110,18 @@ export function useLiveMatchShell(deps) {
     }
   }
 
-  function confirmVorpalDeclaration() {
-    if (!selectedVorpalSpecies.value) return
-    takeHumanAction({
-      type: 'DECLARE_VORPAL',
-      species: selectedVorpalSpecies.value,
+  function onVorpalPickerCardTap(species) {
+    selectedVorpalSpecies.value = applyVorpalPickerSpeciesTap({
+      selectedSpecies: selectedVorpalSpecies.value,
+      tappedSpecies: species,
+      humanGameplayBlocked: humanGameplayBlocked.value,
     })
+  }
+
+  function confirmVorpalDeclaration() {
+    const action = vorpalPickerView.value.confirmAction
+    if (!action) return
+    takeHumanAction(action)
   }
 
   async function runAiTurn() {
@@ -1753,8 +1749,8 @@ export function useLiveMatchShell(deps) {
       neuralRefreshTerminalOpen,
       reloadPageForNeuralRefreshTerminal,
       vorpalDialogOpen,
-      vorpalSelectOptions,
-      selectedVorpalSpecies,
+      vorpalPickerView,
+      onVorpalPickerCardTap,
       confirmVorpalDeclaration,
       deckSplayOpen,
       onCloseDeckSplay,

--- a/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.js
+++ b/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.js
@@ -89,6 +89,8 @@ export function createVorpalDeclarationPickerView({
 
   return {
     open: prompt.open,
+    selectedSpecies,
+    hasSelection: selectedSpecies != null,
     cards,
     handCards,
     confirmEnabled,

--- a/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.js
+++ b/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.js
@@ -1,0 +1,97 @@
+import { ACTION_TYPES } from '../engine/kernel.js'
+import { createVorpalDeclarationPromptView } from './dungeonEquipmentInteractions.js'
+
+export function applyVorpalPickerSpeciesTap({
+  selectedSpecies = null,
+  tappedSpecies = null,
+  humanGameplayBlocked = false,
+} = {}) {
+  if (humanGameplayBlocked || typeof tappedSpecies !== 'string') return selectedSpecies
+  if (selectedSpecies === tappedSpecies) return selectedSpecies
+  return tappedSpecies
+}
+
+/**
+ * @typedef {'splay' | 'above' | 'selected' | 'below-break' | 'below'} VorpalPickerCardLayoutRole
+ */
+
+/**
+ * @param {Array<{ species: string, selected: boolean, selectable: boolean, memoryAidCaption: string | null }>} cards
+ * @param {string | null} selectedSpecies
+ */
+export function annotateVorpalPickerHandCards(cards = [], selectedSpecies = null) {
+  const selectedIndex = cards.findIndex((card) => card.species === selectedSpecies)
+  if (selectedIndex < 0) {
+    return cards.map((card) => ({
+      ...card,
+      layoutRole: 'splay',
+    }))
+  }
+
+  return cards.map((card, index) => {
+    if (index === selectedIndex) {
+      return {
+        ...card,
+        layoutRole: 'selected',
+      }
+    }
+    if (index > selectedIndex) {
+      return {
+        ...card,
+        layoutRole: index === selectedIndex + 1 ? 'below-break' : 'below',
+      }
+    }
+    return {
+      ...card,
+      layoutRole: 'above',
+    }
+  })
+}
+
+export function createVorpalDeclarationPickerView({
+  isHumanTurn = false,
+  gameplayInputLocked = false,
+  phase = null,
+  subphase = null,
+  legalActions = [],
+  memoryAidEnabled = false,
+  viewerOwnPileAdds = [],
+  selectedSpecies = null,
+  humanGameplayBlocked = false,
+} = {}) {
+  const prompt = createVorpalDeclarationPromptView({
+    isHumanTurn,
+    gameplayInputLocked,
+    phase,
+    subphase,
+    legalActions,
+    memoryAidEnabled,
+    viewerOwnPileAdds,
+  })
+
+  const counts = prompt.vorpalSpeciesOwnPileCounts
+  const cards = prompt.speciesOptions.map((species) => {
+    const ownPileCount = counts?.[species] ?? 0
+    return {
+      species,
+      selected: selectedSpecies === species,
+      selectable: !humanGameplayBlocked,
+      memoryAidCaption: ownPileCount > 0 ? String(ownPileCount) : null,
+    }
+  })
+
+  const handCards = annotateVorpalPickerHandCards(cards, selectedSpecies)
+  const confirmEnabled = selectedSpecies != null && !humanGameplayBlocked
+  const confirmAction =
+    confirmEnabled && typeof selectedSpecies === 'string'
+      ? { type: ACTION_TYPES.DECLARE_VORPAL, species: selectedSpecies }
+      : null
+
+  return {
+    open: prompt.open,
+    cards,
+    handCards,
+    confirmEnabled,
+    confirmAction,
+  }
+}

--- a/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.test.js
+++ b/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.test.js
@@ -58,6 +58,28 @@ test('picker card selected flag tracks selectedSpecies', () => {
   )
 })
 
+test('hasSelection is false without selectedSpecies and true when set', () => {
+  const noSelection = createVorpalDeclarationPickerView(OPEN_INPUT)
+  assert.equal(noSelection.hasSelection, false)
+
+  const withSelection = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'goblin',
+  })
+  assert.equal(withSelection.hasSelection, true)
+})
+
+test('returned selectedSpecies echoes the input', () => {
+  const unset = createVorpalDeclarationPickerView(OPEN_INPUT)
+  assert.equal(unset.selectedSpecies, null)
+
+  const set = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'dragon',
+  })
+  assert.equal(set.selectedSpecies, 'dragon')
+})
+
 test('picker cards are not selectable when human gameplay is blocked', () => {
   const view = createVorpalDeclarationPickerView({
     ...OPEN_INPUT,

--- a/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.test.js
+++ b/src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.test.js
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  annotateVorpalPickerHandCards,
+  applyVorpalPickerSpeciesTap,
+  createVorpalDeclarationPickerView,
+} from './vorpalDeclarationPickerInteractions.js'
+
+const POLICY_ORDER_LEGAL = [
+  { type: 'DECLARE_VORPAL', species: 'goblin' },
+  { type: 'DECLARE_VORPAL', species: 'skeleton' },
+  { type: 'DECLARE_VORPAL', species: 'dragon' },
+]
+
+const OPEN_INPUT = {
+  isHumanTurn: true,
+  gameplayInputLocked: false,
+  phase: 'dungeon',
+  subphase: 'vorpal',
+  legalActions: POLICY_ORDER_LEGAL,
+}
+
+test('picker open inherits prompt timing at dungeon vorpal subphase', () => {
+  const open = createVorpalDeclarationPickerView(OPEN_INPUT)
+  assert.equal(open.open, true)
+
+  const closed = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    subphase: 'reveal',
+  })
+  assert.equal(closed.open, false)
+})
+
+test('picker open is false when gameplay input is locked', () => {
+  const locked = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    gameplayInputLocked: true,
+  })
+  assert.equal(locked.open, false)
+})
+
+test('picker cards follow legal DECLARE_VORPAL species order', () => {
+  const view = createVorpalDeclarationPickerView(OPEN_INPUT)
+  assert.deepEqual(
+    view.cards.map((card) => card.species),
+    ['goblin', 'skeleton', 'dragon'],
+  )
+})
+
+test('picker card selected flag tracks selectedSpecies', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'skeleton',
+  })
+  assert.deepEqual(
+    view.cards.map((card) => card.selected),
+    [false, true, false],
+  )
+})
+
+test('picker cards are not selectable when human gameplay is blocked', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    humanGameplayBlocked: true,
+  })
+  assert.ok(view.cards.every((card) => card.selectable === false))
+})
+
+test('applyVorpalPickerSpeciesTap sets species on first tap', () => {
+  assert.equal(
+    applyVorpalPickerSpeciesTap({
+      selectedSpecies: null,
+      tappedSpecies: 'orc',
+      humanGameplayBlocked: false,
+    }),
+    'orc',
+  )
+})
+
+test('applyVorpalPickerSpeciesTap is no-op when re-tapping selected species', () => {
+  assert.equal(
+    applyVorpalPickerSpeciesTap({
+      selectedSpecies: 'orc',
+      tappedSpecies: 'orc',
+      humanGameplayBlocked: false,
+    }),
+    'orc',
+  )
+})
+
+test('applyVorpalPickerSpeciesTap is no-op when human gameplay is blocked', () => {
+  assert.equal(
+    applyVorpalPickerSpeciesTap({
+      selectedSpecies: null,
+      tappedSpecies: 'orc',
+      humanGameplayBlocked: true,
+    }),
+    null,
+  )
+})
+
+test('confirmEnabled is false without selection or when gameplay blocked', () => {
+  const noSelection = createVorpalDeclarationPickerView(OPEN_INPUT)
+  assert.equal(noSelection.confirmEnabled, false)
+
+  const blocked = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'goblin',
+    humanGameplayBlocked: true,
+  })
+  assert.equal(blocked.confirmEnabled, false)
+})
+
+test('confirmEnabled and confirmAction when selection is present', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'dragon',
+  })
+  assert.equal(view.confirmEnabled, true)
+  assert.deepEqual(view.confirmAction, { type: 'DECLARE_VORPAL', species: 'dragon' })
+})
+
+test('memoryAidCaption appears only when memory aid is on and count is greater than zero', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    memoryAidEnabled: true,
+    viewerOwnPileAdds: ['goblin', 'goblin', 'skeleton'],
+  })
+  const goblin = view.cards.find((card) => card.species === 'goblin')
+  const skeleton = view.cards.find((card) => card.species === 'skeleton')
+  const dragon = view.cards.find((card) => card.species === 'dragon')
+  assert.equal(goblin.memoryAidCaption, '2')
+  assert.equal(skeleton.memoryAidCaption, '1')
+  assert.equal(dragon.memoryAidCaption, null)
+})
+
+test('memoryAidCaption is omitted when memory aid is disabled', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    memoryAidEnabled: false,
+    viewerOwnPileAdds: ['goblin', 'goblin'],
+  })
+  assert.ok(view.cards.every((card) => card.memoryAidCaption === null))
+})
+
+test('hand cards stay continuous splay when no species is selected', () => {
+  const cards = [
+    { species: 'goblin', selected: false, selectable: true, memoryAidCaption: null },
+    { species: 'dragon', selected: false, selectable: true, memoryAidCaption: null },
+  ]
+  assert.deepEqual(
+    annotateVorpalPickerHandCards(cards, null).map((card) => card.layoutRole),
+    ['splay', 'splay'],
+  )
+})
+
+test('hand cards keep policy order with one break below the selected species', () => {
+  const cards = [
+    { species: 'goblin', selected: false, selectable: true, memoryAidCaption: null },
+    { species: 'skeleton', selected: true, selectable: true, memoryAidCaption: null },
+    { species: 'dragon', selected: false, selectable: true, memoryAidCaption: null },
+  ]
+  assert.deepEqual(
+    annotateVorpalPickerHandCards(cards, 'skeleton').map((card) => card.layoutRole),
+    ['above', 'selected', 'below-break'],
+  )
+})
+
+test('picker exposes continuous hand cards when a species is selected', () => {
+  const view = createVorpalDeclarationPickerView({
+    ...OPEN_INPUT,
+    selectedSpecies: 'skeleton',
+  })
+  assert.equal(view.handCards.length, 3)
+  assert.deepEqual(
+    view.handCards.map((card) => card.layoutRole),
+    ['above', 'selected', 'below-break'],
+  )
+  assert.equal(view.handCards[1].species, 'skeleton')
+})

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -128,10 +128,10 @@
             ref="dialogImageWrap"
             class="dialog-image-wrap"
             :class="{ 'dialog-image-wrap--zoomed': isZoomed }"
-            @pointermove="onDragMove"
-            @pointerup="onDragEnd"
-            @pointercancel="onDragEnd"
-            @pointerleave="onDragEnd"
+            @pointermove="imageDragHandlers.onMove"
+            @pointerup="imageDragHandlers.onEnd"
+            @pointercancel="imageDragHandlers.onEnd"
+            @pointerleave="imageDragHandlers.onEnd"
           >
             <img
               :src="dialogSrc"
@@ -141,7 +141,7 @@
                 'dialog-image--zoomed': isZoomed,
                 'dialog-image--dragging': isDragging,
               }"
-              @pointerdown="onDragStart"
+              @pointerdown="onImagePointerDown"
               @click="onImageClick"
               @dragstart.prevent
             />
@@ -172,6 +172,7 @@
 import exifr from 'exifr'
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
+import { usePointerDragScroll } from 'src/composables/usePointerDragScroll.js'
 import { exifSummaryLines, exifToRows } from 'src/utils/exifFormat.js'
 
 const googlePhotosUrl = 'https://photos.app.goo.gl/pjuSWsZbgcp3eC7o6'
@@ -365,22 +366,19 @@ const dialogLabel = ref('')
 const exifPanelOpen = ref(true)
 const dialogExifRows = ref([])
 const isZoomed = ref(false)
-const isDragging = ref(false)
 const dialogImageWrap = ref(null)
-
-const dragStart = {
-  x: 0,
-  y: 0,
-  scrollLeft: 0,
-  scrollTop: 0,
-}
-const dragMoved = ref(false)
+const { dragActive: isDragging, handlers: imageDragHandlers } = usePointerDragScroll({
+  scrollElRef: dialogImageWrap,
+  axis: 'both',
+  scrollBeforeThreshold: true,
+  shouldBegin: () => isZoomed.value,
+})
 
 async function openPhoto(photo) {
   dialogSrc.value = photo.src
   dialogLabel.value = photo.label
   isZoomed.value = false
-  isDragging.value = false
+  imageDragHandlers.onEnd()
   dialogExifRows.value = []
   galleryScrollRestore.value = {
     x: window.scrollX,
@@ -398,7 +396,7 @@ async function openPhoto(photo) {
 function toggleZoom() {
   const shouldZoomIn = isZoomed.value === false
   isZoomed.value = !isZoomed.value
-  isDragging.value = false
+  imageDragHandlers.onEnd()
 
   if (shouldZoomIn) {
     void centerZoomedImage()
@@ -424,50 +422,17 @@ async function centerZoomedImage() {
   })
 }
 
-function onDragStart(event) {
-  if (!isZoomed.value || dialogImageWrap.value === null) {
-    return
-  }
+function onImagePointerDown(event) {
+  if (!event.target) return
 
-  isDragging.value = true
-  dragMoved.value = false
-  dragStart.x = event.clientX
-  dragStart.y = event.clientY
-  dragStart.scrollLeft = dialogImageWrap.value.scrollLeft
-  dragStart.scrollTop = dialogImageWrap.value.scrollTop
-
-  if (event.target && typeof event.target.setPointerCapture === 'function') {
-    event.target.setPointerCapture(event.pointerId)
-  }
-}
-
-function onDragMove(event) {
-  if (!isDragging.value || dialogImageWrap.value === null) {
-    return
-  }
-
-  const deltaX = event.clientX - dragStart.x
-  const deltaY = event.clientY - dragStart.y
-  const dragThreshold = 4
-
-  if (Math.abs(deltaX) > dragThreshold || Math.abs(deltaY) > dragThreshold) {
-    dragMoved.value = true
-  }
-
-  dialogImageWrap.value.scrollLeft = dragStart.scrollLeft - deltaX
-  dialogImageWrap.value.scrollTop = dragStart.scrollTop - deltaY
-}
-
-function onDragEnd() {
-  isDragging.value = false
+  imageDragHandlers.beginDrag(event, {
+    captureEl: event.target,
+    suppressClickOnPan: true,
+  })
 }
 
 function onImageClick(event) {
-  // Ignore click events emitted at the end of a drag-pan gesture.
-  if (dragMoved.value) {
-    dragMoved.value = false
-    return
-  }
+  if (imageDragHandlers.consumePanClick()) return
 
   if (!isZoomed.value) {
     const imgRect = event.currentTarget?.getBoundingClientRect?.()

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -453,7 +453,7 @@ function onImageClick(event) {
 
 async function zoomInToPoint(ratioX, ratioY) {
   isZoomed.value = true
-  isDragging.value = false
+  imageDragHandlers.onEnd()
 
   await nextTick()
 


### PR DESCRIPTION
## Summary

- Replaces the human vorpal declaration `q-select` with a mandatory near-fullscreen card-hand picker in the live match shell, showing all eight monster faces in policy species order with tap-to-select and Confirm.
- Adds `vorpalDeclarationPickerInteractions` view-model logic (hand layout roles, confirm gating, tap handling) with unit tests; wires it through `useLiveMatchShell` without changing `DECLARE_VORPAL` engine or bot interfaces.
- Updates help copy and dungeon-runner glossary language for the new picker flow.

Closes #245.

## Test plan

- [ ] Start a dungeon run with Vorpal equipment in play; verify the picker opens with no pre-selected species and no cancel/dismiss.
- [ ] Scroll the hand, tap species cards, and confirm selection dispatches `DECLARE_VORPAL` for the chosen species.
- [ ] With memory aid enabled, verify own-pile counts appear as captions only when count > 0.
- [ ] Verify Confirm and card taps are blocked when gameplay input is locked.
- [ ] Run `node --test src/features/dungeon-runner/ui/vorpalDeclarationPickerInteractions.test.js`