### PR TITLE
Fix Omnipotence alternate win per ADR 0008

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ yarn-error.log*
 .env.local*
 .venv*/*
 artifacts
-data
+/data
 *.log
 
 # python stuff

--- a/docs/adr/0008-dungeon-runner-omnipotence-alternate-win.md
+++ b/docs/adr/0008-dungeon-runner-omnipotence-alternate-win.md
@@ -1,0 +1,28 @@
+# Dungeon Runner: Omnipotence as alternate win on initial pile uniqueness
+
+**Status:** Accepted
+
+**Omnipotence** (`M_OMNI`) is a passive second way to win a **dungeon run** after combat would defeat the runner—not a healing effect and not a player choice. When HP would drop to 0 or below, a healing potion (if in play) revives and the run continues first; otherwise, if **M_OMNI** is still in play and every **species** in the **omnipotence set** is distinct, the run succeeds immediately with normal success scoring and **omnipotence success copy** in the **dungeon run** outcome acknowledgment. If uniqueness fails, the run fails with ordinary failure copy (no “almost saved” hint).
+
+## Omnipotence set
+
+The set is the **monster** pile frozen when the **dungeon run** begins: every card **placed** into the dungeon during bidding, before any lane card is revealed. It does **not** include cards discarded via bidding **equipment** sacrifice (they never entered the pile) or cards never drawn from the **monster deck**. Lane play during the run—defeats, Fire Axe, Vorpal, Polymorph, passives, and so on—does not remove cards from this set; uniqueness is evaluated against the initial pile composition, not against defeated/current/unrevealed lane state at the moment of defeat.
+
+Uniqueness is at **species** level. Duplicate **species** in the initial pile (e.g. strengths 1, 1, 3, 4) fail; all distinct **species** (e.g. 1, 3, 4) pass, even if some of those cards were already removed from the lane earlier in the run.
+
+## Eligibility gate
+
+**Omnipotence** is gated by **M_OMNI** in play at defeat, not by **adventurer** identity. Only the Mage loadout includes **M_OMNI** today, but future loadouts may attach it to other **adventurers** without changing this rule.
+
+## Considered options
+
+- **Live lane partition at defeat** (defeated + current + unrevealed)—rejected: diverges from “pile as it existed at run start” and is harder for players to reason about when **equipment** has removed cards from the lane.
+- **Include bidding sacrifice discards** (`discardedMonsterCards`)—rejected: those cards were never placed in the dungeon; counting them caused false Omnipotence failures when the visible lane looked species-unique.
+- **Gate on Mage **adventurer** only**—rejected: **equipment**-in-play is the stable rule if loadouts change.
+- **Omnipotence as revive** (reset HP and continue)—rejected: contradicts alternate-win semantics; healing potions already own continue-the-run behavior.
+
+## Consequences
+
+- Engine `omniSavesDungeon` (or successor) must read the initial pile snapshot (e.g. bidding `dungeonMonsters` at **dungeon run** entry), not union lane state with sacrifice discards.
+- Successful Omnipotence wins need structured outcome metadata so the outcome acknowledgment can show **omnipotence success copy** without inferring from replay state.
+- **Game data catalog** equipment `details` for **M_OMNI** should describe the initial-pile / **species**-uniqueness rule, aligned with [`CONTEXT.md`](../src/features/dungeon-runner/CONTEXT.md).

--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -330,6 +330,24 @@ Compact **equipment** label for tight UI (e.g. sacrifice phrasing); from the ent
 
 Full **equipment** title for modals and token chrome; from the entry’s **ui** `label` (may differ from **equipment short name**).
 
+### Omnipotence
+
+**Equipment** (`M_OMNI`) that grants a second way to win a **dungeon run** after the runner would otherwise lose to combat: if every **monster** in the **omnipotence set** has a distinct **species**, the run succeeds instead of failing. A passing check yields immediate **dungeon run** success (same scoring as clearing the lane) with **omnipotence success copy** in the outcome acknowledgment—not a mid-run revive and not a failure outcome that is reversed later.
+
+_Avoid_: Treating Omnipotence like a healing potion (revive and continue fighting); counting bidding-sacrifice discards or never-drawn **monster deck** cards in the uniqueness check; recording a failed **dungeon run** before applying the alternate win; applying Omnipotence after **M_OMNI** was removed from play (e.g. bidding **equipment** sacrifice); gating **Omnipotence** on **adventurer** identity when **M_OMNI** in play is the rule gate.
+
+### Omnipotence success copy
+
+User-facing acknowledgment text in the mid-**match** **dungeon run** outcome acknowledgment—the same dialog beat as ordinary success/failure copy—when the run succeeded via **Omnipotence** rather than by clearing the lane through combat. Distinct wording only there; **equipment** `details` and help describe the rule, not run-specific outcomes.
+
+_Avoid_: Generic success-only copy when Omnipotence caused the win; implying a different score or life outcome than a standard successful **dungeon run**; failure copy or “almost saved” hints when **Omnipotence** was in play but uniqueness failed (**Omnipotence** is a passive alternate win, not a player choice); duplicating run-outcome copy on the **scoreboard** or in replay export metadata in v1.
+
+### Omnipotence set
+
+The **monster** pile as it existed when the **dungeon run** began—every card placed into the dungeon during bidding, frozen before any lane card is revealed. Excludes cards removed by sacrificing **equipment** during bidding and cards never drawn from the **monster deck**. Lane resolution during the run (defeats, **equipment** removals, Polymorph, and so on) does not shrink or alter this set. Uniqueness is judged at **species** level: duplicate **species** in that initial pile (e.g. strengths 1, 1, 3, 4) fail **Omnipotence**; all distinct **species** (e.g. 1, 3, 4) pass.
+
+_Avoid_: “Full dungeon set” without this definition; `discardedMonsterCards` (sacrifice discards); the remaining **monster deck** after bidding ends; rebuilding the set from defeated/current/unrevealed lane state at the moment of defeat; card-instance uniqueness when the **monster deck** allows duplicate **species** in the pile.
+
 ### Species
 
 The canonical id string for a **monster** catalog entry (e.g. `goblin`); keys deck composition, rules lookup, and doodle assets.
@@ -365,6 +383,8 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 - **Equipment** optional use/decline action types are **catalog rules**; effect help prose lives in **ui** `details`.
 - **Adventurer identity** fields are **ui** only; the engine/kernel consumes **catalog rules** only, not **ui**.
 - **Equipment** and **monster** definitions are consulted during **dungeon runs** and bidding within a **match**.
+- **Omnipotence** is gated by **M_OMNI** in play, not by **adventurer** identity—the Mage is the only **adventurer** with **M_OMNI** in the catalog today, but alternate loadouts may add it elsewhere later. Rules: [ADR 0008](../../../docs/adr/0008-dungeon-runner-omnipotence-alternate-win.md).
+- **Omnipotence** evaluates **species** uniqueness in the **omnipotence set** (initial pile at **dungeon run** start) only when the runner would lose to combat and **M_OMNI** is still in play; a passing check yields the same successful **dungeon run** outcome as clearing the lane, not a mid-run revive. A healing potion, if present, resolves before **Omnipotence** (revive and continue); the Mage loadout has no healing potion, so that ordering is not player-visible in standard play.
 - After a bidding **draw**, the drawer may **Add to dungeon** or enter **sacrifice mode (bidding)** to discard one legally sacrificable center-table **equipment** piece instead; only highlighted tiles accept sacrifice confirmation. While sacrifice mode is active, **Add to dungeon** and other turn actions are unavailable until **Cancel** or a confirmed sacrifice resolves the choice.
 - **Sacrifice mode (bidding)** is **human player seat** UX in **live match shell** only; **opponent** sacrifice is unchanged. Ephemeral—clears on reload; not part of **current match** persistence. Bidding help copy describes enter → pick highlighted tile → confirm → **Cancel**.
 - **Vorpal declaration (dungeon)** is a hidden-info **species** pick from the full roster, not a choice among visible lane **monsters**; optional memory-aid own-pile counts are supplementary hints only.
@@ -428,8 +448,15 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 > **Dev:** “Player reloads mid-outcome — do we drop them on the board or back to **setup**?”
 > **Domain expert:** “**Match-over shell** again — same outcome UX, upload is idempotent. Only **REFRESH** persisted recovery overrides that and keeps **live match shell** blocked.”
 
+> **Dev:** “Omnipotence failed even though three lane cards looked unique — a bot sacrificed a duplicate **species** during bidding. Bug?”
+> **Domain expert:** “Check the initial pile, not the lane at defeat. Sacrifice discards never entered the dungeon. Omnipotence only cares about **species** uniqueness in the pile frozen at **dungeon run** start.”
+
+> **Dev:** “Is Omnipotence a revive like a healing potion?”
+> **Domain expert:** “No — passive alternate win after combat would defeat the runner. Immediate success with **omnipotence success copy** in the outcome acknowledgment; ordinary failure copy when uniqueness fails.”
+
 ## Flagged ambiguities
 
+- **Omnipotence** engine behavior vs this glossary (2026-06): kernel still checks a live lane partition plus `discardedMonsterCards` and gates on Mage **adventurer** until [ADR 0008](../../../docs/adr/0008-dungeon-runner-omnipotence-alternate-win.md) is implemented—see ADR for authoritative rules.
 - **Empty dungeon pile at bidding end** vs **sim empty-pile forfeit**: **web game engine** gives an immediate successful **dungeon run** (see kernel test). **Python training sim** uses **sim empty-pile forfeit** (`EMPTY_DUNGEON_FORFEIT`, no winner)—an anti-pass-farming rule from early training that remains a sim **local minima**; runtime play follows web/table rules. See [`UBIQUITOUS_LANGUAGE.md`](../../../UBIQUITOUS_LANGUAGE.md).
 - “Game” in casual speech usually means **match**; “run” usually means **dungeon run**.
 - “Catalog” without qualifier may mean the neural **model catalog** or the **game data catalog** — use the full term.

--- a/src/features/dungeon-runner/CONTEXT.md
+++ b/src/features/dungeon-runner/CONTEXT.md
@@ -456,7 +456,6 @@ _Avoid_: Conflating **game data catalog** with the neural **model catalog**; syn
 
 ## Flagged ambiguities
 
-- **Omnipotence** engine behavior vs this glossary (2026-06): kernel still checks a live lane partition plus `discardedMonsterCards` and gates on Mage **adventurer** until [ADR 0008](../../../docs/adr/0008-dungeon-runner-omnipotence-alternate-win.md) is implemented—see ADR for authoritative rules.
 - **Empty dungeon pile at bidding end** vs **sim empty-pile forfeit**: **web game engine** gives an immediate successful **dungeon run** (see kernel test). **Python training sim** uses **sim empty-pile forfeit** (`EMPTY_DUNGEON_FORFEIT`, no winner)—an anti-pass-farming rule from early training that remains a sim **local minima**; runtime play follows web/table rules. See [`UBIQUITOUS_LANGUAGE.md`](../../../UBIQUITOUS_LANGUAGE.md).
 - “Game” in casual speech usually means **match**; “run” usually means **dungeon run**.
 - “Catalog” without qualifier may mean the neural **model catalog** or the **game data catalog** — use the full term.

--- a/src/features/dungeon-runner/data/gameDataCatalog.js
+++ b/src/features/dungeon-runner/data/gameDataCatalog.js
@@ -159,7 +159,7 @@ const EQUIPMENT_ENTRIES = {
       shortName: 'Omni',
       label: 'Omnipotence',
       details:
-        'If you would die, you win instead only when every monster species in the full dungeon set is unique.',
+        'If you would die, you win instead when every species in the dungeon pile at run start is unique (bidding sacrifice discards do not count).',
       symbolKey: 'omni',
     },
   },

--- a/src/features/dungeon-runner/dungeonRunOutcome.js
+++ b/src/features/dungeon-runner/dungeonRunOutcome.js
@@ -1,0 +1,3 @@
+export const DUNGEON_RUN_WIN_VIA = Object.freeze({
+  OMNIPOTENCE: 'omnipotence',
+})

--- a/src/features/dungeon-runner/dungeonRunOutcome.test.js
+++ b/src/features/dungeon-runner/dungeonRunOutcome.test.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { DUNGEON_RUN_WIN_VIA } from './dungeonRunOutcome.js'
+
+test('DUNGEON_RUN_WIN_VIA exposes omnipotence win metadata key', () => {
+  assert.equal(DUNGEON_RUN_WIN_VIA.OMNIPOTENCE, 'omnipotence')
+})

--- a/src/features/dungeon-runner/engine/kernel.js
+++ b/src/features/dungeon-runner/engine/kernel.js
@@ -1,4 +1,5 @@
 import { catalogRules } from '../data/gameDataCatalog.js'
+import { DUNGEON_RUN_WIN_VIA, shouldOmnipotenceSave } from './omnipotencePolicy.js'
 
 export const ACTION_TYPES = {
   PASS: 'PASS',
@@ -428,6 +429,7 @@ function buildDungeonStateOnEnter(state, nextBidding) {
     subphase,
     currentMonster: null,
     remainingMonsters: pile,
+    omnipotenceSet: [...(nextBidding.dungeonMonsters ?? [])],
     hp,
     startingHp: hp,
     inPlayEquipmentIds: inPlay,
@@ -562,8 +564,18 @@ function pickAdventurerSeatId(state, runnerSeatId, scoreboard) {
   return findNextActiveSeatId(state, runnerSeatId, []) ?? runnerSeatId
 }
 
-function enterPickAdventurerPhase(state, runnerSeatId, scoreboard, result) {
+function enterPickAdventurerPhase(state, runnerSeatId, scoreboard, result, options = {}) {
   const pickSeatId = pickAdventurerSeatId(state, runnerSeatId, scoreboard)
+  const lastDungeonRun = {
+    runnerSeatId,
+    monsters: [...state.bidding.dungeonMonsters],
+    heroLoadoutSize: state.heroLoadout[runnerSeatId]?.length ?? 0,
+    result,
+    steps: [],
+  }
+  if (options.winVia) {
+    lastDungeonRun.winVia = options.winVia
+  }
   return {
     ...state,
     phase: MATCH_PHASES.PICK_ADVENTURER,
@@ -572,13 +584,7 @@ function enterPickAdventurerPhase(state, runnerSeatId, scoreboard, result) {
       0,
       5 - Math.max(...Object.values(scoreboard).map((score) => score.successes ?? 0)),
     ),
-    lastDungeonRun: {
-      runnerSeatId,
-      monsters: [...state.bidding.dungeonMonsters],
-      heroLoadoutSize: state.heroLoadout[runnerSeatId]?.length ?? 0,
-      result,
-      steps: [],
-    },
+    lastDungeonRun,
     turn: {
       activeSeatId: pickSeatId,
       turnNumber: state.turn.turnNumber + 1,
@@ -760,17 +766,26 @@ function applyMonsterCombatHits(state, dungeon) {
         inPlayEquipmentIds: [...inPlay].filter((id) => id !== equipId),
       })
     }
-    if (state.hero === 'MAGE' && inPlay.has('M_OMNI') && omniSavesDungeon(state, dungeon)) {
-      return concludeDungeonSuccess(state, {
-        ...dungeon,
-        currentMonster: null,
-        remainingMonsters: [],
-        discardedRunMonsters: [
-          ...(dungeon.discardedRunMonsters ?? []),
-          current,
-          ...(dungeon.remainingMonsters ?? []),
-        ].filter(Boolean),
+    if (
+      shouldOmnipotenceSave({
+        inPlayEquipmentIds: [...inPlay],
+        omnipotenceSet: dungeon.omnipotenceSet ?? state.bidding?.dungeonMonsters,
       })
+    ) {
+      return concludeDungeonSuccess(
+        state,
+        {
+          ...dungeon,
+          currentMonster: null,
+          remainingMonsters: [],
+          discardedRunMonsters: [
+            ...(dungeon.discardedRunMonsters ?? []),
+            current,
+            ...(dungeon.remainingMonsters ?? []),
+          ].filter(Boolean),
+        },
+        { winVia: DUNGEON_RUN_WIN_VIA.OMNIPOTENCE },
+      )
     }
     return concludeDungeonFailure(state, dungeon)
   }
@@ -893,7 +908,7 @@ function transitionAfterDefeat(state, dungeon, defeatRecord = null) {
   }
 }
 
-function concludeDungeonSuccess(state, dungeon) {
+function concludeDungeonSuccess(state, dungeon, options = {}) {
   const runnerSeatId = state.bidding.runnerSeatId
   if (!runnerSeatId) return null
   const currentScore = state.scoreboard[runnerSeatId]
@@ -923,6 +938,7 @@ function concludeDungeonSuccess(state, dungeon) {
     runnerSeatId,
     scoreboard,
     'success',
+    options,
   )
 }
 
@@ -1044,17 +1060,6 @@ function applyAutoDefeat(state, dungeon) {
     )
   }
   return null
-}
-
-function omniSavesDungeon(state, dungeon) {
-  const allSpecies = [
-    ...(dungeon.discardedRunMonsters ?? []),
-    ...(state.bidding?.discardedMonsterCards ?? []),
-    ...(dungeon.currentMonster ? [dungeon.currentMonster] : []),
-    ...(dungeon.remainingMonsters ?? []),
-  ]
-  if (!allSpecies.length) return false
-  return allSpecies.length === new Set(allSpecies).size
 }
 
 function mergeNnSeatMetadata(prevState, nextState, action, actor) {

--- a/src/features/dungeon-runner/engine/kernel.js
+++ b/src/features/dungeon-runner/engine/kernel.js
@@ -1,5 +1,6 @@
 import { catalogRules } from '../data/gameDataCatalog.js'
-import { DUNGEON_RUN_WIN_VIA, shouldOmnipotenceSave } from './omnipotencePolicy.js'
+import { DUNGEON_RUN_WIN_VIA } from '../dungeonRunOutcome.js'
+import { shouldOmnipotenceSave } from './omnipotencePolicy.js'
 
 export const ACTION_TYPES = {
   PASS: 'PASS',
@@ -769,7 +770,7 @@ function applyMonsterCombatHits(state, dungeon) {
     if (
       shouldOmnipotenceSave({
         inPlayEquipmentIds: [...inPlay],
-        omnipotenceSet: dungeon.omnipotenceSet ?? state.bidding?.dungeonMonsters,
+        omnipotenceSet: dungeon.omnipotenceSet,
       })
     ) {
       return concludeDungeonSuccess(

--- a/src/features/dungeon-runner/engine/kernel.omnipotence.test.js
+++ b/src/features/dungeon-runner/engine/kernel.omnipotence.test.js
@@ -7,7 +7,7 @@ import {
   applyAction,
   createInitialMatchState,
 } from './kernel.js'
-import { DUNGEON_RUN_WIN_VIA } from './omnipotencePolicy.js'
+import { DUNGEON_RUN_WIN_VIA } from '../dungeonRunOutcome.js'
 
 /**
  * @param {object} params
@@ -139,6 +139,26 @@ test('omnipotence is gated by M_OMNI in play rather than adventurer identity', (
   const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
   assert.equal(result.ok, true)
   assert.equal(result.state.lastDungeonRun?.result, 'success')
+})
+
+test('omnipotence does not save when omnipotenceSet snapshot is missing', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7009 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  delete state.dungeon.omnipotenceSet
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.result, 'failure')
 })
 
 test('healing potion revives before omnipotence alternate win is considered', () => {

--- a/src/features/dungeon-runner/engine/kernel.omnipotence.test.js
+++ b/src/features/dungeon-runner/engine/kernel.omnipotence.test.js
@@ -1,0 +1,239 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ACTION_TYPES,
+  DUNGEON_SUBPHASES,
+  MATCH_PHASES,
+  applyAction,
+  createInitialMatchState,
+} from './kernel.js'
+import { DUNGEON_RUN_WIN_VIA } from './omnipotencePolicy.js'
+
+/**
+ * @param {object} params
+ * @param {ReturnType<typeof createInitialMatchState>} params.base
+ * @param {string} params.seatId
+ * @param {readonly string[]} params.dungeonMonsters
+ * @param {readonly string[]} [params.discardedMonsterCards]
+ * @param {readonly string[]} params.inPlayEquipmentIds
+ * @param {number} params.hp
+ * @param {readonly string[]} [params.remainingMonsters]
+ * @param {readonly string[]} [params.discardedRunMonsters]
+ * @param {string} [params.hero]
+ */
+function buildLethalRevealState({
+  base,
+  seatId,
+  dungeonMonsters,
+  discardedMonsterCards = [],
+  inPlayEquipmentIds,
+  hp,
+  remainingMonsters,
+  discardedRunMonsters = [],
+  hero = 'MAGE',
+}) {
+  const pile = remainingMonsters ?? [...dungeonMonsters]
+  return {
+    ...base,
+    hero,
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...base.turn, activeSeatId: seatId },
+    bidding: {
+      ...base.bidding,
+      runnerSeatId: seatId,
+      dungeonMonsters: [...dungeonMonsters],
+      discardedMonsterCards: [...discardedMonsterCards],
+    },
+    dungeon: {
+      ...base.dungeon,
+      subphase: DUNGEON_SUBPHASES.REVEAL,
+      currentMonster: null,
+      remainingMonsters: [...pile],
+      omnipotenceSet: [...dungeonMonsters],
+      hp,
+      inPlayEquipmentIds: [...inPlayEquipmentIds],
+      polySpent: true,
+      axeSpent: true,
+      discardedRunMonsters: [...discardedRunMonsters],
+    },
+  }
+}
+
+test('omnipotence wins when sacrifice discards duplicate species not in the dungeon pile', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7001 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    discardedMonsterCards: ['goblin'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(result.state.lastDungeonRun?.result, 'success')
+  assert.equal(result.state.scoreboard[seatId].successes, 1)
+})
+
+test('omnipotence fails when initial pile has duplicate species', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7002 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'goblin', 'orc'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.PICK_ADVENTURER)
+  assert.equal(result.state.lastDungeonRun?.result, 'failure')
+  assert.equal(result.state.scoreboard[seatId].lives, 1)
+})
+
+test('lethal combat fails ordinarily when M_OMNI is not in play', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7003 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['M_WALL'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.result, 'failure')
+})
+
+test('omnipotence is gated by M_OMNI in play rather than adventurer identity', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7004 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    hero: 'WARRIOR',
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.result, 'success')
+})
+
+test('healing potion revives before omnipotence alternate win is considered', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7005 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    hero: 'ROGUE',
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['R_HEAL', 'M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin', 'dragon'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.phase, MATCH_PHASES.DUNGEON)
+  assert.equal(result.state.dungeon.hp, 3)
+  assert.equal(result.state.dungeon.remainingMonsters.length, 1)
+  assert.equal(result.state.dungeon.inPlayEquipmentIds.includes('R_HEAL'), false)
+  assert.equal(result.state.dungeon.inPlayEquipmentIds.includes('M_OMNI'), true)
+  assert.equal(result.state.lastDungeonRun, null)
+})
+
+test('lane removals do not shrink the omnipotence set used at defeat', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7006 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['dragon'],
+    discardedRunMonsters: ['goblin', 'orc'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.result, 'success')
+})
+
+test('omnipotence success records winVia metadata on lastDungeonRun', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7007 },
+  )
+  const seatId = base.seats[0].id
+  const state = buildLethalRevealState({
+    base,
+    seatId,
+    dungeonMonsters: ['goblin', 'orc', 'dragon'],
+    inPlayEquipmentIds: ['M_OMNI'],
+    hp: 1,
+    remainingMonsters: ['goblin'],
+  })
+  const result = applyAction(state, { type: ACTION_TYPES.REVEAL_OR_CONTINUE }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.winVia, DUNGEON_RUN_WIN_VIA.OMNIPOTENCE)
+})
+
+test('normal dungeon clear omits winVia on lastDungeonRun', () => {
+  const base = createInitialMatchState(
+    { totalSeats: 2, opponents: [{ type: 'randombot' }] },
+    { seed: 7008 },
+  )
+  const seatId = base.seats[0].id
+  const state = {
+    ...base,
+    hero: 'MAGE',
+    phase: MATCH_PHASES.DUNGEON,
+    turn: { ...base.turn, activeSeatId: seatId },
+    bidding: {
+      ...base.bidding,
+      runnerSeatId: seatId,
+      dungeonMonsters: ['goblin'],
+    },
+    dungeon: {
+      ...base.dungeon,
+      subphase: DUNGEON_SUBPHASES.PICK_POLYMORPH,
+      currentMonster: 'goblin',
+      remainingMonsters: [],
+      omnipotenceSet: ['goblin'],
+      hp: 20,
+      inPlayEquipmentIds: ['M_POLY'],
+      polySpent: false,
+    },
+  }
+  const result = applyAction(state, { type: ACTION_TYPES.USE_POLYMORPH }, { seatId })
+  assert.equal(result.ok, true)
+  assert.equal(result.state.lastDungeonRun?.result, 'success')
+  assert.equal(result.state.lastDungeonRun?.winVia, undefined)
+})

--- a/src/features/dungeon-runner/engine/kernel.test.js
+++ b/src/features/dungeon-runner/engine/kernel.test.js
@@ -668,6 +668,7 @@ test('bidding to dungeon initializes runner dungeon state like Python _end_biddi
   assert.equal(state.bidding.runnerSeatId, s2)
   assert.equal(state.bidding.dungeonMonsters.length, 2)
   const d = state.dungeon
+  assert.deepEqual(d.omnipotenceSet, state.bidding.dungeonMonsters)
   assert.equal(d.currentMonster, null)
   assert.equal(d.remainingMonsters.length, 2)
   assert.equal(d.subphase, DUNGEON_SUBPHASES.VORPAL)

--- a/src/features/dungeon-runner/engine/omnipotencePolicy.js
+++ b/src/features/dungeon-runner/engine/omnipotencePolicy.js
@@ -1,0 +1,23 @@
+export const DUNGEON_RUN_WIN_VIA = Object.freeze({
+  OMNIPOTENCE: 'omnipotence',
+})
+
+const OMNI_EQUIPMENT_ID = 'M_OMNI'
+
+/**
+ * @param {readonly string[] | string[] | null | undefined} omnipotenceSet
+ */
+export function isOmnipotenceSetSpeciesUnique(omnipotenceSet) {
+  const species = Array.isArray(omnipotenceSet) ? omnipotenceSet : []
+  if (!species.length) return false
+  return species.length === new Set(species).size
+}
+
+/**
+ * @param {{ inPlayEquipmentIds?: readonly string[] | string[]; omnipotenceSet?: readonly string[] | string[] }} params
+ */
+export function shouldOmnipotenceSave({ inPlayEquipmentIds, omnipotenceSet }) {
+  const inPlay = new Set(inPlayEquipmentIds ?? [])
+  if (!inPlay.has(OMNI_EQUIPMENT_ID)) return false
+  return isOmnipotenceSetSpeciesUnique(omnipotenceSet)
+}

--- a/src/features/dungeon-runner/engine/omnipotencePolicy.js
+++ b/src/features/dungeon-runner/engine/omnipotencePolicy.js
@@ -1,7 +1,3 @@
-export const DUNGEON_RUN_WIN_VIA = Object.freeze({
-  OMNIPOTENCE: 'omnipotence',
-})
-
 const OMNI_EQUIPMENT_ID = 'M_OMNI'
 
 /**

--- a/src/features/dungeon-runner/engine/omnipotencePolicy.test.js
+++ b/src/features/dungeon-runner/engine/omnipotencePolicy.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  DUNGEON_RUN_WIN_VIA,
+  isOmnipotenceSetSpeciesUnique,
+  shouldOmnipotenceSave,
+} from './omnipotencePolicy.js'
+
+test('isOmnipotenceSetSpeciesUnique passes when every species in the initial pile is distinct', () => {
+  assert.equal(isOmnipotenceSetSpeciesUnique(['goblin', 'orc', 'dragon']), true)
+})
+
+test('isOmnipotenceSetSpeciesUnique fails when the initial pile has duplicate species', () => {
+  assert.equal(isOmnipotenceSetSpeciesUnique(['goblin', 'goblin', 'orc']), false)
+})
+
+test('shouldOmnipotenceSave requires M_OMNI in play and a species-unique omnipotence set', () => {
+  assert.equal(
+    shouldOmnipotenceSave({
+      inPlayEquipmentIds: ['M_WALL'],
+      omnipotenceSet: ['goblin', 'orc', 'dragon'],
+    }),
+    false,
+  )
+  assert.equal(
+    shouldOmnipotenceSave({
+      inPlayEquipmentIds: ['M_OMNI'],
+      omnipotenceSet: ['goblin', 'orc', 'dragon'],
+    }),
+    true,
+  )
+})
+
+test('DUNGEON_RUN_WIN_VIA exposes omnipotence win metadata key', () => {
+  assert.equal(DUNGEON_RUN_WIN_VIA.OMNIPOTENCE, 'omnipotence')
+})

--- a/src/features/dungeon-runner/engine/omnipotencePolicy.test.js
+++ b/src/features/dungeon-runner/engine/omnipotencePolicy.test.js
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
-  DUNGEON_RUN_WIN_VIA,
   isOmnipotenceSetSpeciesUnique,
   shouldOmnipotenceSave,
 } from './omnipotencePolicy.js'
@@ -29,8 +28,4 @@ test('shouldOmnipotenceSave requires M_OMNI in play and a species-unique omnipot
     }),
     true,
   )
-})
-
-test('DUNGEON_RUN_WIN_VIA exposes omnipotence win metadata key', () => {
-  assert.equal(DUNGEON_RUN_WIN_VIA.OMNIPOTENCE, 'omnipotence')
 })

--- a/src/features/dungeon-runner/ui/dungeonOutcomeDialog.js
+++ b/src/features/dungeon-runner/ui/dungeonOutcomeDialog.js
@@ -1,4 +1,4 @@
-import { DUNGEON_RUN_WIN_VIA } from '../engine/omnipotencePolicy.js'
+import { DUNGEON_RUN_WIN_VIA } from '../dungeonRunOutcome.js'
 
 export const DUNGEON_OUTCOME_MESSAGE_KIND = Object.freeze({
   CLEARED: 'cleared',

--- a/src/features/dungeon-runner/ui/dungeonOutcomeDialog.js
+++ b/src/features/dungeon-runner/ui/dungeonOutcomeDialog.js
@@ -1,3 +1,40 @@
+import { DUNGEON_RUN_WIN_VIA } from '../engine/omnipotencePolicy.js'
+
+export const DUNGEON_OUTCOME_MESSAGE_KIND = Object.freeze({
+  CLEARED: 'cleared',
+  OMNIPOTENCE: 'omnipotence',
+  FAILED: 'failed',
+})
+
+/**
+ * @param {{ result?: string; winVia?: string } | null | undefined} lastDungeonRun
+ */
+export function resolveDungeonOutcomeMessageKind(lastDungeonRun) {
+  if (!lastDungeonRun) return null
+  if (lastDungeonRun.result === 'failure') return DUNGEON_OUTCOME_MESSAGE_KIND.FAILED
+  if (lastDungeonRun.winVia === DUNGEON_RUN_WIN_VIA.OMNIPOTENCE) {
+    return DUNGEON_OUTCOME_MESSAGE_KIND.OMNIPOTENCE
+  }
+  if (lastDungeonRun.result === 'success') return DUNGEON_OUTCOME_MESSAGE_KIND.CLEARED
+  return null
+}
+
+const DUNGEON_OUTCOME_MESSAGES = Object.freeze({
+  [DUNGEON_OUTCOME_MESSAGE_KIND.CLEARED]: 'Clean run. The dungeon is cleared.',
+  [DUNGEON_OUTCOME_MESSAGE_KIND.OMNIPOTENCE]:
+    'Omnipotence prevailed. Every species in the initial dungeon pile was unique.',
+  [DUNGEON_OUTCOME_MESSAGE_KIND.FAILED]: 'The run failed.',
+})
+
+/**
+ * @param {{ result?: string; winVia?: string } | null | undefined} lastDungeonRun
+ */
+export function resolveDungeonOutcomeMessage(lastDungeonRun) {
+  const kind = resolveDungeonOutcomeMessageKind(lastDungeonRun)
+  if (!kind) return ''
+  return DUNGEON_OUTCOME_MESSAGES[kind] ?? ''
+}
+
 export function isDungeonOutcomeDialogOpen({
   lastDungeonRun = null,
   dismissedDungeonRun = null,

--- a/src/features/dungeon-runner/ui/dungeonOutcomeDialog.test.js
+++ b/src/features/dungeon-runner/ui/dungeonOutcomeDialog.test.js
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { DUNGEON_RUN_WIN_VIA } from '../engine/omnipotencePolicy.js'
 import {
   buildDungeonOutcomeSummary,
   countCenterEquipmentRemaining,
+  DUNGEON_OUTCOME_MESSAGE_KIND,
   dismissDungeonRunForOutcomeDialog,
   isDungeonOutcomeDialogOpen,
+  resolveDungeonOutcomeMessageKind,
   resolveLastDungeonRunWatcherUpdate,
   shouldShowDungeonOutcomeDialog,
 } from './dungeonOutcomeDialog.js'
@@ -98,6 +101,25 @@ test('continue dismisses outcome dialog by run reference identity', () => {
   assert.equal(
     isDungeonOutcomeDialogOpen({ lastDungeonRun: run, dismissedDungeonRun: run }),
     false,
+  )
+})
+
+test('resolveDungeonOutcomeMessageKind maps lastDungeonRun metadata to stable outcome kinds', () => {
+  assert.equal(resolveDungeonOutcomeMessageKind(null), null)
+  assert.equal(
+    resolveDungeonOutcomeMessageKind({ result: 'failure' }),
+    DUNGEON_OUTCOME_MESSAGE_KIND.FAILED,
+  )
+  assert.equal(
+    resolveDungeonOutcomeMessageKind({ result: 'success' }),
+    DUNGEON_OUTCOME_MESSAGE_KIND.CLEARED,
+  )
+  assert.equal(
+    resolveDungeonOutcomeMessageKind({
+      result: 'success',
+      winVia: DUNGEON_RUN_WIN_VIA.OMNIPOTENCE,
+    }),
+    DUNGEON_OUTCOME_MESSAGE_KIND.OMNIPOTENCE,
   )
 })
 

--- a/src/features/dungeon-runner/ui/dungeonOutcomeDialog.test.js
+++ b/src/features/dungeon-runner/ui/dungeonOutcomeDialog.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { DUNGEON_RUN_WIN_VIA } from '../engine/omnipotencePolicy.js'
+import { DUNGEON_RUN_WIN_VIA } from '../dungeonRunOutcome.js'
 import {
   buildDungeonOutcomeSummary,
   countCenterEquipmentRemaining,

--- a/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
+++ b/src/features/dungeon-runner/ui/shells/useLiveMatchShell.js
@@ -58,6 +58,7 @@ import {
   buildDungeonOutcomeSummary,
   dismissDungeonRunForOutcomeDialog,
   isDungeonOutcomeDialogOpen,
+  resolveDungeonOutcomeMessage,
   resolveLastDungeonRunWatcherUpdate,
   shouldShowDungeonOutcomeDialog,
 } from '../dungeonOutcomeDialog.js'
@@ -697,9 +698,7 @@ export function useLiveMatchShell(deps) {
       : 'dr-outcome--failure',
   )
   const dungeonOutcomeMessage = computed(() =>
-    dungeonOutcomeSummary.value?.resultLabel === 'Success'
-      ? 'Clean run. The dungeon is cleared.'
-      : 'The run failed.',
+    resolveDungeonOutcomeMessage(match.value?.state?.lastDungeonRun ?? null),
   )
   const dungeonOutcomeDialogOpen = computed({
     get() {


### PR DESCRIPTION
## Summary

- Implement Omnipotence as a passive alternate win per ADR 0008: uniqueness is checked against the frozen **omnipotence set** at dungeon run entry (species-level), not live lane state or bidding sacrifice discards.
- Gate Omnipotence on `M_OMNI` in play at defeat rather than Mage adventurer identity; healing potions still resolve before Omnipotence.
- Record `lastDungeonRun.winVia: 'omnipotence'` on alternate wins and show distinct outcome acknowledgment copy in the live match shell.
- Add focused test coverage via `omnipotencePolicy` unit tests and `kernel.omnipotence` integration tests.

Closes #247

## Test plan

- [x] `node --test src/features/dungeon-runner/engine/omnipotencePolicy.test.js`
- [x] `node --test src/features/dungeon-runner/engine/kernel.omnipotence.test.js`
- [x] `node --test src/features/dungeon-runner/ui/dungeonOutcomeDialog.test.js`
- [x] `node --test src/features/dungeon-runner/engine/kernel.golden.test.js`
- [x] Manual: inject omni-win console state → Reveal → Success with Omnipotence copy
- [x] Manual: inject omni-fail console state → Reveal → Failure with ordinary copy