### PR TITLE
P2P session facade contract tests (Game Timer and Movie Vote)

### DIFF
--- a/src/features/game-timer/CONTEXT.md
+++ b/src/features/game-timer/CONTEXT.md
@@ -42,15 +42,23 @@ Optional coupling where the sequence from **hard pass** events informs who goes 
 
 ### Snapshot
 
-Exchangeable authoritative slice of timer state (**players**, **active player**, **round**, timings, toggles such as hard-pass flags) kept in one **room**-level copy the **host** owns and **guests** mirror.
+Exchangeable authoritative slice of timer state (**players**, **active player**, **round**, timings, toggles such as hard-pass flags) kept in one **room**-level copy the **host** owns and **guests** mirror. Each **host** broadcast uses **monotonic authority broadcast** **seq**; **guests** never apply a regressive **snapshot**.
 
 ### Guest intent
 
 Facilitator gesture bundled with a **guest** update (player selection or hard-pass registration) so the **host** can collapse duplicate rapid sends while merging **snapshots**.
 
+### Guest reconnect coherence (Game Timer)
+
+On **guest** refresh or reattach, **stable client identity** on hello maps to the same logical **guest** slot; the **host** merges any pending **guest intent** (deduped) into the authoritative **snapshot** timeline and rebroadcasts. The **guest** mirrors that **snapshot**—local timer state is provisional until acknowledged.
+
+_Avoid_: Promoting local **banked time** or **active player** as truth before the next **host** broadcast.
+
 ### Session phase
 
-High-level connection posture for multiplayer control UI (idle, connecting, reconnecting, hosting, guest_connected).
+High-level **connection posture** for multiplayer control UI (`idle`, `connecting`, `reconnecting`, `hosting`, `guest_connected`)—the same shell contract Movie Vote calls **connection status**; not collaborative play state (**snapshot**, **round**, **banked time**).
+
+_Avoid_: **Phase** when you mean connectivity; Movie Vote reserves **phase** for **suggest** / **voting** / **results**.
 
 ### Host / Guest
 
@@ -59,6 +67,12 @@ Same role meanings as [**Star-room P2P**](../p2p/CONTEXT.md) and [**Movie Vote**
 ### Timing strip
 
 Compact session summary UI showing aggregate elapsed/session timing separate from round controls, anchored from the first **turn** selection once play has started.
+
+### Room exit survival
+
+After **room exit**, the **player** roster and timer session options stay; only persisted **room** join role and **room suffix** clear. Facilitators can **Host room** again without re-entering names.
+
+_Avoid_: Wiping the roster when the wire ends unless the user explicitly resets the game.
 
 ### New game with same players
 
@@ -79,7 +93,7 @@ _Avoid_: Implying a guarantee on every OS or browser—best-effort only.
 - **Rounds** own **player** order mappings; totals track both overall **banked** time and optionally per-round portions.
 - **Hard pass** interacts only with intra-**round** participation unless **pass order determines round order** binds outcomes to subsequent **round** ordering.
 - **Host** merges **guest** intents into authoritative **snapshot** timelines.
-- **Host** presence in a **room** is separate from the **room** itself; a temporary **host** disconnect (refresh, network blip) does not end the **room** for **guests**—only an explicit host end does. **Guests** keep the last **snapshot** until the **host** returns.
+- **Host** presence in a **room** is separate from the **room** itself; **host abrupt disconnect** does not end the **room** for **guests**—**connection posture** stays `guest_connected`, last **snapshot** stays authoritative, `remoteHostPresent` / `remoteHostTabVisible` may flicker informationally until **host reclaim** resumes broadcast (**loose guest attachment**).
 - **Keep display on** engages whenever the roster is non-empty so facilitators are less likely to lose the **room** mid-game.
 
 ## Example dialogue

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -586,8 +586,8 @@ export function broadcastGameTimerSnapshot(snapshot, intent) {
 
 /**
  * Ends the session for this tab: clears phase and suffix, then tears down RTDB listeners.
- * Does not reset host/guest seq counters or handler bindings — use
- * {@link resetGameTimerP2PWireStateForTests} in tests when reusing one module instance.
+ * Does not reset host/guest seq counters or handler bindings — use `session.testExports.js`
+ * when reusing one module instance in tests.
  * @returns {void}
  */
 export function teardownSession() {
@@ -596,37 +596,42 @@ export function teardownSession() {
   core.teardownSession()
 }
 
-/**
- * Test-only: advances reconnect generation without clearing join persistence (supersede in-flight loops).
- * @returns {void}
- */
-export function bumpGameTimerReconnectGenerationForTests() {
-  core.bumpReconnectGeneration()
+/** @returns {import('../types.js').GameTimerSyncPayload} */
+function emptyGameTimerSnapshot() {
+  return {
+    players: [],
+    activePlayerId: null,
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+  }
 }
 
 /**
- * Test-only: clears module-level P2P wire state (seq counters, deduper, listeners, reactive refs,
- * handler bindings). Prefer nonce-based `importGameTimerSession` for isolation; call after
- * `teardownSession` when a test reuses one `session.js` instance.
- * @returns {void}
+ * Test-only wire access for `session.testExports.js`. Do not import from production code.
+ * @returns {{
+ *   core: ReturnType<typeof createStarRoomSession>,
+ *   remoteHostTabVisible: typeof remoteHostTabVisible,
+ *   remoteHostPresent: typeof remoteHostPresent,
+ *   resetHostGuestWireState: typeof resetHostGuestWireState,
+ *   emptyHandlers: () => GameTimerP2PHandlers,
+ *   setHandlers: (h: GameTimerP2PHandlers) => void,
+ * }}
  */
-export function resetGameTimerP2PWireStateForTests() {
-  remoteHostTabVisible.value = true
-  remoteHostPresent.value = true
-  resetHostGuestWireState()
-  core.destroyWireOnly()
-  sessionPhase.value = 'idle'
-  sessionSuffix.value = null
-  handlers = {
-    getSnapshot: () => ({
-      players: [],
-      activePlayerId: null,
-      turnStartedAt: null,
-      turnStartedRound: null,
-      round: 1,
-      playerOrderByRound: {},
+export function getGameTimerSessionTestWireAccess() {
+  return {
+    core,
+    remoteHostTabVisible,
+    remoteHostPresent,
+    resetHostGuestWireState,
+    emptyHandlers: () => ({
+      getSnapshot: () => emptyGameTimerSnapshot(),
+      applySnapshot: () => {},
     }),
-    applySnapshot: () => {},
+    setHandlers: (h) => {
+      handlers = h
+    },
   }
 }
 

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -274,6 +274,7 @@ function handleHostInboxMessage(stableId, raw) {
     return
   }
 
+  // Guest hello still publishes via onGuestHello above; only rebroadcast when an update intent applied.
   if (mergeResult.appliedGuestSnapshot) {
     hostPublishSnapshot(mergeResult.broadcastSnapshot)
   }

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -251,18 +251,18 @@ function handleHostInboxMessage(stableId, raw) {
   }
 
   const now = Date.now()
-  let snap
+  /** @type {{ broadcastSnapshot: GameTimerSyncPayload, appliedGuestSnapshot: boolean } | null} */
+  let mergeResult = null
   try {
-    const result = authoritativeSnapshotAfterGuestMessage(
+    mergeResult = authoritativeSnapshotAfterGuestMessage(
       msg,
       hostGuestIntentDeduper,
       now,
       (s) => handlers.applySnapshot(s),
       () => handlers.getSnapshot(),
     )
-    snap = result.broadcastSnapshot
     if (
-      !result.appliedGuestSnapshot &&
+      !mergeResult.appliedGuestSnapshot &&
       msg.intent &&
       typeof import.meta !== 'undefined' &&
       import.meta.env &&
@@ -274,7 +274,9 @@ function handleHostInboxMessage(stableId, raw) {
     return
   }
 
-  hostPublishSnapshot(snap)
+  if (mergeResult.appliedGuestSnapshot) {
+    hostPublishSnapshot(mergeResult.broadcastSnapshot)
+  }
 }
 
 function handleGuestHostEnded() {
@@ -584,12 +586,48 @@ export function broadcastGameTimerSnapshot(snapshot, intent) {
 
 /**
  * Ends the session for this tab: clears phase and suffix, then tears down RTDB listeners.
+ * Does not reset host/guest seq counters or handler bindings — use
+ * {@link resetGameTimerP2PWireStateForTests} in tests when reusing one module instance.
  * @returns {void}
  */
 export function teardownSession() {
   remoteHostTabVisible.value = true
   remoteHostPresent.value = true
   core.teardownSession()
+}
+
+/**
+ * Test-only: advances reconnect generation without clearing join persistence (supersede in-flight loops).
+ * @returns {void}
+ */
+export function bumpGameTimerReconnectGenerationForTests() {
+  core.bumpReconnectGeneration()
+}
+
+/**
+ * Test-only: clears module-level P2P wire state (seq counters, deduper, listeners, reactive refs,
+ * handler bindings). Prefer nonce-based `importGameTimerSession` for isolation; call after
+ * `teardownSession` when a test reuses one `session.js` instance.
+ * @returns {void}
+ */
+export function resetGameTimerP2PWireStateForTests() {
+  remoteHostTabVisible.value = true
+  remoteHostPresent.value = true
+  resetHostGuestWireState()
+  core.destroyWireOnly()
+  sessionPhase.value = 'idle'
+  sessionSuffix.value = null
+  handlers = {
+    getSnapshot: () => ({
+      players: [],
+      activePlayerId: null,
+      turnStartedAt: null,
+      turnStartedRound: null,
+      round: 1,
+      playerOrderByRound: {},
+    }),
+    applySnapshot: () => {},
+  }
 }
 
 /**

--- a/src/features/game-timer/p2p/session.testExports.js
+++ b/src/features/game-timer/p2p/session.testExports.js
@@ -1,0 +1,27 @@
+/**
+ * Test-only helpers for Game Timer session facade contract tests.
+ * Import from tests only — not from production code.
+ */
+
+/**
+ * @param {{ getGameTimerSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getGameTimerSessionTestWireAccess> }} sessionMod
+ * @returns {void}
+ */
+export function bumpGameTimerReconnectGenerationForTests(sessionMod) {
+  sessionMod.getGameTimerSessionTestWireAccess().core.bumpReconnectGeneration()
+}
+
+/**
+ * @param {{ getGameTimerSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getGameTimerSessionTestWireAccess> }} sessionMod
+ * @returns {void}
+ */
+export function resetGameTimerP2PWireStateForTests(sessionMod) {
+  const access = sessionMod.getGameTimerSessionTestWireAccess()
+  access.remoteHostTabVisible.value = true
+  access.remoteHostPresent.value = true
+  access.resetHostGuestWireState()
+  access.core.destroyWireOnly()
+  access.core.setPhase('idle')
+  access.core.setSuffix(null)
+  access.setHandlers(access.emptyHandlers())
+}

--- a/src/features/game-timer/p2p/sessionFacadeDomainWire.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeDomainWire.test.js
@@ -1,0 +1,174 @@
+/**
+ * Run: node --test src/features/game-timer/p2p/sessionFacadeDomainWire.test.js
+ *
+ * Guest inbound monotonic authority broadcast on snapshot messages — domain wire only
+ * (not connection posture; see posture contract tests separately).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { encodeHostSnapshot, MSG_HOST_SNAPSHOT } from './protocol.js'
+import {
+  bindGameTimerP2PHandlers,
+  broadcastGameTimerSnapshot,
+  handleGuestInbound,
+  resetGameTimerP2PWireStateForTests,
+  sessionSuffix,
+  teardownSession,
+} from './session.js'
+
+/** @returns {GameTimerSyncPayload} */
+function baseSnapshot(overrides = {}) {
+  return {
+    players: [],
+    activePlayerId: null,
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+    hardPassEnabled: false,
+    hardPassOrderNextRound: false,
+    hardPassOrderByRound: {},
+    ...overrides,
+  }
+}
+
+/** @param {string} playerId @param {number} [round] @returns {GameTimerSyncPayload} */
+function snapshotWithActivePlayer(playerId, round = 1) {
+  return baseSnapshot({
+    players: [{ id: playerId, name: playerId, color: '#111111' }],
+    activePlayerId: playerId,
+    round,
+    playerOrderByRound: { [String(round)]: [playerId] },
+  })
+}
+
+function bindFakeMirrorHandlers() {
+  /** @type {GameTimerSyncPayload | null} */
+  let mirror = null
+  let applyCount = 0
+
+  bindGameTimerP2PHandlers({
+    getSnapshot: () => mirror ?? baseSnapshot(),
+    applySnapshot: (snap) => {
+      applyCount += 1
+      mirror = structuredClone(snap)
+    },
+  })
+
+  return {
+    get mirror() {
+      return mirror
+    },
+    get applyCount() {
+      return applyCount
+    },
+    /** Simulates local mirror drift without host authority (e.g. reconnect fork). */
+    setLocalFork(snap) {
+      mirror = structuredClone(snap)
+    },
+  }
+}
+
+test('guest inbound snapshot applies only when seq strictly increases', () => {
+  const wire = bindFakeMirrorHandlers()
+  const snapA = snapshotWithActivePlayer('p-a')
+  const snapB = snapshotWithActivePlayer('p-b', 2)
+
+  handleGuestInbound(encodeHostSnapshot(snapA, 1))
+  assert.equal(wire.applyCount, 1)
+  assert.equal(wire.mirror?.activePlayerId, 'p-a')
+
+  handleGuestInbound(encodeHostSnapshot(snapB, 1))
+  assert.equal(wire.applyCount, 1, 'equal seq must not re-apply')
+  assert.equal(wire.mirror?.activePlayerId, 'p-a')
+
+  handleGuestInbound(encodeHostSnapshot(snapB, 2))
+  assert.equal(wire.applyCount, 2)
+  assert.equal(wire.mirror?.activePlayerId, 'p-b')
+  assert.equal(wire.mirror?.round, 2)
+})
+
+test('guest inbound snapshot ignores regressive seq without changing mirror', () => {
+  const wire = bindFakeMirrorHandlers()
+  const authoritative = snapshotWithActivePlayer('host-truth', 3)
+
+  handleGuestInbound(encodeHostSnapshot(authoritative, 5))
+  assert.equal(wire.applyCount, 1)
+
+  wire.setLocalFork(snapshotWithActivePlayer('local-fork'))
+
+  handleGuestInbound(encodeHostSnapshot(snapshotWithActivePlayer('stale-host'), 3))
+  assert.equal(wire.applyCount, 1, 'regressive seq is a no-op on applySnapshot')
+  assert.equal(wire.mirror?.activePlayerId, 'local-fork')
+
+  handleGuestInbound(encodeHostSnapshot(authoritative, 5))
+  assert.equal(wire.applyCount, 1, 'duplicate max seq is still ignored')
+  assert.equal(wire.mirror?.activePlayerId, 'local-fork')
+})
+
+test('guest inbound snapshot ignores invalid and malformed wire shapes', () => {
+  const wire = bindFakeMirrorHandlers()
+  const valid = encodeHostSnapshot(snapshotWithActivePlayer('kept'), 1)
+
+  handleGuestInbound(valid)
+  assert.equal(wire.applyCount, 1)
+
+  const malformed = [
+    null,
+    'not-an-object',
+    {},
+    { type: MSG_HOST_SNAPSHOT, seq: 0, snapshot: baseSnapshot() },
+    { type: MSG_HOST_SNAPSHOT, seq: 1 },
+    { type: MSG_HOST_SNAPSHOT, seq: 1, snapshot: { round: 'bad', players: [] } },
+    { type: 'gt-wrong', seq: 2, snapshot: baseSnapshot() },
+  ]
+
+  for (const raw of malformed) {
+    handleGuestInbound(raw)
+  }
+
+  assert.equal(wire.applyCount, 1, 'malformed host snapshots must not touch mirror handlers')
+  assert.equal(wire.mirror?.activePlayerId, 'kept')
+})
+
+test('guest reconnect coherence: authoritative broadcast overwrites local mirror fork', () => {
+  const wire = bindFakeMirrorHandlers()
+  const beforeDisconnect = snapshotWithActivePlayer('host-seat', 1)
+
+  handleGuestInbound(encodeHostSnapshot(beforeDisconnect, 1))
+  assert.equal(wire.mirror?.activePlayerId, 'host-seat')
+
+  wire.setLocalFork(snapshotWithActivePlayer('guest-fork', 1))
+
+  const afterReconnect = snapshotWithActivePlayer('host-seat-resumed', 2)
+  handleGuestInbound(encodeHostSnapshot(afterReconnect, 2))
+
+  assert.equal(wire.applyCount, 2)
+  assert.equal(wire.mirror?.activePlayerId, 'host-seat-resumed')
+  assert.equal(wire.mirror?.round, 2)
+})
+
+test('guest broadcastGameTimerSnapshot does not promote local state as mirror truth', () => {
+  const wire = bindFakeMirrorHandlers()
+  const hostTruth = snapshotWithActivePlayer('host-authority', 1)
+
+  handleGuestInbound(encodeHostSnapshot(hostTruth, 1))
+  assert.equal(wire.applyCount, 1)
+
+  sessionSuffix.value = 'WIRE01'
+  const localOnly = snapshotWithActivePlayer('guest-local-fork', 9)
+  broadcastGameTimerSnapshot(localOnly, {
+    kind: 'selectPlayer',
+    playerId: 'guest-local-fork',
+    sentAt: Date.now(),
+  })
+
+  assert.equal(wire.applyCount, 1, 'guest outbound snapshot must not call applySnapshot')
+  assert.equal(wire.mirror?.activePlayerId, 'host-authority')
+  assert.equal(wire.mirror?.round, 1)
+})
+
+afterEach(() => {
+  teardownSession()
+  resetGameTimerP2PWireStateForTests()
+})

--- a/src/features/game-timer/p2p/sessionFacadeDomainWire.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeDomainWire.test.js
@@ -7,14 +7,15 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { encodeHostSnapshot, MSG_HOST_SNAPSHOT } from './protocol.js'
+import * as sessionMod from './session.js'
 import {
   bindGameTimerP2PHandlers,
   broadcastGameTimerSnapshot,
   handleGuestInbound,
-  resetGameTimerP2PWireStateForTests,
   sessionSuffix,
   teardownSession,
 } from './session.js'
+import { resetGameTimerP2PWireStateForTests } from './session.testExports.js'
 
 /** @returns {GameTimerSyncPayload} */
 function baseSnapshot(overrides = {}) {
@@ -170,5 +171,5 @@ test('guest broadcastGameTimerSnapshot does not promote local state as mirror tr
 
 afterEach(() => {
   teardownSession()
-  resetGameTimerP2PWireStateForTests()
+  resetGameTimerP2PWireStateForTests(sessionMod)
 })

--- a/src/features/game-timer/p2p/sessionFacadeHostInbox.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeHostInbox.test.js
@@ -1,0 +1,222 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionFacadeHostInbox.test.js
+ *
+ * Host inbox domain wire — guest hello monotonic authority broadcast rebroadcast and
+ * guest intent dedupe at the session facade boundary (separate from posture tests).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { encodeGuestHello, encodeGuestUpdate, parseHostMessage } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const hostInboxTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {import('../types.js').GameTimerSyncPayload} */
+const HOST_TRUTH = {
+  players: [{ id: 'host-p', name: 'Host', color: '#111111' }],
+  activePlayerId: 'host-p',
+  turnStartedAt: null,
+  turnStartedRound: null,
+  round: 1,
+  playerOrderByRound: { '1': ['host-p'] },
+  hardPassEnabled: false,
+  hardPassOrderNextRound: false,
+  hardPassOrderByRound: {},
+}
+
+/**
+ * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {unknown} payload
+ */
+function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
+  const inboxParent = `gameTimerRooms/${suffix}/inbox`
+  assert.ok(
+    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
+    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
+  )
+  harness.emitChildAdded(inboxParent, guestStableId)
+  const childPath = `${inboxParent}/${guestStableId}`
+  assert.ok(
+    harness.listeners.has(childPath),
+    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
+  )
+  harness.emitValue(childPath, payload)
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {Array<{ seq: number, snapshot: import('../types.js').GameTimerSyncPayload }>}
+ */
+function parseStateBroadcasts(sets) {
+  return sets
+    .filter((entry) => entry.path.endsWith('/state'))
+    .map((entry) => {
+      const parsed = parseHostMessage(entry.value)
+      assert.ok(parsed, 'state write must be a host snapshot message')
+      return { seq: parsed.seq, snapshot: parsed.snapshot }
+    })
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importGameTimerSession>>} sessionMod
+ */
+function bindHostMirrorHandlers(sessionMod) {
+  setActivePinia(createPinia())
+  /** @type {import('../types.js').GameTimerSyncPayload} */
+  let mirror = structuredClone(HOST_TRUTH)
+  let applyCount = 0
+
+  sessionMod.bindGameTimerP2PHandlers({
+    getSnapshot: () => structuredClone(mirror),
+    applySnapshot: (snap) => {
+      applyCount += 1
+      mirror = structuredClone(snap)
+    },
+  })
+
+  return {
+    get mirror() {
+      return mirror
+    },
+    get applyCount() {
+      return applyCount
+    },
+  }
+}
+
+test(
+  'guest hello: monotonic authority broadcast rebroadcasts authoritative snapshot with increasing seq',
+  hostInboxTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'GTHOSTHELLO1'
+    const guestStableId = 'GTGUESTHELLO'
+    const suffix = 'HELLO1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`hello-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const wire = bindHostMirrorHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const broadcastsAfterHostStart = parseStateBroadcasts(harness.sets)
+      assert.equal(broadcastsAfterHostStart.length, 1)
+      assert.equal(broadcastsAfterHostStart[0].seq, 1)
+      assert.equal(broadcastsAfterHostStart[0].snapshot.activePlayerId, 'host-p')
+      assert.equal(wire.applyCount, 0)
+
+      const setsBeforeHello = harness.sets.length
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeGuestHello(guestStableId))
+
+      assert.equal(wire.applyCount, 0, 'guest hello must not merge guest snapshot into host mirror')
+      const helloBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeHello))
+      assert.equal(helloBroadcasts.length, 1)
+      assert.ok(
+        helloBroadcasts[0].seq > broadcastsAfterHostStart[0].seq,
+        'monotonic authority broadcast seq must increase after guest hello',
+      )
+      assert.equal(helloBroadcasts[0].snapshot.activePlayerId, 'host-p')
+    })
+  },
+)
+
+test(
+  'guest intent dedupe at host inbox: one merge and one monotonic authority broadcast within debounce window',
+  hostInboxTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'GTHOSTDEDUP1'
+    const guestStableId = 'GTGUESTDEDUP'
+    const suffix = 'DEDUP1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`dedupe-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const wire = bindHostMirrorHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const guestFirst = structuredClone(HOST_TRUTH)
+      guestFirst.activePlayerId = 'guest-p'
+      guestFirst.players = [{ id: 'guest-p', name: 'Guest', color: '#222222' }]
+      guestFirst.playerOrderByRound = { '1': ['guest-p'] }
+
+      const guestSecond = structuredClone(guestFirst)
+      guestSecond.round = 2
+
+      const intent = { kind: 'selectPlayer', playerId: 'guest-p', sentAt: 1_700_000_000_000 }
+      const setsBeforeGuest = harness.sets.length
+      const applyBeforeGuest = wire.applyCount
+
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeGuestUpdate(guestFirst, intent),
+      )
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeGuestUpdate(guestSecond, intent),
+      )
+
+      assert.equal(wire.applyCount - applyBeforeGuest, 1, 'duplicate guest intent merges snapshot once')
+      assert.equal(wire.mirror.activePlayerId, 'guest-p')
+      assert.equal(wire.mirror.round, 1, 'second duplicate must not apply competing snapshot')
+
+      const guestBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuest))
+      assert.equal(
+        guestBroadcasts.length,
+        1,
+        'duplicate guest intent produces one monotonic authority broadcast',
+      )
+      assert.ok(guestBroadcasts[0].seq > 1, 'rebroadcast seq must advance past host start')
+      assert.equal(guestBroadcasts[0].snapshot.activePlayerId, 'guest-p')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionFacadeHostInbox.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeHostInbox.test.js
@@ -8,6 +8,7 @@ import assert from 'node:assert/strict'
 import { afterEach, mock, test } from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { encodeGuestHello, encodeGuestUpdate, parseHostMessage } from './protocol.js'
+import { parseStateBroadcasts, simulateHostInboxMessage } from '../../p2p/test/hostInboxHarness.js'
 import {
   createRtdbLifecycleAfterEach,
   importGameTimerSession,
@@ -31,39 +32,9 @@ const HOST_TRUTH = {
   hardPassOrderByRound: {},
 }
 
-/**
- * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
- * @param {string} suffix
- * @param {string} guestStableId
- * @param {unknown} payload
- */
-function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
-  const inboxParent = `gameTimerRooms/${suffix}/inbox`
-  assert.ok(
-    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
-    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
-  )
-  harness.emitChildAdded(inboxParent, guestStableId)
-  const childPath = `${inboxParent}/${guestStableId}`
-  assert.ok(
-    harness.listeners.has(childPath),
-    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
-  )
-  harness.emitValue(childPath, payload)
-}
-
-/**
- * @param {Array<{ path: string, value: unknown }>} sets
- * @returns {Array<{ seq: number, snapshot: import('../types.js').GameTimerSyncPayload }>}
- */
-function parseStateBroadcasts(sets) {
-  return sets
-    .filter((entry) => entry.path.endsWith('/state'))
-    .map((entry) => {
-      const parsed = parseHostMessage(entry.value)
-      assert.ok(parsed, 'state write must be a host snapshot message')
-      return { seq: parsed.seq, snapshot: parsed.snapshot }
-    })
+/** @param {Array<{ path: string, value: unknown }>} sets */
+function gtStateBroadcasts(sets) {
+  return parseStateBroadcasts(sets, parseHostMessage, 'snapshot')
 }
 
 /**
@@ -125,17 +96,17 @@ test(
       await startAsHost(3)
       assert.equal(sessionPhase.value, 'hosting')
 
-      const broadcastsAfterHostStart = parseStateBroadcasts(harness.sets)
+      const broadcastsAfterHostStart = gtStateBroadcasts(harness.sets)
       assert.equal(broadcastsAfterHostStart.length, 1)
       assert.equal(broadcastsAfterHostStart[0].seq, 1)
       assert.equal(broadcastsAfterHostStart[0].snapshot.activePlayerId, 'host-p')
       assert.equal(wire.applyCount, 0)
 
       const setsBeforeHello = harness.sets.length
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeGuestHello(guestStableId))
+      simulateHostInboxMessage(harness, 'gameTimerRooms', suffix, guestStableId, encodeGuestHello(guestStableId))
 
       assert.equal(wire.applyCount, 0, 'guest hello must not merge guest snapshot into host mirror')
-      const helloBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeHello))
+      const helloBroadcasts = gtStateBroadcasts(harness.sets.slice(setsBeforeHello))
       assert.equal(helloBroadcasts.length, 1)
       assert.ok(
         helloBroadcasts[0].seq > broadcastsAfterHostStart[0].seq,
@@ -192,12 +163,14 @@ test(
 
       simulateHostInboxMessage(
         harness,
+        'gameTimerRooms',
         suffix,
         guestStableId,
         encodeGuestUpdate(guestFirst, intent),
       )
       simulateHostInboxMessage(
         harness,
+        'gameTimerRooms',
         suffix,
         guestStableId,
         encodeGuestUpdate(guestSecond, intent),
@@ -207,7 +180,7 @@ test(
       assert.equal(wire.mirror.activePlayerId, 'guest-p')
       assert.equal(wire.mirror.round, 1, 'second duplicate must not apply competing snapshot')
 
-      const guestBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuest))
+      const guestBroadcasts = gtStateBroadcasts(harness.sets.slice(setsBeforeGuest))
       assert.equal(
         guestBroadcasts.length,
         1,

--- a/src/features/game-timer/p2p/sessionFacadePosture.test.js
+++ b/src/features/game-timer/p2p/sessionFacadePosture.test.js
@@ -1,0 +1,288 @@
+/**
+ * Game Timer facade connection posture — structured session events and loose guest attachment.
+ * Separate from domain wire / snapshot tests.
+ *
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionFacadePosture.test.js
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { encodeHostSnapshot, encodeHostVisibility } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const postureTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {import('../types.js').GameTimerSyncPayload} */
+const EMPTY_SNAPSHOT = {
+  players: [],
+  activePlayerId: null,
+  turnStartedAt: null,
+  turnStartedRound: null,
+  round: 1,
+  playerOrderByRound: {},
+}
+
+const JOINABLE_HOST_STATE = encodeHostSnapshot(
+  {
+    players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+    activePlayerId: 'p1',
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+  },
+  1,
+)
+
+/**
+ * Production bridge shape without mounting Vue.
+ * @param {Awaited<ReturnType<typeof importGameTimerSession>>} sessionMod
+ */
+function bindPostureHandlers(sessionMod) {
+  setActivePinia(createPinia())
+  const room = useGameTimerRoomSessionStore()
+  sessionMod.bindGameTimerP2PHandlers({
+    getSnapshot: () => ({ ...EMPTY_SNAPSHOT }),
+    applySnapshot: () => {},
+  })
+  return { room }
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @param {string} leaf
+ * @returns {(value: unknown) => void}
+ */
+function listenerAt(listeners, leaf) {
+  const path = [...listeners.keys()].find((p) => p.endsWith(leaf))
+  assert.ok(path, `expected listener on path ending with ${leaf}`)
+  const handler = listeners.get(path)
+  assert.ok(handler)
+  return (value) => handler({ val: () => value })
+}
+
+/**
+ * @param {() => string} readPhase
+ * @returns {Promise<void>}
+ */
+async function waitForReconnectExhaustion(readPhase) {
+  const deadline = Date.now() + 3_000
+  while (readPhase() !== 'idle' && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+test(
+  'fatal reconnect exhaustion clears persistence and returns tab to idle',
+  postureTests,
+  async () => {
+    mock.reset()
+
+    mock.module('../../p2p/starRoomReconnectDelay.js', {
+      namedExports: {
+        starRoomReconnectDelayMs: () => 5,
+      },
+    })
+    mock.module('../../p2p/starRoomTiming.js', {
+      namedExports: {
+        RECONNECT_MAX_ATTEMPTS: 3,
+        RECONNECT_INITIAL_PAUSE_MS: 5,
+        RECONNECT_BASE_DELAY_MS: 5,
+        RECONNECT_MAX_DELAY_MS: 5,
+      },
+    })
+
+    let roomJoinable = true
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => (roomJoinable ? Date.now() : null),
+      getState: () => (roomJoinable ? JOINABLE_HOST_STATE : null),
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`fatal-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('FATAL1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'FATAL1')
+
+      roomJoinable = false
+      listenerAt(listeners, 'connected')(false)
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      await waitForReconnectExhaustion(() => sessionPhase.value)
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+    })
+  },
+)
+
+test(
+  'connectivity_offline moves guest connection posture to reconnecting',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`offline-${Date.now()}`)
+      const { joinRoom, sessionPhase } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('OFFLN1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(listeners, 'connected')(false)
+
+      assert.equal(sessionPhase.value, 'reconnecting')
+    })
+  },
+)
+
+test(
+  'host_ended_room triggers room exit on guest tab',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`ended-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('END123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+
+      listenerAt(listeners, 'ended')(1_700_000_000_000)
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+    })
+  },
+)
+
+test(
+  'host_ping_present updates remoteHostPresent while posture stays guest_connected',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`ping-${Date.now()}`)
+      const { joinRoom, remoteHostPresent, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('PING01')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      const emitHostPing = listenerAt(listeners, 'hostPing')
+      emitHostPing(Date.now())
+      assert.equal(remoteHostPresent.value, true)
+
+      emitHostPing(null)
+      assert.equal(remoteHostPresent.value, false)
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(sessionSuffix.value, 'PING01')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'PING01')
+    })
+  },
+)
+
+test(
+  'host_tab_visible updates remoteHostTabVisible ref',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`vis-${Date.now()}`)
+      const { joinRoom, remoteHostTabVisible, sessionPhase } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('VIS001')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(remoteHostTabVisible.value, true)
+
+      listenerAt(listeners, 'hostVisible')(encodeHostVisibility(false))
+      assert.equal(remoteHostTabVisible.value, false)
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(listeners, 'hostVisible')(encodeHostVisibility(true))
+      assert.equal(remoteHostTabVisible.value, true)
+    })
+  },
+)
+
+test(
+  'loose guest attachment stays guest_connected when host wire drops briefly',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`loose-${Date.now()}`)
+      const { joinRoom, remoteHostPresent, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('LOOSE1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      const emitHostPing = listenerAt(listeners, 'hostPing')
+      emitHostPing(null)
+
+      assert.equal(remoteHostPresent.value, false)
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(sessionSuffix.value, 'LOOSE1')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'LOOSE1')
+
+      const endedPath = [...listeners.keys()].find((p) => p.endsWith('ended'))
+      assert.ok(endedPath)
+      listenerAt(listeners, 'ended')(null)
+      assert.equal(sessionPhase.value, 'guest_connected')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
@@ -1,0 +1,381 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionFacadeReconnect.test.js
+ *
+ * Star-room shell reconnect integration at the Game Timer session facade — teardown
+ * ordering and persistence/posture outcomes only (no Quasar Notify assertions).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { encodeHostSnapshot } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const facadeReconnectTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/**
+ * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
+ * @returns {string[]}
+ */
+function collectRefPath(ref) {
+  /** @type {string[]} */
+  const parts = []
+  let cur = ref
+  while (cur) {
+    if (cur.key) parts.unshift(cur.key)
+    cur = /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null } */ (
+      cur.parent ?? null
+    )
+  }
+  return parts
+}
+
+/** @type {Awaited<ReturnType<typeof importGameTimerSession>> | null} */
+let guestSessionForShellHook = null
+
+/** @type {typeof import('../../p2p/starRoomShell.js').runGuestStarReconnectLoop | null} */
+let realGuestStarReconnectLoop = null
+
+/** @type {typeof import('../../p2p/starRoomShell.js').runHostStarReconnectLoop | null} */
+let realHostStarReconnectLoop = null
+
+/**
+ * @param {() => boolean} condition
+ * @param {string} label
+ * @returns {Promise<void>}
+ */
+async function waitForPhase(condition, label) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`timed out waiting for ${label}`)
+}
+
+/**
+ * @param {import('../../p2p/starRoomShell.js').StarRoomGuestReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+async function runGuestReconnectWithSupersedeHook(h) {
+  assert.ok(realGuestStarReconnectLoop)
+  return realGuestStarReconnectLoop({
+    ...h,
+    sleep: async () => {},
+    establishGuest: async () => {
+      await h.establishGuest()
+      guestSessionForShellHook?.bumpGameTimerReconnectGenerationForTests()
+    },
+  })
+}
+
+/**
+ * @param {import('../../p2p/starRoomShell.js').StarRoomHostReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+async function runHostReconnectWithoutBackoff(h) {
+  assert.ok(realHostStarReconnectLoop)
+  return realHostStarReconnectLoop({
+    ...h,
+    sleep: async () => {},
+  })
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function installGuestReconnectShellHook() {
+  const shellActual = await import('../../p2p/starRoomShell.js')
+  realGuestStarReconnectLoop = shellActual.runGuestStarReconnectLoop
+  realHostStarReconnectLoop = shellActual.runHostStarReconnectLoop
+  mock.module('../../p2p/starRoomShell.js', {
+    namedExports: {
+      ...shellActual,
+      runGuestStarReconnectLoop: runGuestReconnectWithSupersedeHook,
+      runHostStarReconnectLoop: shellActual.runHostStarReconnectLoop,
+    },
+  })
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function installHostReconnectShellHook() {
+  const shellActual = await import('../../p2p/starRoomShell.js')
+  if (!realGuestStarReconnectLoop) {
+    realGuestStarReconnectLoop = shellActual.runGuestStarReconnectLoop
+    realHostStarReconnectLoop = shellActual.runHostStarReconnectLoop
+  }
+  mock.module('../../p2p/starRoomShell.js', {
+    namedExports: {
+      ...shellActual,
+      runGuestStarReconnectLoop: realGuestStarReconnectLoop,
+      runHostStarReconnectLoop: runHostReconnectWithoutBackoff,
+    },
+  })
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importGameTimerSession>>} sessionMod
+ * @returns {{ getSnapshot: () => import('../types.js').GameTimerSyncPayload, applied: import('../types.js').GameTimerSyncPayload[] }}
+ */
+function bindFakeHandlers(sessionMod) {
+  /** @type {import('../types.js').GameTimerSyncPayload} */
+  const snapshot = {
+    players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+    activePlayerId: 'p1',
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+  }
+  /** @type {import('../types.js').GameTimerSyncPayload[]} */
+  const applied = []
+  sessionMod.bindGameTimerP2PHandlers({
+    getSnapshot: () => snapshot,
+    applySnapshot: (s) => {
+      applied.push(s)
+    },
+  })
+  return { getSnapshot: () => snapshot, applied }
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @returns {(connected: boolean) => void}
+ */
+function getConnectedEmitter(listeners) {
+  const connectedPath = [...listeners.keys()].find((p) => p.endsWith('connected'))
+  assert.ok(connectedPath, 'session should subscribe to Firebase .info/connected')
+  const onConnected = listeners.get(connectedPath)
+  assert.ok(onConnected)
+  return (connected) => onConnected({ val: () => connected })
+}
+
+test(
+  'superseded guest reconnect loop tears down wire only and keeps join persistence',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+    guestSessionForShellHook = null
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
+    await installGuestReconnectShellHook()
+
+    const harness = await installRtdbLifecycleMocks()
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`supersede-guest-${Date.now()}`)
+      guestSessionForShellHook = sessionMod
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      bindFakeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const room = useGameTimerRoomSessionStore()
+
+      await joinRoom('SUP001')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'SUP001')
+
+      const emitConnected = getConnectedEmitter(harness.listeners)
+      emitConnected(false)
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      await waitForPhase(() => sessionPhase.value === 'idle', 'superseded loop unwind')
+
+      assert.equal(room.role, 'guest', 'superseded unwind must not clear join persistence')
+      assert.equal(room.suffix, 'SUP001')
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'superseded guest loop must not broadcast deliberate room end',
+      )
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+    })
+  },
+)
+
+test(
+  'host reconnect recovery does not end room for connected guests',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
+
+    const hostStableId = 'GTHOSTRCV01'
+    const guestStableId = 'GTGUESTRCV1'
+    const suffix = 'HRECV1'
+    let clientId = hostStableId
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => clientId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const joinableState = encodeHostSnapshot(
+      {
+        players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+        activePlayerId: 'p1',
+        turnStartedAt: null,
+        turnStartedRound: null,
+        round: 1,
+        playerOrderByRound: {},
+      },
+      1,
+    )
+
+    await installHostReconnectShellHook()
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getHostClientId: () => hostStableId,
+      getEnded: () => null,
+      getState: () => joinableState,
+    })
+
+    await withFirebaseEnv(async () => {
+      const hostPinia = createPinia()
+      setActivePinia(hostPinia)
+
+      const hostMod = await importGameTimerSession(`host-recover-${Date.now()}`)
+      bindFakeHandlers(hostMod)
+      const { startAsHost, sessionPhase: hostPhase } = hostMod
+
+      await startAsHost(3)
+      assert.equal(hostPhase.value, 'hosting')
+
+      const connectedPath = [...harness.listeners.keys()].find((p) => p.endsWith('connected'))
+      assert.ok(connectedPath)
+      const hostOnConnected = harness.listeners.get(connectedPath)
+      assert.ok(hostOnConnected)
+
+      clientId = guestStableId
+      const guestPinia = createPinia()
+      setActivePinia(guestPinia)
+
+      const guestMod = await importGameTimerSession(`guest-recover-${Date.now()}`)
+      bindFakeHandlers(guestMod)
+      const { joinRoom, sessionPhase: guestPhase, sessionSuffix: guestSuffix } = guestMod
+      const guestRoom = useGameTimerRoomSessionStore()
+
+      await joinRoom(suffix)
+      assert.equal(guestPhase.value, 'guest_connected')
+      assert.equal(guestRoom.role, 'guest')
+
+      setActivePinia(hostPinia)
+      hostOnConnected({ val: () => false })
+      assert.equal(hostPhase.value, 'reconnecting')
+
+      await waitForPhase(() => hostPhase.value === 'hosting', 'host reconnect recovery')
+
+      setActivePinia(guestPinia)
+      assert.equal(guestPhase.value, 'guest_connected')
+      assert.equal(guestSuffix.value, suffix)
+      assert.equal(guestRoom.role, 'guest')
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'host reconnect recovery must not write deliberate room end',
+      )
+    })
+  },
+)
+
+test(
+  'host reclaim applies preserved snapshot and continues broadcast seq from RTDB',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'GTRECLAIM01'
+    const suffix = 'RECLM1'
+    /** @type {import('../types.js').GameTimerSyncPayload} */
+    const preservedSnapshot = {
+      players: [
+        { id: 'p1', name: 'Host', color: '#111111' },
+        { id: 'p2', name: 'Guest', color: '#222222' },
+      ],
+      activePlayerId: 'p2',
+      turnStartedAt: 1_700_000_000_000,
+      turnStartedRound: 2,
+      round: 2,
+      playerOrderByRound: { 1: ['p1', 'p2'], 2: ['p2', 'p1'] },
+    }
+    const preservedState = encodeHostSnapshot(preservedSnapshot, 5)
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getHostClientId: () => hostStableId,
+      getEnded: () => null,
+      getState: () => preservedState,
+    })
+
+    /** @type {Array<{ path: string, value: { seq?: number } }>} */
+    const broadcastSets = []
+    const actualRtdb = await import('../firebase/rtdb.js')
+    mock.module('../firebase/rtdb.js', {
+      namedExports: {
+        ...actualRtdb,
+        setRtdb: async (ref, value) => {
+          broadcastSets.push({
+            path: [...collectRefPath(ref)].join('/'),
+            value: /** @type {{ seq?: number }} */ (value),
+          })
+        },
+      },
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`reclaim-seq-${Date.now()}`)
+      const { resumeAsHost, sessionPhase, broadcastGameTimerSnapshot } = sessionMod
+      const { getSnapshot, applied } = bindFakeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      useGameTimerRoomSessionStore().setHost(suffix)
+
+      const result = await resumeAsHost(suffix, 1)
+      assert.equal(result.suffix, suffix)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(applied.length, 1)
+      assert.equal(applied[0].activePlayerId, preservedSnapshot.activePlayerId)
+      assert.equal(applied[0].round, preservedSnapshot.round)
+      assert.deepEqual(applied[0].players, preservedSnapshot.players)
+
+      const resumePublish = broadcastSets.find((s) => s.path.endsWith('/state'))
+      assert.ok(resumePublish, 'host reclaim should publish hydrated authoritative state')
+      assert.equal(
+        resumePublish.value.seq,
+        6,
+        'first publish after reclaim should continue from RTDB seq',
+      )
+
+      broadcastSets.length = 0
+      broadcastGameTimerSnapshot(getSnapshot())
+
+      const nextPublish = broadcastSets.find((s) => s.path.endsWith('/state'))
+      assert.ok(nextPublish, 'host broadcast should write authoritative state')
+      assert.equal(nextPublish.value.seq, 7, 'subsequent broadcast should monotonically advance seq')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
@@ -15,6 +15,7 @@ import {
   installRtdbLifecycleMocks,
   withFirebaseEnv,
 } from './sessionRtdbLifecycleHarness.js'
+import { bumpGameTimerReconnectGenerationForTests } from './session.testExports.js'
 
 const facadeReconnectTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
@@ -69,7 +70,7 @@ async function runGuestReconnectWithSupersedeHook(h) {
     sleep: async () => {},
     establishGuest: async () => {
       await h.establishGuest()
-      guestSessionForShellHook?.bumpGameTimerReconnectGenerationForTests()
+      if (guestSessionForShellHook) bumpGameTimerReconnectGenerationForTests(guestSessionForShellHook)
     },
   })
 }
@@ -374,6 +375,98 @@ test(
       const nextPublish = broadcastSets.find((s) => s.path.endsWith('/state'))
       assert.ok(nextPublish, 'host broadcast should write authoritative state')
       assert.equal(nextPublish.value.seq, 7, 'subsequent broadcast should monotonically advance seq')
+    })
+  },
+)
+
+test(
+  'host fatal reconnect exhaustion clears persistence without deliberate room end',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
+
+    mock.module('../../p2p/starRoomReconnectDelay.js', {
+      namedExports: {
+        starRoomReconnectDelayMs: () => 5,
+      },
+    })
+    mock.module('../../p2p/starRoomTiming.js', {
+      namedExports: {
+        RECONNECT_MAX_ATTEMPTS: 3,
+        RECONNECT_INITIAL_PAUSE_MS: 5,
+        RECONNECT_BASE_DELAY_MS: 5,
+        RECONNECT_MAX_DELAY_MS: 5,
+      },
+    })
+
+    const hostStableId = 'GTHOSTFATAL1'
+    const suffix = 'HFATAL1'
+    const joinableState = encodeHostSnapshot(
+      {
+        players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+        activePlayerId: 'p1',
+        turnStartedAt: null,
+        turnStartedRound: null,
+        round: 1,
+        playerOrderByRound: {},
+      },
+      1,
+    )
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    await installHostReconnectShellHook()
+
+    let roomOccupiedByOther = false
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => (roomOccupiedByOther ? Date.now() : null),
+      getHostClientId: () => (roomOccupiedByOther ? 'occupant-other-host' : hostStableId),
+      getEnded: () => null,
+      getState: () => joinableState,
+    })
+
+    await withFirebaseEnv(async () => {
+      setActivePinia(createPinia())
+      const hostRoom = useGameTimerRoomSessionStore()
+
+      const hostMod = await importGameTimerSession(`host-fatal-${Date.now()}`)
+      bindFakeHandlers(hostMod)
+      const { startAsHost, sessionPhase, sessionSuffix } = hostMod
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(hostRoom.role, 'host')
+
+      roomOccupiedByOther = true
+
+      const connectedPath = [...harness.listeners.keys()].find((p) => p.endsWith('connected'))
+      assert.ok(connectedPath)
+      const hostOnConnected = harness.listeners.get(connectedPath)
+      assert.ok(hostOnConnected)
+      hostOnConnected({ val: () => false })
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      const deadline = Date.now() + 3_000
+      while (sessionPhase.value !== 'idle' && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+      assert.equal(sessionPhase.value, 'idle', 'host fatal exhaustion')
+
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(hostRoom.role, null)
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'host fatal exhaustion must not broadcast deliberate room end',
+      )
     })
   },
 )

--- a/src/features/game-timer/p2p/sessionFacadeRoomExit.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeRoomExit.test.js
@@ -1,0 +1,361 @@
+/**
+ * Game Timer facade room exit survival contracts — distinct from Movie Vote semantics.
+ *
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionFacadeRoomExit.test.js
+ *
+ * Unit-level leaveSession / MSG_HOST_ENDED contracts live in sessionRoomLifecycle.test.js
+ * (no RTDB mocks). This file covers RTDB wire paths and cross-feature survival contrast.
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../../movie-vote/core.js'
+import { useGameTimerStore } from '../../../stores/gameTimer.js'
+import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import { encodeHostSnapshot, MSG_HOST_ENDED } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const facadeRoomExitTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {import('../types.js').GameTimerSyncPayload} */
+const JOINABLE_HOST_STATE = encodeHostSnapshot(
+  {
+    players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+    activePlayerId: 'p1',
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+  },
+  1,
+)
+
+/**
+ * @param {{
+ *   phase: { value: string },
+ *   suffix: { value: string | null },
+ *   room: ReturnType<typeof useGameTimerRoomSessionStore>,
+ *   store: ReturnType<typeof useGameTimerStore>,
+ *   expectedCount: number,
+ *   expectedIds?: string[],
+ *   expectedNames?: string[],
+ *   expectedSessionOptions?: {
+ *     hardPassEnabled: boolean,
+ *     hardPassOrderNextRound: boolean,
+ *     fullscreenEnabled: boolean,
+ *     timingStripMode: string,
+ *   },
+ * }} ctx
+ */
+function assertGameTimerRoomExitSurvival(ctx) {
+  assert.equal(ctx.phase.value, 'idle', 'connection posture should be idle after room exit')
+  assert.equal(ctx.suffix.value, null, 'session suffix should clear after room exit')
+  assert.equal(ctx.room.role, null, 'persisted room role should clear after room exit')
+  assert.equal(ctx.room.suffix, null, 'persisted room suffix should clear after room exit')
+  assert.equal(ctx.store.players.length, ctx.expectedCount, 'player roster should survive room exit')
+  if (ctx.expectedIds) {
+    assert.deepEqual(
+      ctx.store.players.map((p) => p.id),
+      ctx.expectedIds,
+      'player roster ids should be unchanged',
+    )
+  }
+  if (ctx.expectedNames) {
+    assert.deepEqual(
+      ctx.store.players.map((p) => p.name),
+      ctx.expectedNames,
+      'player roster names should be unchanged',
+    )
+  }
+  if (ctx.expectedSessionOptions) {
+    const o = ctx.expectedSessionOptions
+    assert.equal(ctx.store.hardPassEnabled, o.hardPassEnabled, 'hardPassEnabled should survive room exit')
+    assert.equal(
+      ctx.store.hardPassOrderNextRound,
+      o.hardPassOrderNextRound,
+      'hardPassOrderNextRound should survive room exit',
+    )
+    assert.equal(ctx.store.fullscreenEnabled, o.fullscreenEnabled, 'fullscreenEnabled should survive room exit')
+    assert.equal(ctx.store.timingStripMode, o.timingStripMode, 'timingStripMode should survive room exit')
+  }
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof installRtdbLifecycleMocks>>} harness
+ * @param {string} [suffixHint]
+ */
+function assertDeliberateHostEndWirePaths(harness, suffixHint) {
+  const endedWrite = harness.sets.find((s) => s.path.endsWith('/ended'))
+  assert.ok(endedWrite, 'deliberate host end should write ended marker')
+  if (suffixHint) {
+    assert.ok(
+      endedWrite.path.includes(suffixHint),
+      `ended marker should target room suffix ${suffixHint}`,
+    )
+  }
+  assert.ok(
+    typeof endedWrite.value === 'number' && endedWrite.value > 0,
+    'ended marker should be a positive timestamp',
+  )
+  assert.ok(
+    harness.removes.some((r) => r.path.endsWith('/hostPing')),
+    'deliberate host end should remove hostPing',
+  )
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @param {string} leaf
+ * @returns {(value: unknown) => void}
+ */
+function listenerAt(listeners, leaf) {
+  const path = [...listeners.keys()].find((p) => p.endsWith(leaf))
+  assert.ok(path, `expected listener on path ending with ${leaf}`)
+  const handler = listeners.get(path)
+  assert.ok(handler)
+  return (value) => handler({ val: () => value })
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importGameTimerSession>>} sessionMod
+ */
+function bindFacadeHandlers(sessionMod) {
+  sessionMod.bindGameTimerP2PHandlers({
+    getSnapshot: () => ({
+      players: [],
+      activePlayerId: null,
+      turnStartedAt: null,
+      turnStartedRound: null,
+      round: 1,
+      playerOrderByRound: {},
+    }),
+    applySnapshot: () => {},
+  })
+}
+
+test(
+  'host leaveSession writes deliberate end wire paths and keeps roster',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'GTEXITHOST1'
+    const suffix = 'EXIT01'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`host-exit-${Date.now()}`)
+      const { startAsHost, leaveSession: hostLeave, sessionPhase, sessionSuffix } = sessionMod
+      bindFacadeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      const room = useGameTimerRoomSessionStore()
+      store.addPlayer({ name: 'Facilitator', color: '#aaaaaa' })
+      store.addPlayer({ name: 'Player Two', color: '#bbbbbb' })
+      const ids = store.players.map((p) => p.id)
+      const names = store.players.map((p) => p.name)
+      store.setHardPassEnabled(true)
+      store.setHardPassOrderNextRound(true)
+      store.setFullscreenEnabled(true)
+      store.setTimingStripMode('non-player')
+      const sessionOptions = {
+        hardPassEnabled: true,
+        hardPassOrderNextRound: true,
+        fullscreenEnabled: true,
+        timingStripMode: 'non-player',
+      }
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      activeRtdbSetsClear(harness)
+
+      hostLeave()
+
+      assertDeliberateHostEndWirePaths(harness, suffix)
+      assertGameTimerRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedCount: 2,
+        expectedIds: ids,
+        expectedNames: names,
+        expectedSessionOptions: sessionOptions,
+      })
+    })
+  },
+)
+
+test(
+  'guest RTDB ended marker matches deliberate host end survival contract',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`guest-ended-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      bindFacadeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      const room = useGameTimerRoomSessionStore()
+      store.addPlayer({ name: 'Guest', color: '#444444' })
+      const ids = store.players.map((p) => p.id)
+      const names = store.players.map((p) => p.name)
+
+      await joinRoom('END123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(harness.listeners, 'ended')(1_700_000_000_000)
+
+      assertGameTimerRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedCount: 1,
+        expectedIds: ids,
+        expectedNames: names,
+      })
+    })
+  },
+)
+
+test(
+  'guest leaveSession after join clears persistence and keeps roster',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`guest-leave-${Date.now()}`)
+      const { joinRoom, leaveSession: guestLeave, sessionPhase, sessionSuffix } = sessionMod
+      bindFacadeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      const room = useGameTimerRoomSessionStore()
+      store.addPlayer({ name: 'Leaver', color: '#555555' })
+      const ids = store.players.map((p) => p.id)
+      const names = store.players.map((p) => p.name)
+
+      await joinRoom('LEAVE1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      guestLeave()
+
+      assertGameTimerRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedCount: 1,
+        expectedIds: ids,
+        expectedNames: names,
+      })
+    })
+  },
+)
+
+test(
+  'room exit survival keeps game timer roster but clears movie vote participants',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const gt = await importGameTimerSession(`gt-exit-contrast-${Date.now()}`)
+      bindFacadeHandlers(gt)
+
+      setActivePinia(createPinia())
+      const gtStore = useGameTimerStore()
+      const gtRoom = useGameTimerRoomSessionStore()
+      gtStore.addPlayer({ name: 'Timer Player', color: '#111111' })
+      const gtIds = gtStore.players.map((p) => p.id)
+      const gtNames = gtStore.players.map((p) => p.name)
+
+      await gt.joinRoom('GTROOM')
+      assert.equal(gt.sessionPhase.value, 'guest_connected')
+
+      gt.handleGuestInbound({ type: MSG_HOST_ENDED })
+
+      assertGameTimerRoomExitSurvival({
+        phase: gt.sessionPhase,
+        suffix: gt.sessionSuffix,
+        room: gtRoom,
+        store: gtStore,
+        expectedCount: 1,
+        expectedIds: gtIds,
+        expectedNames: gtNames,
+      })
+
+      const mv = await import(`../../movie-vote/p2p/session.js?mv-exit-contrast=${Date.now()}`)
+
+      setActivePinia(createPinia())
+      const mvStore = useMovieVoteStore()
+      const mvRoom = useMovieVoteRoomSessionStore()
+      mvStore.setParticipants([
+        { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+        { id: 'guest-1', ready: false, pickCount: 1 },
+      ])
+      mvStore.phase = 'voting'
+      mvRoom.setGuest('MVROOM')
+      mv.sessionPhase.value = 'guest_connected'
+
+      mv.leaveSession()
+
+      assert.equal(mv.sessionPhase.value, 'idle')
+      assert.equal(mvRoom.role, null)
+      assert.equal(mvStore.participants.length, 0, 'movie vote room exit should clear participants')
+      assert.equal(mvStore.phase, 'suggest')
+    })
+  },
+)
+
+/**
+ * @param {{ sets: Array<{ path: string, value: unknown }> }} harness
+ */
+function activeRtdbSetsClear(harness) {
+  harness.sets.length = 0
+  harness.removes.length = 0
+}
+
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionRoomLifecycle.test.js
+++ b/src/features/game-timer/p2p/sessionRoomLifecycle.test.js
@@ -19,6 +19,11 @@ test('leaveSession clears room persistence but keeps game timer roster', () => {
   store.addPlayer({ name: 'Ada', color: '#111111' })
   store.addPlayer({ name: 'Bob', color: '#222222' })
   const ids = store.players.map((p) => p.id)
+  const names = store.players.map((p) => p.name)
+  store.setHardPassEnabled(true)
+  store.setHardPassOrderNextRound(true)
+  store.setFullscreenEnabled(true)
+  store.setTimingStripMode('non-player')
   room.setHost('abc123')
 
   leaveSession()
@@ -32,6 +37,14 @@ test('leaveSession clears room persistence but keeps game timer roster', () => {
     store.players.map((p) => p.id),
     ids,
   )
+  assert.deepEqual(
+    store.players.map((p) => p.name),
+    names,
+  )
+  assert.equal(store.hardPassEnabled, true)
+  assert.equal(store.hardPassOrderNextRound, true)
+  assert.equal(store.fullscreenEnabled, true)
+  assert.equal(store.timingStripMode, 'non-player')
 })
 
 test('guest host-ended protocol notice clears room persistence but keeps roster', () => {

--- a/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
@@ -6,6 +6,7 @@ import { afterEach, mock, test } from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { encodeGuestHello, parseHostMessage } from './protocol.js'
 import {
   createRtdbLifecycleAfterEach,
   importGameTimerSession,
@@ -15,6 +16,32 @@ import {
 
 const rtdbLifecycleTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/**
+ * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {unknown} payload
+ */
+function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
+  const inboxParent = `gameTimerRooms/${suffix}/inbox`
+  harness.emitChildAdded(inboxParent, guestStableId)
+  harness.emitValue(`${inboxParent}/${guestStableId}`, payload)
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {Array<{ seq: number }>}
+ */
+function stateSeqWrites(sets) {
+  return sets
+    .filter((entry) => entry.path.endsWith('/state'))
+    .map((entry) => {
+      const parsed = parseHostMessage(entry.value)
+      assert.ok(parsed, 'state write must be a host snapshot message')
+      return { seq: parsed.seq }
+    })
+}
 
 test(
   'guest RTDB ended marker clears room persistence but keeps roster',
@@ -87,6 +114,203 @@ test(
       assert.equal(remoteHostPresent.value, false)
       assert.equal(store.players.length, 1)
       assert.equal(store.players[0].name, 'Guest')
+    })
+  },
+)
+
+test(
+  'loose host startAsHost publishes initial authoritative snapshot',
+  rtdbLifecycleTests,
+  async () => {
+    mock.reset()
+    const hostStableId = 'GTHOSTLIFE01'
+    const suffix = 'LIFE01'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`host-start-${Date.now()}`)
+      const { startAsHost, sessionPhase, bindGameTimerP2PHandlers } = sessionMod
+
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      store.addPlayer({ name: 'Host', color: '#111111' })
+      bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: store.players.map((p) => ({
+            id: p.id,
+            name: p.name,
+            color: p.color,
+          })),
+          activePlayerId: store.players[0]?.id ?? null,
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: {},
+        }),
+        applySnapshot: () => {},
+      })
+
+      const result = await startAsHost(3)
+      assert.equal(result.suffix, suffix)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const broadcasts = stateSeqWrites(harness.sets)
+      assert.equal(broadcasts.length, 1)
+      assert.equal(broadcasts[0].seq, 1)
+    })
+  },
+)
+
+test(
+  'loose host guest hello rebroadcasts snapshot with increasing seq',
+  rtdbLifecycleTests,
+  async () => {
+    mock.reset()
+    const hostStableId = 'GTHOSTLIFE02'
+    const guestStableId = 'GTGUESTLIFE2'
+    const suffix = 'LIFE02'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`host-hello-${Date.now()}`)
+      const { startAsHost, sessionPhase, bindGameTimerP2PHandlers } = sessionMod
+
+      setActivePinia(createPinia())
+      bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+          activePlayerId: 'p1',
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: { 1: ['p1'] },
+        }),
+        applySnapshot: () => {},
+      })
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const beforeHello = harness.sets.length
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeGuestHello(guestStableId))
+
+      const helloBroadcasts = stateSeqWrites(harness.sets.slice(beforeHello))
+      assert.equal(helloBroadcasts.length, 1)
+      assert.equal(helloBroadcasts[0].seq, 2)
+    })
+  },
+)
+
+test(
+  'guest leaveSession clears join persistence and returns tab to idle',
+  rtdbLifecycleTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks()
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`guest-leave-${Date.now()}`)
+      const { joinRoom, leaveSession, sessionPhase, sessionSuffix } = sessionMod
+
+      setActivePinia(createPinia())
+      const room = useGameTimerRoomSessionStore()
+      const store = useGameTimerStore()
+      store.addPlayer({ name: 'Guest', color: '#666666' })
+
+      await joinRoom('LEAVE1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+
+      leaveSession()
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+      assert.equal(store.players.length, 1, 'room exit should keep roster on guest tab')
+    })
+  },
+)
+
+test(
+  'host leaveSession writes deliberate ended marker and clears host persistence',
+  rtdbLifecycleTests,
+  async () => {
+    mock.reset()
+    const hostStableId = 'GTHOSTLIFE03'
+    const suffix = 'LIFE03'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`host-leave-${Date.now()}`)
+      const { startAsHost, leaveSession, sessionPhase, bindGameTimerP2PHandlers } = sessionMod
+
+      setActivePinia(createPinia())
+      const room = useGameTimerRoomSessionStore()
+      bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: [],
+          activePlayerId: null,
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: {},
+        }),
+        applySnapshot: () => {},
+      })
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(room.role, 'host')
+
+      const setsBeforeLeave = harness.sets.length
+      leaveSession()
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(room.role, null)
+      assert.ok(
+        harness.sets.slice(setsBeforeLeave).some((s) => s.path.endsWith('/ended')),
+        'deliberate host end should write ended marker',
+      )
     })
   },
 )

--- a/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
@@ -7,6 +7,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
 import { encodeGuestHello, parseHostMessage } from './protocol.js'
+import { simulateHostInboxMessage } from '../../p2p/test/hostInboxHarness.js'
 import {
   createRtdbLifecycleAfterEach,
   importGameTimerSession,
@@ -16,18 +17,6 @@ import {
 
 const rtdbLifecycleTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
-
-/**
- * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
- * @param {string} suffix
- * @param {string} guestStableId
- * @param {unknown} payload
- */
-function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
-  const inboxParent = `gameTimerRooms/${suffix}/inbox`
-  harness.emitChildAdded(inboxParent, guestStableId)
-  harness.emitValue(`${inboxParent}/${guestStableId}`, payload)
-}
 
 /**
  * @param {Array<{ path: string, value: unknown }>} sets
@@ -218,7 +207,7 @@ test(
       assert.equal(sessionPhase.value, 'hosting')
 
       const beforeHello = harness.sets.length
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeGuestHello(guestStableId))
+      simulateHostInboxMessage(harness, 'gameTimerRooms', suffix, guestStableId, encodeGuestHello(guestStableId))
 
       const helloBroadcasts = stateSeqWrites(harness.sets.slice(beforeHello))
       assert.equal(helloBroadcasts.length, 1)

--- a/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
@@ -1,124 +1,55 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionRoomLifecycleRtdb.test.js
+ */
 import assert from 'node:assert/strict'
 import { afterEach, mock, test } from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
-
-const REQUIRED_FIREBASE_ENV = {
-  VITE_FIREBASE_API_KEY: 'test-api-key',
-  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
-  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
-  VITE_FIREBASE_PROJECT_ID: 'test-project',
-  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
-}
-
-/** @param {() => void | Promise<void>} fn */
-async function withFirebaseEnv(fn) {
-  const saved = {}
-  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-    saved[key] = process.env[key]
-    process.env[key] = REQUIRED_FIREBASE_ENV[key]
-  }
-  try {
-    await fn()
-  } finally {
-    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-      if (saved[key] === undefined) delete process.env[key]
-      else process.env[key] = saved[key]
-    }
-  }
-}
-
-/**
- * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
- * @returns {string}
- */
-function refPath(ref) {
-  const parts = []
-  let cur = ref
-  while (cur) {
-    if (cur.key) parts.unshift(cur.key)
-    cur = cur.parent ?? null
-  }
-  return parts.join('/')
-}
-
-/**
- * @returns {Promise<{
- *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
- * }>}
- */
-async function installRtdbLifecycleMocks() {
-  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
-  const listeners = new Map()
-  const actual = await import('firebase/database')
-
-  mock.module('firebase/database', {
-    namedExports: {
-      ...actual,
-      get: async (ref) => {
-        if (ref.key === 'hostPing') return { val: () => Date.now() }
-        if (ref.key === 'ended') return { val: () => null }
-        return { val: () => null }
-      },
-      set: async () => {},
-      remove: async () => {},
-      onDisconnect: () => ({
-        remove: () => Promise.resolve(),
-        set: () => Promise.resolve(),
-      }),
-      onChildAdded: () => () => {},
-      onValue: (ref, cb) => {
-        listeners.set(refPath(ref), cb)
-        return () => {}
-      },
-    },
-  })
-
-  return { listeners }
-}
-
-/** @param {string} nonce */
-async function importSession(nonce) {
-  return import(`./session.js?rtdb-lifecycle=${nonce}`)
-}
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
 
 const rtdbLifecycleTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
 
 test(
   'guest RTDB ended marker clears room persistence but keeps roster',
   rtdbLifecycleTests,
   async () => {
-  mock.reset()
-  const { listeners } = await installRtdbLifecycleMocks()
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks()
 
-  await withFirebaseEnv(async () => {
-    const { joinRoom, sessionPhase, sessionSuffix } = await importSession(
-      String(Date.now()),
-    )
-    setActivePinia(createPinia())
-    const store = useGameTimerStore()
-    const room = useGameTimerRoomSessionStore()
-    store.addPlayer({ name: 'Guest', color: '#444444' })
-    const playerIds = store.players.map((p) => p.id)
+    await withFirebaseEnv(async () => {
+      const { joinRoom, sessionPhase, sessionSuffix } = await importGameTimerSession(
+        String(Date.now()),
+      )
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      const room = useGameTimerRoomSessionStore()
+      store.addPlayer({ name: 'Guest', color: '#444444' })
+      const playerIds = store.players.map((p) => p.id)
 
-    await joinRoom('ABC123')
-    assert.equal(sessionPhase.value, 'guest_connected')
-    assert.equal(room.role, 'guest')
+      await joinRoom('ABC123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
 
-    const endedPath = [...listeners.keys()].find((p) => p.endsWith('ended'))
-    assert.ok(endedPath, 'guest wire should subscribe to ended')
-    const onEnded = listeners.get(endedPath)
-    assert.ok(onEnded)
-    onEnded({ val: () => 1_700_000_000_000 })
+      const endedPath = [...listeners.keys()].find((p) => p.endsWith('ended'))
+      assert.ok(endedPath, 'guest wire should subscribe to ended')
+      const onEnded = listeners.get(endedPath)
+      assert.ok(onEnded)
+      onEnded({ val: () => 1_700_000_000_000 })
 
-    assert.equal(sessionPhase.value, 'idle')
-    assert.equal(sessionSuffix.value, null)
-    assert.equal(room.role, null)
-    assert.equal(room.suffix, null)
-    assert.equal(store.players.length, 1)
-    assert.deepEqual(store.players.map((p) => p.id), playerIds)
-  })
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+      assert.equal(store.players.length, 1)
+      assert.deepEqual(store.players.map((p) => p.id), playerIds)
+    })
   },
 )
 
@@ -126,41 +57,38 @@ test(
   'guest RTDB hostPing removal stays connected and keeps room persistence',
   rtdbLifecycleTests,
   async () => {
-  mock.reset()
-  const { listeners } = await installRtdbLifecycleMocks()
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks()
 
-  await withFirebaseEnv(async () => {
-    const { joinRoom, remoteHostPresent, sessionPhase, sessionSuffix } = await importSession(
-      String(Date.now()),
-    )
-    setActivePinia(createPinia())
-    const store = useGameTimerStore()
-    const room = useGameTimerRoomSessionStore()
-    store.addPlayer({ name: 'Guest', color: '#555555' })
+    await withFirebaseEnv(async () => {
+      const { joinRoom, remoteHostPresent, sessionPhase, sessionSuffix } =
+        await importGameTimerSession(String(Date.now()))
+      setActivePinia(createPinia())
+      const store = useGameTimerStore()
+      const room = useGameTimerRoomSessionStore()
+      store.addPlayer({ name: 'Guest', color: '#555555' })
 
-    await joinRoom('ABC123')
-    assert.equal(sessionPhase.value, 'guest_connected')
-    assert.equal(room.role, 'guest')
-    assert.equal(room.suffix, 'ABC123')
+      await joinRoom('ABC123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'ABC123')
 
-    const hostPingPath = [...listeners.keys()].find((p) => p.endsWith('hostPing'))
-    assert.ok(hostPingPath, 'guest wire should subscribe to hostPing')
-    const onHostPing = listeners.get(hostPingPath)
-    assert.ok(onHostPing)
-    onHostPing({ val: () => Date.now() })
-    onHostPing({ val: () => null })
+      const hostPingPath = [...listeners.keys()].find((p) => p.endsWith('hostPing'))
+      assert.ok(hostPingPath, 'guest wire should subscribe to hostPing')
+      const onHostPing = listeners.get(hostPingPath)
+      assert.ok(onHostPing)
+      onHostPing({ val: () => Date.now() })
+      onHostPing({ val: () => null })
 
-    assert.equal(sessionPhase.value, 'guest_connected')
-    assert.equal(sessionSuffix.value, 'ABC123')
-    assert.equal(room.role, 'guest')
-    assert.equal(room.suffix, 'ABC123')
-    assert.equal(remoteHostPresent.value, false)
-    assert.equal(store.players.length, 1)
-    assert.equal(store.players[0].name, 'Guest')
-  })
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(sessionSuffix.value, 'ABC123')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'ABC123')
+      assert.equal(remoteHostPresent.value, false)
+      assert.equal(store.players.length, 1)
+      assert.equal(store.players[0].name, 'Guest')
+    })
   },
 )
 
-afterEach(async () => {
-  mock.reset()
-})
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.js
+++ b/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.js
@@ -1,5 +1,5 @@
 /**
- * Shared RTDB mocks for Game Timer P2P lifecycle / facade contract tests.
+ * Game Timer RTDB lifecycle harness — thin wrapper over shared star-room test mocks.
  * Requires `node --experimental-test-module-mocks`.
  *
  * ## Module hygiene
@@ -7,193 +7,18 @@
  * - Prefer {@link importGameTimerSession} with a unique nonce per test so each case gets a fresh
  *   `session.js` instance (isolated `nextSeq`, `lastSeenSeq`, and listener maps).
  * - When reusing one session module (e.g. static `import('./session.js')`), call
- *   `teardownSession()` then {@link resetGameTimerP2PWireStateForTests} from that module in
- *   `afterEach` so parallel runs do not leak handlers or seq counters.
+ *   `teardownSession()` then reset helpers from `session.testExports.js` in `afterEach`.
  * - Use {@link createRtdbLifecycleAfterEach} for standard mock/timer cleanup after each case.
  */
 
-import { mock } from 'node:test'
-
-/** @type {Array<{ path: string, value: unknown }>} */
-let activeRtdbSets = []
-/** @type {Array<{ path: string }>} */
-let activeRtdbRemoves = []
-
-const REQUIRED_FIREBASE_ENV = {
-  VITE_FIREBASE_API_KEY: 'test-api-key',
-  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
-  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
-  VITE_FIREBASE_PROJECT_ID: 'test-project',
-  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
-}
-
-/** @param {() => void | Promise<void>} fn */
-export async function withFirebaseEnv(fn) {
-  const saved = {}
-  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-    saved[key] = process.env[key]
-    process.env[key] = REQUIRED_FIREBASE_ENV[key]
-  }
-  try {
-    await fn()
-  } finally {
-    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-      if (saved[key] === undefined) delete process.env[key]
-      else process.env[key] = saved[key]
-    }
-  }
-}
-
-/**
- * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
- * @returns {string}
- */
-export function refPath(ref) {
-  const parts = []
-  let cur = ref
-  while (cur) {
-    if (cur.key) parts.unshift(cur.key)
-    cur = cur.parent ?? null
-  }
-  return parts.join('/')
-}
-
-/**
- * @param {string} dotPath
- * @returns {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }}
- */
-function buildRef(dotPath) {
-  const parts = dotPath.split('/').filter(Boolean)
-  /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null} */
-  let node = null
-  for (const part of parts) {
-    node = { key: part, parent: node }
-  }
-  return /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} */ (
-    node ?? { key: null, parent: null }
-  )
-}
-
-/**
- * @param {{
- *   getHostPing?: () => unknown,
- *   getEnded?: () => unknown,
- *   getHostClientId?: () => unknown,
- *   getState?: () => unknown,
- * }} [opts]
- * @returns {Promise<{
- *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
- *   sets: Array<{ path: string, value: unknown }>,
- *   removes: Array<{ path: string }>,
- *   childAddedParentPaths: () => string[],
- *   emitChildAdded: (parentPath: string, childKey: string) => void,
- *   emitValue: (path: string, value: unknown) => void,
- * }>}
- */
-export async function installRtdbLifecycleMocks(opts = {}) {
-  activeRtdbSets = []
-  activeRtdbRemoves = []
-
-  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
-  const listeners = new Map()
-  /** @type {Map<string, Set<(snap: { key: string | null, ref: ReturnType<typeof buildRef> }) => void>>} */
-  const childAddedHandlers = new Map()
-
-  /**
-   * @param {string} parentPath
-   * @param {string} childKey
-   */
-  function emitChildAdded(parentPath, childKey) {
-    const handlers = childAddedHandlers.get(parentPath)
-    if (!handlers?.size) return
-    const childPath = `${parentPath}/${childKey}`
-    const snap = { key: childKey, ref: buildRef(childPath) }
-    for (const handler of handlers) handler(snap)
-  }
-
-  /**
-   * @param {string} path
-   * @param {unknown} value
-   */
-  function emitValue(path, value) {
-    const handler = listeners.get(path)
-    if (handler) handler({ val: () => value })
-  }
-
-  const actual = await import('firebase/database')
-
-  mock.module('firebase/database', {
-    namedExports: {
-      ...actual,
-      get: async (ref) => {
-        if (ref.key === 'hostPing') {
-          return {
-            val: () => (opts.getHostPing !== undefined ? opts.getHostPing() : Date.now()),
-          }
-        }
-        if (ref.key === 'ended') {
-          return { val: () => (opts.getEnded !== undefined ? opts.getEnded() : null) }
-        }
-        if (ref.key === 'hostClientId') {
-          return {
-            val: () => (opts.getHostClientId !== undefined ? opts.getHostClientId() : null),
-          }
-        }
-        if (ref.key === 'state') {
-          return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
-        }
-        return { val: () => null }
-      },
-      set: async (ref, value) => {
-        activeRtdbSets.push({ path: refPath(ref), value })
-      },
-      remove: async (ref) => {
-        activeRtdbRemoves.push({ path: refPath(ref) })
-      },
-      onDisconnect: () => ({
-        remove: () => Promise.resolve(),
-        set: () => Promise.resolve(),
-      }),
-      onChildAdded: (ref, cb) => {
-        const path = refPath(ref)
-        if (!childAddedHandlers.has(path)) childAddedHandlers.set(path, new Set())
-        childAddedHandlers.get(path)?.add(cb)
-        return () => childAddedHandlers.get(path)?.delete(cb)
-      },
-      onValue: (ref, cb) => {
-        const path = refPath(ref)
-        listeners.set(path, cb)
-        return () => listeners.delete(path)
-      },
-    },
-  })
-
-  return {
-    listeners,
-    get sets() {
-      return activeRtdbSets
-    },
-    get removes() {
-      return activeRtdbRemoves
-    },
-    childAddedParentPaths: () => [...childAddedHandlers.keys()],
-    emitChildAdded,
-    emitValue,
-  }
-}
+export {
+  createRtdbLifecycleAfterEach,
+  installRtdbLifecycleMocks,
+  refPath,
+  withFirebaseEnv,
+} from '../../p2p/test/rtdbLifecycleHarness.js'
 
 /** @param {string} nonce */
 export async function importGameTimerSession(nonce) {
   return import(`./session.js?gt-rtdb-lifecycle=${nonce}`)
-}
-
-/**
- * @param {typeof import('node:test').mock} mockRef
- * @returns {() => Promise<void>}
- */
-export function createRtdbLifecycleAfterEach(mockRef) {
-  return async () => {
-    mockRef.timers?.reset?.()
-    mockRef.reset()
-  }
 }

--- a/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.js
+++ b/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.js
@@ -1,14 +1,14 @@
 /**
- * Shared RTDB mocks for Movie Vote P2P lifecycle / facade contract tests.
+ * Shared RTDB mocks for Game Timer P2P lifecycle / facade contract tests.
  * Requires `node --experimental-test-module-mocks`.
  *
  * ## Module hygiene
  *
- * - Prefer {@link importMovieVoteSession} with a unique nonce per test so each case gets a fresh
- *   `session.js` instance (isolated maps, seq counters, and listener registrations).
+ * - Prefer {@link importGameTimerSession} with a unique nonce per test so each case gets a fresh
+ *   `session.js` instance (isolated `nextSeq`, `lastSeenSeq`, and listener maps).
  * - When reusing one session module (e.g. static `import('./session.js')`), call
- *   `teardownSession()` then {@link resetMovieVoteFacadeWireStateForTests} from that module in
- *   `afterEach` so parallel runs do not leak handlers, `nextSeq`, or `lastSeenSeq`.
+ *   `teardownSession()` then {@link resetGameTimerP2PWireStateForTests} from that module in
+ *   `afterEach` so parallel runs do not leak handlers or seq counters.
  * - Use {@link createRtdbLifecycleAfterEach} for standard mock/timer cleanup after each case.
  */
 
@@ -80,8 +80,6 @@ function buildRef(dotPath) {
  *   getEnded?: () => unknown,
  *   getHostClientId?: () => unknown,
  *   getState?: () => unknown,
- *   getWelcome?: () => unknown,
- *   getGuestOnline?: () => unknown,
  * }} [opts]
  * @returns {Promise<{
  *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
@@ -144,14 +142,6 @@ export async function installRtdbLifecycleMocks(opts = {}) {
         if (ref.key === 'state') {
           return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
         }
-        if (ref.key === 'welcome') {
-          return { val: () => (opts.getWelcome !== undefined ? opts.getWelcome() : null) }
-        }
-        if (ref.key === 'guestOnline') {
-          return {
-            val: () => (opts.getGuestOnline !== undefined ? opts.getGuestOnline() : null),
-          }
-        }
         return { val: () => null }
       },
       set: async (ref, value) => {
@@ -193,8 +183,8 @@ export async function installRtdbLifecycleMocks(opts = {}) {
 }
 
 /** @param {string} nonce */
-export async function importMovieVoteSession(nonce) {
-  return import(`./session.js?mv-rtdb-lifecycle=${nonce}`)
+export async function importGameTimerSession(nonce) {
+  return import(`./session.js?gt-rtdb-lifecycle=${nonce}`)
 }
 
 /**

--- a/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.test.js
+++ b/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.test.js
@@ -1,0 +1,114 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/game-timer/p2p/sessionRtdbLifecycleHarness.test.js
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { encodeHostSnapshot } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importGameTimerSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const harnessTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+test(
+  'importGameTimerSession loads isolated session module per nonce',
+  harnessTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks()
+
+    await withFirebaseEnv(async () => {
+      const modA = await importGameTimerSession(`iso-a-${Date.now()}`)
+      const modB = await importGameTimerSession(`iso-b-${Date.now()}`)
+      assert.notEqual(modA, modB)
+      assert.equal(modA.sessionPhase.value, 'idle')
+      assert.equal(modB.sessionPhase.value, 'idle')
+    })
+  },
+)
+
+test(
+  'resetGameTimerP2PWireStateForTests clears guest lastSeenSeq between inbound applies',
+  harnessTests,
+  async () => {
+    mock.reset()
+    const hostSnapshot = encodeHostSnapshot(
+      {
+        players: [{ id: 'p1', name: 'Host', color: '#111111' }],
+        activePlayerId: 'p1',
+        turnStartedAt: null,
+        turnStartedRound: null,
+        round: 1,
+        playerOrderByRound: {},
+      },
+      3,
+    )
+
+    const harness = await installRtdbLifecycleMocks()
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importGameTimerSession(`last-seen-${Date.now()}`)
+      const {
+        joinRoom,
+        teardownSession,
+        resetGameTimerP2PWireStateForTests,
+        bindGameTimerP2PHandlers,
+      } = sessionMod
+
+      setActivePinia(createPinia())
+      let applyCount = 0
+      bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: [],
+          activePlayerId: null,
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: {},
+        }),
+        applySnapshot: () => {
+          applyCount += 1
+        },
+      })
+
+      await joinRoom('LAST01')
+      const statePath = [...harness.listeners.keys()].find((p) => p.endsWith('/state'))
+      assert.ok(statePath)
+      harness.emitValue(statePath, hostSnapshot)
+      assert.equal(applyCount, 1)
+
+      harness.emitValue(statePath, hostSnapshot)
+      assert.equal(applyCount, 1, 'duplicate seq should be ignored while module is live')
+
+      teardownSession()
+      resetGameTimerP2PWireStateForTests()
+      applyCount = 0
+      bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: [],
+          activePlayerId: null,
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: {},
+        }),
+        applySnapshot: () => {
+          applyCount += 1
+        },
+      })
+
+      await joinRoom('LAST01')
+      const statePathAfterReset = [...harness.listeners.keys()].find((p) => p.endsWith('/state'))
+      assert.ok(statePathAfterReset)
+      harness.emitValue(statePathAfterReset, hostSnapshot)
+      assert.equal(applyCount, 1, 'reset should allow the same seq to apply again on reuse')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.test.js
+++ b/src/features/game-timer/p2p/sessionRtdbLifecycleHarness.test.js
@@ -11,6 +11,7 @@ import {
   installRtdbLifecycleMocks,
   withFirebaseEnv,
 } from './sessionRtdbLifecycleHarness.js'
+import { resetGameTimerP2PWireStateForTests } from './session.testExports.js'
 
 const harnessTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
@@ -53,12 +54,7 @@ test(
 
     await withFirebaseEnv(async () => {
       const sessionMod = await importGameTimerSession(`last-seen-${Date.now()}`)
-      const {
-        joinRoom,
-        teardownSession,
-        resetGameTimerP2PWireStateForTests,
-        bindGameTimerP2PHandlers,
-      } = sessionMod
+      const { joinRoom, teardownSession, bindGameTimerP2PHandlers } = sessionMod
 
       setActivePinia(createPinia())
       let applyCount = 0
@@ -86,7 +82,7 @@ test(
       assert.equal(applyCount, 1, 'duplicate seq should be ignored while module is live')
 
       teardownSession()
-      resetGameTimerP2PWireStateForTests()
+      resetGameTimerP2PWireStateForTests(sessionMod)
       applyCount = 0
       bindGameTimerP2PHandlers({
         getSnapshot: () => ({

--- a/src/features/movie-vote/CONTEXT.md
+++ b/src/features/movie-vote/CONTEXT.md
@@ -70,6 +70,12 @@ _Avoid_: Treating the host as “not a **participant**” in copy about counts.
 
 Guest → host bundle of provisional **movie picks** plus suggest-phase signals during **suggest phase**.
 
+### Guest reconnect coherence (Movie Vote)
+
+On **guest** refresh or reattach, **stable client identity** on hello remaps to the same **participant id** when the **host** preserves the binding; the **host** re-attaches **draft payload** and **ranking** to that seat and rebroadcasts **room** authority. The **guest** mirrors public state—local ballot or vote copies are provisional until acknowledged.
+
+_Avoid_: Promoting local **ballot order**, **ranking**, or tallies as truth before the next **host** broadcast.
+
 ### Ready flag
 
 Per-**participant** indicator that they finished nominating while drafts can still change.
@@ -184,6 +190,12 @@ Local star-room shell posture for transport and listeners (`idle`, `connecting`,
 
 _Avoid_: Saying “phase” when you mean connectivity or reconnect banners.
 
+### Room exit survival
+
+After **room exit**, all **room**-scoped collaboration resets—**phase**, **participants**, **ballot**, votes, results, **voting method** (back to default **instant-runoff voting**). Personal **movie pick** drafts and **browser fullscreen toggle** preference survive so a returning user is not forced to re-nominate from scratch.
+
+_Avoid_: Treating **room exit** like **resetSessionSoft** (join/resume hygiene); exit is a full collaborative wipe except personal prep and display prefs.
+
 ### Vote progress
 
 Submitted vs total ballot submission counts surfaced while ballots are still arriving.
@@ -200,12 +212,13 @@ _Avoid_: **Black’s method**, **Borda tiebreak**, subset runoffs, or any second
 
 ## Relationships
 
-- **Phase** (collaborative flow) and **connection status** (shell connectivity) stay independent—do not merge them in UI or persisted **room** fields.
+- **Phase** (collaborative flow) and **connection status** (shell **connection posture**) are two independent contracts—do not merge them in UI, diagnostics, or persisted **room** fields.
+- **Room exit survival** differs from Game Timer: Movie Vote wipes **room** authority; Game Timer keeps the facilitator **roster**—see [**Star-room P2P**](../p2p/CONTEXT.md) **room exit**.
 - A **participant** submits many **movie picks** during **suggest phase**, shipped incrementally inside **draft payloads** guarded by **ready flags**.
 - The **host** is a **participant** via the **host participant seat**; **guests** receive **participant id** seat labels from the **host** while **stable client identity** is the canonical browser principal for reconnect and per-**participant** persistence.
 - **Room**-level authority (**phase**, **ballot order**, **ballot compilation**) is **host**-owned; **participant**-scoped state (**draft payload**, **ready flag**, **ranking**) is **participant**-owned at persistence while the **host** still aggregates for compilation and tally.
-- The **host** is never reassigned for a **room**; **guest** **participants** do not lose the **room** because the **host** tab sleeps or disconnects—only **host**-only progression waits on the **host**.
-- What collaborators must agree on in a **room** has a single authoritative shared copy; each browser mirrors that copy locally for UI rather than treating local state as a competing source of truth.
+- The **host** is never reassigned for a **room**; **host abrupt disconnect** does not end the **room** for **guests**—**connection posture** stays `guest_connected`, last **room** authority remains, **host**-only moves wait, and **guest online signal** / readiness tallies follow **strict guest presence** rules until **host reclaim**.
+- What collaborators must agree on in a **room** has a single authoritative shared copy; each browser mirrors that copy locally for UI rather than treating local state as a competing source of truth. **Host** state rebroadcasts use **monotonic authority broadcast** **seq**; **guests** never apply regressive **room** authority.
 - **Unique suggested movie count** summarizes nomination breadth before compilation locks **ballot order**.
 - Compilation reduces picks to mutually distinct **ballot movies** keyed by TMDB id or **normalized custom title**.
 - **Voting phase** consumes exactly the compiled ballot; each **participant** submits one **ranking**.

--- a/src/features/movie-vote/p2p/guestInboundWire.js
+++ b/src/features/movie-vote/p2p/guestInboundWire.js
@@ -1,0 +1,67 @@
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import {
+  isHostEndedNotice,
+  isHostPing,
+  parseHostVisibility,
+  parseState,
+  parseWelcome,
+} from './protocol.js'
+
+/**
+ * @param {object} deps
+ * @param {import('vue').Ref<boolean>} deps.remoteHostTabVisible
+ * @param {() => number} deps.getLastSeenSeq
+ * @param {(n: number) => void} deps.setLastSeenSeq
+ * @param {(payload: import('../types.js').MovieVotePublicPayload) => void} deps.applyPublicPayload
+ * @param {() => void} deps.onGuestHostEnded
+ */
+export function createGuestInboundWire(deps) {
+  /**
+   * @param {unknown} raw
+   */
+  function handleGuestWelcome(raw) {
+    const welcome = parseWelcome(raw)
+    if (!welcome) return
+    useMovieVoteStore().setMyParticipantId(welcome.participantId)
+  }
+
+  /**
+   * @param {unknown} raw
+   */
+  function handleGuestState(raw) {
+    const st = parseState(raw)
+    if (!st) return
+    if (st.seq <= deps.getLastSeenSeq()) return
+    deps.setLastSeenSeq(st.seq)
+    try {
+      deps.applyPublicPayload(st.payload)
+    } catch {
+      return
+    }
+  }
+
+  /**
+   * @param {unknown} raw
+   */
+  function handleGuestInbound(raw) {
+    if (isHostEndedNotice(raw)) {
+      deps.onGuestHostEnded()
+      return
+    }
+    if (isHostPing(raw)) {
+      return
+    }
+    const vis = parseHostVisibility(raw)
+    if (vis) {
+      deps.remoteHostTabVisible.value = vis.visible
+      return
+    }
+    if (parseWelcome(raw)) {
+      handleGuestWelcome(raw)
+      return
+    }
+    handleGuestState(raw)
+  }
+
+  return { handleGuestWelcome, handleGuestState, handleGuestInbound }
+}

--- a/src/features/movie-vote/p2p/guestOnlineWire.js
+++ b/src/features/movie-vote/p2p/guestOnlineWire.js
@@ -1,0 +1,119 @@
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+
+const GUEST_REMOVAL_GRACE_MS = 45_000
+
+/**
+ * @param {object} deps
+ * @param {ReturnType<import('./movieVoteWireState.js').createMovieVoteWireState>} deps.wireState
+ * @param {(suffix: string, path: string) => import('firebase/database').DatabaseReference} deps.roomChild
+ * @param {(ref: import('firebase/database').DatabaseReference, value: unknown) => Promise<void>} deps.setRtdb
+ * @param {(ref: import('firebase/database').DatabaseReference) => import('firebase/database').OnDisconnect} deps.onDisconnect
+ * @param {typeof onChildAdded} deps.onChildAdded
+ * @param {typeof onValue} deps.onValue
+ * @param {(unsub: () => void) => void} deps.trackFeatureUnsub
+ * @param {() => boolean} deps.isHostRole
+ * @param {() => string} deps.getSessionPhase
+ * @param {() => void} deps.tryCompileBallot
+ * @param {() => void} deps.tryFinishVoting
+ * @param {() => void} deps.hostBroadcastState
+ * @param {(fn: () => void, ms: number) => ReturnType<typeof setTimeout>} [deps.scheduleTimer]
+ * @param {(id: ReturnType<typeof setTimeout>) => void} [deps.cancelTimer]
+ */
+export function createGuestOnlineWire(deps) {
+  const { wireState } = deps
+  const {
+    stableIdToParticipant,
+    activeGuestStableIds,
+    guestDrafts,
+    pendingRemovalTimers,
+  } = wireState
+  const scheduleTimer = deps.scheduleTimer ?? ((fn, ms) => setTimeout(fn, ms))
+  const cancelTimer = deps.cancelTimer ?? ((id) => clearTimeout(id))
+  /**
+   * @param {string} suffix
+   * @param {string} stableId
+   */
+  async function markGuestOnline(suffix, stableId) {
+    const onlineRef = deps.roomChild(suffix, `guestOnline/${stableId}`)
+    await deps.setRtdb(onlineRef, true)
+    deps.onDisconnect(onlineRef).set(false)
+  }
+
+  /**
+   * @param {string} suffix
+   * @param {string} stableId
+   */
+  async function markGuestOffline(suffix, stableId) {
+    await deps.setRtdb(deps.roomChild(suffix, `guestOnline/${stableId}`), false).catch(() => {})
+  }
+
+  function scheduleParticipantRemoval(pid) {
+    if (!guestDrafts.has(pid)) return
+    const stableId = [...stableIdToParticipant.entries()].find(([, p]) => p === pid)?.[0]
+    if (stableId && activeGuestStableIds.has(stableId)) return
+    const existing = pendingRemovalTimers.get(pid)
+    if (existing) cancelTimer(existing)
+    const t = scheduleTimer(() => {
+      pendingRemovalTimers.delete(pid)
+      if (stableId && activeGuestStableIds.has(stableId)) return
+      guestDrafts.delete(pid)
+      if (stableId) {
+        stableIdToParticipant.delete(stableId)
+        activeGuestStableIds.delete(stableId)
+      }
+      if (deps.isHostRole() && deps.getSessionPhase() === 'hosting') {
+        useMovieVoteStore().removeParticipantFromVote(pid)
+        deps.tryCompileBallot()
+        deps.tryFinishVoting()
+        deps.hostBroadcastState()
+      }
+    }, GUEST_REMOVAL_GRACE_MS)
+    pendingRemovalTimers.set(pid, t)
+  }
+
+  /**
+   * @param {string} pid
+   */
+  function cancelParticipantRemoval(pid) {
+    const t = pendingRemovalTimers.get(pid)
+    if (t) {
+      cancelTimer(t)
+      pendingRemovalTimers.delete(pid)
+    }
+  }
+
+  /**
+   * @param {string} suffix
+   */
+  function wireHostGuestOnline(suffix) {
+    const guestOnlineRef = deps.roomChild(suffix, 'guestOnline')
+    deps.trackFeatureUnsub(
+      deps.onChildAdded(guestOnlineRef, (snap) => {
+        const stableId = snap.key
+        if (!stableId) return
+        const onlineRef = snap.ref
+        deps.trackFeatureUnsub(
+          deps.onValue(onlineRef, (onlineSnap) => {
+            const pid = stableIdToParticipant.get(stableId)
+            if (!pid) return
+            if (onlineSnap.val() === true) {
+              activeGuestStableIds.add(stableId)
+              cancelParticipantRemoval(pid)
+            } else {
+              activeGuestStableIds.delete(stableId)
+              if (!activeGuestStableIds.has(stableId)) scheduleParticipantRemoval(pid)
+            }
+          }),
+        )
+      }),
+    )
+  }
+
+  return {
+    markGuestOnline,
+    markGuestOffline,
+    wireHostGuestOnline,
+    scheduleParticipantRemoval,
+    cancelParticipantRemoval,
+  }
+}

--- a/src/features/movie-vote/p2p/hostInboxWire.js
+++ b/src/features/movie-vote/p2p/hostInboxWire.js
@@ -1,0 +1,168 @@
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { normalizeCustomTitle } from '../core.js'
+import {
+  encodeHostVisibility,
+  encodeState,
+  encodeWelcome,
+  parseDraft,
+  parseHello,
+  parseVote,
+} from './protocol.js'
+import { generateAnonymousVoterId } from './roomId.js'
+
+/**
+ * @param {import('../types.js').MoviePick[]} picks
+ */
+function normalizePicks(picks) {
+  const out = []
+  for (const p of picks) {
+    if (!p || typeof p.localId !== 'string' || typeof p.title !== 'string') continue
+    const title = p.title.trim()
+    if (!title) continue
+
+    const explicitSource = p.source === 'tmdb' || p.source === 'custom' ? p.source : null
+    const source = explicitSource ?? (typeof p.tmdbId === 'number' ? 'tmdb' : 'custom')
+
+    if (source === 'tmdb' && typeof p.tmdbId !== 'number') continue
+
+    out.push({
+      localId: p.localId,
+      source,
+      tmdbId: source === 'tmdb' ? p.tmdbId : null,
+      customKey: source === 'custom' ? (p.customKey || normalizeCustomTitle(title)) : undefined,
+      title,
+      posterPath: p.posterPath ?? null,
+      overview: typeof p.overview === 'string' ? p.overview : '',
+      releaseDate: p.releaseDate,
+      runtime: typeof p.runtime === 'number' && p.runtime > 0 ? p.runtime : undefined,
+    })
+  }
+  return out
+}
+
+/**
+ * @param {object} deps
+ * @param {ReturnType<import('./movieVoteWireState.js').createMovieVoteWireState>} deps.wireState
+ * @param {(suffix: string, path: string) => import('firebase/database').DatabaseReference} deps.roomChild
+ * @param {(ref: import('firebase/database').DatabaseReference, value: unknown) => Promise<void>} deps.setRtdb
+ * @param {() => string | null} deps.getSessionSuffix
+ * @param {() => number} deps.getNextSeq
+ * @param {(n: number) => void} deps.setNextSeq
+ * @param {() => import('../types.js').MovieVotePublicPayload} deps.buildPublicPayload
+ * @param {() => void} deps.hostBroadcastState
+ * @param {() => void} deps.tryCompileBallot
+ * @param {() => void} deps.tryFinishVoting
+ * @param {(pid: string) => void} deps.cancelParticipantRemoval
+ */
+export function createHostInboxWire(deps) {
+  const {
+    stableIdToParticipant,
+    activeGuestStableIds,
+    guestDrafts,
+  } = deps.wireState
+  /**
+   * @param {string} stableId
+   * @param {unknown} raw
+   * @returns {string | null}
+   */
+  function bindStableIdFromGuestPayload(stableId, raw) {
+    const existing = stableIdToParticipant.get(stableId)
+    if (existing) return existing
+
+    const draft = parseDraft(raw)
+    const pid = draft?.participantId ?? parseVote(raw)?.participantId
+    if (!pid) return null
+
+    stableIdToParticipant.set(stableId, pid)
+    if (!guestDrafts.has(pid)) {
+      guestDrafts.set(pid, { picks: [], ready: false })
+    }
+    deps.cancelParticipantRemoval(pid)
+    return pid
+  }
+
+  /**
+   * @param {string} stableId
+   */
+  function onGuestHello(stableId) {
+    const existingPid = stableIdToParticipant.get(stableId)
+    const pid = existingPid ?? generateAnonymousVoterId()
+    const resumed = Boolean(existingPid)
+
+    if (!existingPid) {
+      stableIdToParticipant.set(stableId, pid)
+      guestDrafts.set(pid, { picks: [], ready: false })
+    } else {
+      deps.cancelParticipantRemoval(pid)
+    }
+
+    activeGuestStableIds.add(stableId)
+
+    const suffix = deps.getSessionSuffix()
+    if (!suffix) return
+
+    const welcomeRef = deps.roomChild(suffix, `welcome/${stableId}`)
+    deps.setRtdb(welcomeRef, encodeWelcome(pid, resumed)).catch(() => {})
+
+    const payload = deps.buildPublicPayload()
+    if (deps.getNextSeq() < 1) deps.setNextSeq(1)
+    deps.setRtdb(deps.roomChild(suffix, 'state'), encodeState(payload, deps.getNextSeq())).catch(() => {})
+
+    if (typeof document !== 'undefined') {
+      deps.setRtdb(
+        deps.roomChild(suffix, 'hostVisible'),
+        encodeHostVisibility(document.visibilityState === 'visible'),
+      ).catch(() => {})
+    }
+
+    if (resumed) deps.hostBroadcastState()
+  }
+
+  /**
+   * @param {string} stableId
+   * @param {unknown} raw
+   */
+  function handleHostInboxMessage(stableId, raw) {
+    const hello = parseHello(raw)
+    if (hello) {
+      if (hello.stableId !== stableId) return
+      onGuestHello(stableId)
+      return
+    }
+
+    const expectedPid = bindStableIdFromGuestPayload(stableId, raw)
+    if (!expectedPid) return
+
+    const store = useMovieVoteStore()
+    const draft = parseDraft(raw)
+    if (draft) {
+      if (draft.participantId !== expectedPid) return
+      guestDrafts.set(expectedPid, {
+        picks: normalizePicks(draft.picks),
+        ready: draft.ready,
+      })
+      deps.tryCompileBallot()
+      deps.hostBroadcastState()
+      return
+    }
+
+    const vote = parseVote(raw)
+    if (vote) {
+      if (vote.participantId !== expectedPid) return
+      if (store.phase !== 'voting') return
+      if (!store.voterIds.includes(expectedPid)) return
+      const valid = new Set(store.ballotOrderIds)
+      if (vote.ranking.length !== store.ballotOrderIds.length) return
+      const seen = new Set()
+      for (const id of vote.ranking) {
+        if (!valid.has(id) || seen.has(id)) return
+        seen.add(id)
+      }
+      store.mergeGuestVote(expectedPid, vote.ranking)
+      deps.hostBroadcastState()
+      deps.tryFinishVoting()
+    }
+  }
+
+  return { handleHostInboxMessage, onGuestHello }
+}

--- a/src/features/movie-vote/p2p/movieVotePiniaBridge.hostReset.test.js
+++ b/src/features/movie-vote/p2p/movieVotePiniaBridge.hostReset.test.js
@@ -9,6 +9,12 @@ import { createApp } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { installRtdbLifecycleMocks, withFirebaseEnv } from './sessionRtdbLifecycleHarness.js'
+import {
+  drainHostStateBroadcastProbeForTests,
+  getGuestDraftReadyForTests,
+  resetHostStateBroadcastProbeForTests,
+  setGuestDraftForTests,
+} from './session.testExports.js'
 
 /** @returns {import('../types.js').MoviePick} */
 function customPick(localId, title) {
@@ -50,7 +56,7 @@ test(
         const sessionMod = await import('./session.js')
         const bridgeMod = await import('./movieVotePiniaBridge.js')
 
-        sessionMod.resetHostStateBroadcastProbeForTests()
+        resetHostStateBroadcastProbeForTests(sessionMod)
 
         const pinia = createPinia()
         pinia.use(bridgeMod.movieVoteP2PPlugin)
@@ -62,14 +68,14 @@ test(
         await sessionMod.startAsHost(3)
         assert.equal(sessionMod.sessionPhase.value, 'hosting')
 
-        sessionMod.setGuestDraftForTests('guest-1', { picks: [], ready: true })
-        sessionMod.setGuestDraftForTests('guest-2', {
+        setGuestDraftForTests(sessionMod, 'guest-1', { picks: [], ready: true })
+        setGuestDraftForTests(sessionMod, 'guest-2', {
           picks: [customPick('g2', 'Guest Two')],
           ready: true,
         })
 
         store.phase = 'results'
-        sessionMod.drainHostStateBroadcastProbeForTests()
+        drainHostStateBroadcastProbeForTests(sessionMod)
         bridgeMod.resetMovieVoteHostResetToSuggestProbeForTests()
 
         store.resetToSuggest()
@@ -77,9 +83,9 @@ test(
         assert.deepEqual(bridgeMod.drainMovieVoteHostResetToSuggestProbeForTests(), [
           'resetToSuggest',
         ])
-        assert.equal(sessionMod.getGuestDraftReadyForTests('guest-1'), false)
-        assert.equal(sessionMod.getGuestDraftReadyForTests('guest-2'), false)
-        assert.ok(sessionMod.drainHostStateBroadcastProbeForTests() >= 1)
+        assert.equal(getGuestDraftReadyForTests(sessionMod, 'guest-1'), false)
+        assert.equal(getGuestDraftReadyForTests(sessionMod, 'guest-2'), false)
+        assert.ok(drainHostStateBroadcastProbeForTests(sessionMod) >= 1)
         assert.ok(
           harness.sets.some((s) => s.path.endsWith('/state')),
           'host reset should write sequenced hub state',

--- a/src/features/movie-vote/p2p/movieVoteWireState.js
+++ b/src/features/movie-vote/p2p/movieVoteWireState.js
@@ -1,0 +1,61 @@
+/**
+ * Per-session host-side guest wire bookkeeping for Movie Vote P2P.
+ */
+
+export function createMovieVoteWireState() {
+  /** @type {Map<string, string>} */
+  const stableIdToParticipant = new Map()
+
+  /** @type {Set<string>} */
+  const activeGuestStableIds = new Set()
+
+  /** @type {Map<string, { picks: import('../types.js').MoviePick[], ready: boolean }>} */
+  const guestDrafts = new Map()
+
+  /** @type {Map<string, ReturnType<typeof setTimeout>>} */
+  const pendingRemovalTimers = new Map()
+
+  function resetMaps() {
+    stableIdToParticipant.clear()
+    activeGuestStableIds.clear()
+    guestDrafts.clear()
+    for (const t of pendingRemovalTimers.values()) clearTimeout(t)
+    pendingRemovalTimers.clear()
+  }
+
+  /**
+   * @param {string} participantId
+   * @param {{ picks: import('../types.js').MoviePick[], ready: boolean }} entry
+   */
+  function seedGuestDraft(participantId, entry) {
+    guestDrafts.set(participantId, entry)
+  }
+
+  /**
+   * @param {string} participantId
+   * @returns {boolean | undefined}
+   */
+  function getGuestDraftReady(participantId) {
+    return guestDrafts.get(participantId)?.ready
+  }
+
+  function onlineGuestParticipantIds() {
+    /** @type {string[]} */
+    const out = []
+    for (const [stableId, pid] of stableIdToParticipant) {
+      if (activeGuestStableIds.has(stableId)) out.push(pid)
+    }
+    return out
+  }
+
+  return {
+    stableIdToParticipant,
+    activeGuestStableIds,
+    guestDrafts,
+    pendingRemovalTimers,
+    resetMaps,
+    seedGuestDraft,
+    getGuestDraftReady,
+    onlineGuestParticipantIds,
+  }
+}

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -40,6 +40,8 @@ import {
   encodeState,
   encodeVote,
   encodeWelcome,
+  isHostEndedNotice,
+  isHostPing,
   parseDraft,
   parseHello,
   parseHostVisibility,
@@ -505,21 +507,28 @@ function handleGuestState(raw) {
 }
 
 /**
- * Guest inbound sequenced public state (domain wire tests and direct dispatch).
+ * Dispatches inbound hub messages on the guest: room ended, ping, visibility, welcome, or sequenced state.
  * @param {unknown} raw
  * @returns {void}
  */
-export function handleGuestInboundState(raw) {
+export function handleGuestInbound(raw) {
+  if (isHostEndedNotice(raw)) {
+    handleGuestHostEnded()
+    return
+  }
+  if (isHostPing(raw)) {
+    return
+  }
+  const vis = parseHostVisibility(raw)
+  if (vis) {
+    remoteHostTabVisible.value = vis.visible
+    return
+  }
+  if (parseWelcome(raw)) {
+    handleGuestWelcome(raw)
+    return
+  }
   handleGuestState(raw)
-}
-
-/**
- * Guest inbound welcome (participant slot reattach on reconnect).
- * @param {unknown} raw
- * @returns {void}
- */
-export function handleGuestWelcomeInbound(raw) {
-  handleGuestWelcome(raw)
 }
 
 /**
@@ -577,35 +586,6 @@ const movieVoteP2POutboundSync = {
 export function bindMovieVoteP2PHandlers(h) {
   handlers = { ...handlers, ...h }
   return movieVoteP2POutboundSync
-}
-
-/** @returns {void} */
-export function resetHostStateBroadcastProbeForTests() {
-  hostStateBroadcastProbe = 0
-}
-
-/** @returns {number} */
-export function drainHostStateBroadcastProbeForTests() {
-  const n = hostStateBroadcastProbe
-  hostStateBroadcastProbe = 0
-  return n
-}
-
-/**
- * @param {string} participantId
- * @param {{ picks: import('../types.js').MoviePick[], ready: boolean }} entry
- * @returns {void}
- */
-export function setGuestDraftForTests(participantId, entry) {
-  guestDrafts.set(participantId, entry)
-}
-
-/**
- * @param {string} participantId
- * @returns {boolean | undefined}
- */
-export function getGuestDraftReadyForTests(participantId) {
-  return guestDrafts.get(participantId)?.ready
 }
 
 /**
@@ -960,8 +940,8 @@ export async function joinRoom(rawSuffix) {
 
 /**
  * Ends the session for this tab: clears phase and suffix, then tears down RTDB listeners.
- * Does not reset `nextSeq` or handler bindings — use {@link resetMovieVoteFacadeWireStateForTests}
- * in tests when reusing one module instance.
+ * Does not reset `nextSeq` or handler bindings — use `session.testExports.js` when reusing
+ * one module instance in tests.
  * @returns {void}
  */
 export function teardownSession() {
@@ -972,36 +952,53 @@ export function teardownSession() {
 }
 
 /**
- * Test-only: advances reconnect generation without clearing join persistence (supersede in-flight loops).
- * @returns {void}
+ * Test-only wire access for `session.testExports.js`. Do not import from production code.
+ * @returns {{
+ *   core: ReturnType<typeof createStarRoomSession>,
+ *   remoteHostTabVisible: typeof remoteHostTabVisible,
+ *   clearFeatureWireUnsubs: typeof clearFeatureWireUnsubs,
+ *   stableIdToParticipant: typeof stableIdToParticipant,
+ *   activeGuestStableIds: typeof activeGuestStableIds,
+ *   guestDrafts: typeof guestDrafts,
+ *   pendingRemovalTimers: typeof pendingRemovalTimers,
+ *   getHostStateBroadcastProbe: () => number,
+ *   setHostStateBroadcastProbe: (n: number) => void,
+ *   getNextSeq: () => number,
+ *   setNextSeq: (n: number) => void,
+ *   getLastSeenSeq: () => number,
+ *   setLastSeenSeq: (n: number) => void,
+ *   emptyHandlers: () => MovieVoteP2PHandlers,
+ *   setHandlers: (h: MovieVoteP2PHandlers) => void,
+ * }}
  */
-export function bumpMovieVoteReconnectGenerationForTests() {
-  core.bumpReconnectGeneration()
-}
-
-/**
- * Test-only: clears module-level facade wire state without RTDB guest-offline writes.
- * Prefer nonce-based `importMovieVoteSession` for isolation; call after `teardownSession`
- * when a test reuses one `session.js` instance.
- * @returns {void}
- */
-export function resetMovieVoteFacadeWireStateForTests() {
-  remoteHostTabVisible.value = true
-  clearFeatureWireUnsubs()
-  stableIdToParticipant.clear()
-  activeGuestStableIds.clear()
-  guestDrafts.clear()
-  for (const t of pendingRemovalTimers.values()) clearTimeout(t)
-  pendingRemovalTimers.clear()
-  nextSeq = 0
-  lastSeenSeq = 0
-  hostStateBroadcastProbe = 0
-  core.destroyWireOnly()
-  sessionPhase.value = 'idle'
-  sessionSuffix.value = null
-  handlers = {
-    applyPublicPayload: () => {},
-    onWireTeardown: () => {},
+export function getMovieVoteSessionTestWireAccess() {
+  return {
+    core,
+    remoteHostTabVisible,
+    clearFeatureWireUnsubs,
+    stableIdToParticipant,
+    activeGuestStableIds,
+    guestDrafts,
+    pendingRemovalTimers,
+    getHostStateBroadcastProbe: () => hostStateBroadcastProbe,
+    setHostStateBroadcastProbe: (n) => {
+      hostStateBroadcastProbe = n
+    },
+    getNextSeq: () => nextSeq,
+    setNextSeq: (n) => {
+      nextSeq = n
+    },
+    getLastSeenSeq: () => lastSeenSeq,
+    setLastSeenSeq: (n) => {
+      lastSeenSeq = n
+    },
+    emptyHandlers: () => ({
+      applyPublicPayload: () => {},
+      onWireTeardown: () => {},
+    }),
+    setHandlers: (h) => {
+      handlers = h
+    },
   }
 }
 

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -505,6 +505,24 @@ function handleGuestState(raw) {
 }
 
 /**
+ * Guest inbound sequenced public state (domain wire tests and direct dispatch).
+ * @param {unknown} raw
+ * @returns {void}
+ */
+export function handleGuestInboundState(raw) {
+  handleGuestState(raw)
+}
+
+/**
+ * Guest inbound welcome (participant slot reattach on reconnect).
+ * @param {unknown} raw
+ * @returns {void}
+ */
+export function handleGuestWelcomeInbound(raw) {
+  handleGuestWelcome(raw)
+}
+
+/**
  * @typedef {object} MovieVoteP2POutboundSync
  * @property {() => void} hostLocalChanged
  * @property {() => void} hostResetToSuggest
@@ -940,11 +958,51 @@ export async function joinRoom(rawSuffix) {
   }
 }
 
+/**
+ * Ends the session for this tab: clears phase and suffix, then tears down RTDB listeners.
+ * Does not reset `nextSeq` or handler bindings — use {@link resetMovieVoteFacadeWireStateForTests}
+ * in tests when reusing one module instance.
+ * @returns {void}
+ */
 export function teardownSession() {
   remoteHostTabVisible.value = true
   destroyWireOnly()
   core.setPhase('idle')
   core.setSuffix(null)
+}
+
+/**
+ * Test-only: advances reconnect generation without clearing join persistence (supersede in-flight loops).
+ * @returns {void}
+ */
+export function bumpMovieVoteReconnectGenerationForTests() {
+  core.bumpReconnectGeneration()
+}
+
+/**
+ * Test-only: clears module-level facade wire state without RTDB guest-offline writes.
+ * Prefer nonce-based `importMovieVoteSession` for isolation; call after `teardownSession`
+ * when a test reuses one `session.js` instance.
+ * @returns {void}
+ */
+export function resetMovieVoteFacadeWireStateForTests() {
+  remoteHostTabVisible.value = true
+  clearFeatureWireUnsubs()
+  stableIdToParticipant.clear()
+  activeGuestStableIds.clear()
+  guestDrafts.clear()
+  for (const t of pendingRemovalTimers.values()) clearTimeout(t)
+  pendingRemovalTimers.clear()
+  nextSeq = 0
+  lastSeenSeq = 0
+  hostStateBroadcastProbe = 0
+  core.destroyWireOnly()
+  sessionPhase.value = 'idle'
+  sessionSuffix.value = null
+  handlers = {
+    applyPublicPayload: () => {},
+    onWireTeardown: () => {},
+  }
 }
 
 function resetLocalStateAfterRoomExit() {

--- a/src/features/movie-vote/p2p/session.js
+++ b/src/features/movie-vote/p2p/session.js
@@ -22,7 +22,6 @@ import { createStarRoomSession } from '../../p2p/starRoomSessionCore.js'
 import {
   HOST_PARTICIPANT_ID,
   compileBallotMovies,
-  normalizeCustomTitle,
   uniqueMoviesInPicks,
 } from '../core.js'
 import { buildMovieVotePublicPayload, clearGuestDraftReadyFlags } from '../publicPayload.js'
@@ -39,23 +38,20 @@ import {
   encodeHostVisibility,
   encodeState,
   encodeVote,
-  encodeWelcome,
-  isHostEndedNotice,
-  isHostPing,
-  parseDraft,
-  parseHello,
   parseHostVisibility,
   parseState,
-  parseVote,
   parseWelcome,
 } from './protocol.js'
 import { ROOM_CLAIM_RESET_PATHS } from './sessionRoomRtdb.js'
 import {
-  generateAnonymousVoterId,
   generateRoomSuffix,
   isValidRoomSuffix,
   normalizeRoomSuffixInput,
 } from './roomId.js'
+import { createGuestInboundWire } from './guestInboundWire.js'
+import { createGuestOnlineWire } from './guestOnlineWire.js'
+import { createHostInboxWire } from './hostInboxWire.js'
+import { createMovieVoteWireState } from './movieVoteWireState.js'
 
 const STABLE_HOST_SUFFIX_APP = 'movievote'
 
@@ -75,28 +71,12 @@ let nextSeq = 0
 
 let lastSeenSeq = 0
 
-/**
- * Stable client id → participant id.
- * @type {Map<string, string>}
- */
-const stableIdToParticipant = new Map()
-
-/**
- * Stable ids currently marked online under `guestOnline/`.
- * @type {Set<string>}
- */
-const activeGuestStableIds = new Set()
-
-/**
- * Guest drafts keyed by participant id (host tab uses store only).
- * @type {Map<string, { picks: import('../types.js').MoviePick[], ready: boolean }>}
- */
-const guestDrafts = new Map()
-
-/**
- * @type {Map<string, ReturnType<typeof setTimeout>>}
- */
-const pendingRemovalTimers = new Map()
+const wireState = createMovieVoteWireState()
+const {
+  stableIdToParticipant,
+  activeGuestStableIds,
+  guestDrafts,
+} = wireState
 
 /** @type {Array<() => void>} */
 let featureWireUnsubs = []
@@ -112,8 +92,6 @@ export const sessionSuffix = vueRef(/** @type {string | null} */ (null))
  * Stays `true` when idle / hosting / unknown.
  */
 export const remoteHostTabVisible = vueRef(true)
-
-const GUEST_REMOVAL_GRACE_MS = 45_000
 
 const MIN_DISTINCT_SUGGESTIONS_FOR_READY = 2
 
@@ -140,16 +118,6 @@ function allParticipantsReadyReason() {
   return null
 }
 
-/** Guest participant ids with a stable id currently marked online. */
-function onlineGuestParticipantIds() {
-  /** @type {string[]} */
-  const out = []
-  for (const [stableId, pid] of stableIdToParticipant) {
-    if (activeGuestStableIds.has(stableId)) out.push(pid)
-  }
-  return out
-}
-
 /**
  * @param {string} suffix
  * @param {string} path
@@ -166,55 +134,6 @@ const rtdbPort = {
   onChildAdded,
   onDisconnect,
 }
-
-const core = createStarRoomSession({
-  guestPresence: 'strict',
-  claimResetPaths: ROOM_CLAIM_RESET_PATHS,
-  getStableClientId,
-  roomChild,
-  rtdb: rtdbPort,
-  protocolAdapter: {
-    encodeGuestHello: encodeHello,
-    parseHostVisibility,
-    hasGuestJoinableState: (stateVal) => parseState(stateVal) != null,
-    encodeHostVisibility,
-  },
-  onPhaseChange: (phase) => {
-    sessionPhase.value = phase
-  },
-  onSuffixChange: (s) => {
-    sessionSuffix.value = s
-  },
-  onSessionEvent: (event) => {
-    if (event.type === 'host_ended_room') {
-      handleGuestHostEnded()
-      return
-    }
-    if (event.type === 'host_tab_visible') {
-      remoteHostTabVisible.value = event.visible
-      return
-    }
-    if (event.type === 'connectivity_offline') {
-      const suffix = core.getSuffix()
-      if (!suffix) return
-      if (event.role === 'guest') {
-        void guestReconnectLoop(suffix, core.getReconnectGeneration())
-      } else {
-        void hostReconnectLoop(suffix, core.getReconnectGeneration())
-      }
-    }
-  },
-  onHostInboxMessage: (stableId, raw) => handleHostInboxMessage(stableId, raw),
-  onGuestAuthorityMessage: (raw) => handleGuestState(raw),
-  hydrateHost: hydrateHostFromRtdb,
-  subscribeFirebaseConnected: (onOffline) => {
-    const connectedRef = dbRef(getMovieVoteDatabase(), '.info/connected')
-    return onValue(connectedRef, (snap) => {
-      if (snap.val() !== false) return
-      onOffline()
-    })
-  },
-})
 
 /**
  * @param {() => void} unsub
@@ -265,39 +184,9 @@ function clearRoomPersistence() {
   }
 }
 
-/**
- * @param {string} suffix
- * @param {string} stableId
- */
-async function markGuestOnline(suffix, stableId) {
-  const onlineRef = roomChild(suffix, `guestOnline/${stableId}`)
-  await setRtdb(onlineRef, true)
-  onDisconnect(onlineRef).set(false)
-}
-
-/**
- * @param {string} suffix
- * @param {string} stableId
- */
-async function markGuestOffline(suffix, stableId) {
-  await setRtdb(roomChild(suffix, `guestOnline/${stableId}`), false).catch(() => {})
-}
-
-function destroyWireOnly() {
-  const suffix = core.getSuffix()
-  const sid = core.getGuestStableId()
-  if (!core.isHostRole() && suffix && sid) {
-    void markGuestOffline(suffix, sid)
-  }
-
-  clearFeatureWireUnsubs()
-  stableIdToParticipant.clear()
-  activeGuestStableIds.clear()
-  guestDrafts.clear()
-  for (const t of pendingRemovalTimers.values()) clearTimeout(t)
-  pendingRemovalTimers.clear()
+function resetMovieVoteWireState() {
+  wireState.resetMaps()
   lastSeenSeq = 0
-  core.destroyWireOnly()
 }
 
 function allDraftPicksFlat() {
@@ -354,7 +243,7 @@ function tryCompileBallot() {
   }
 
   const orderIds = movies.map((m) => m.publicId)
-  const voterIds = [HOST_PARTICIPANT_ID, ...onlineGuestParticipantIds()]
+  const voterIds = [HOST_PARTICIPANT_ID, ...wireState.onlineGuestParticipantIds()]
   store.setVotingState(movies, orderIds, voterIds)
   hostBroadcastState()
 }
@@ -375,104 +264,6 @@ function tryFinishVoting() {
   hostBroadcastState()
 }
 
-/**
- * @param {import('../types.js').MoviePick[]} picks
- */
-function normalizePicks(picks) {
-  const out = []
-  for (const p of picks) {
-    if (!p || typeof p.localId !== 'string' || typeof p.title !== 'string') continue
-    const title = p.title.trim()
-    if (!title) continue
-
-    const explicitSource = p.source === 'tmdb' || p.source === 'custom' ? p.source : null
-    const source = explicitSource ?? (typeof p.tmdbId === 'number' ? 'tmdb' : 'custom')
-
-    if (source === 'tmdb' && typeof p.tmdbId !== 'number') continue
-
-    out.push({
-      localId: p.localId,
-      source,
-      tmdbId: source === 'tmdb' ? p.tmdbId : null,
-      customKey: source === 'custom' ? (p.customKey || normalizeCustomTitle(title)) : undefined,
-      title,
-      posterPath: p.posterPath ?? null,
-      overview: typeof p.overview === 'string' ? p.overview : '',
-      releaseDate: p.releaseDate,
-      runtime: typeof p.runtime === 'number' && p.runtime > 0 ? p.runtime : undefined,
-    })
-  }
-  return out
-}
-
-/**
- * Re-attach stable id → participant after host tab refresh (inbox may hold draft/vote, not hello).
- * @param {string} stableId
- * @param {unknown} raw
- * @returns {string | null}
- */
-function bindStableIdFromGuestPayload(stableId, raw) {
-  const existing = stableIdToParticipant.get(stableId)
-  if (existing) return existing
-
-  const draft = parseDraft(raw)
-  const pid = draft?.participantId ?? parseVote(raw)?.participantId
-  if (!pid) return null
-
-  stableIdToParticipant.set(stableId, pid)
-  if (!guestDrafts.has(pid)) {
-    guestDrafts.set(pid, { picks: [], ready: false })
-  }
-  cancelParticipantRemoval(pid)
-  return pid
-}
-
-/**
- * @param {string} stableId
- * @param {unknown} raw
- */
-function handleHostInboxMessage(stableId, raw) {
-  const hello = parseHello(raw)
-  if (hello) {
-    if (hello.stableId !== stableId) return
-    onGuestHello(stableId)
-    return
-  }
-
-  const expectedPid = bindStableIdFromGuestPayload(stableId, raw)
-  if (!expectedPid) return
-
-  const store = useMovieVoteStore()
-  const draft = parseDraft(raw)
-  if (draft) {
-    if (draft.participantId !== expectedPid) return
-    guestDrafts.set(expectedPid, {
-      picks: normalizePicks(draft.picks),
-      ready: draft.ready,
-    })
-    tryCompileBallot()
-    hostBroadcastState()
-    return
-  }
-
-  const vote = parseVote(raw)
-  if (vote) {
-    if (vote.participantId !== expectedPid) return
-    if (store.phase !== 'voting') return
-    if (!store.voterIds.includes(expectedPid)) return
-    const valid = new Set(store.ballotOrderIds)
-    if (vote.ranking.length !== store.ballotOrderIds.length) return
-    const seen = new Set()
-    for (const id of vote.ranking) {
-      if (!valid.has(id) || seen.has(id)) return
-      seen.add(id)
-    }
-    store.mergeGuestVote(expectedPid, vote.ranking)
-    hostBroadcastState()
-    tryFinishVoting()
-  }
-}
-
 function handleGuestHostEnded() {
   notifyP2P('The host ended the room.', 'info')
   core.bumpReconnectGeneration()
@@ -480,55 +271,110 @@ function handleGuestHostEnded() {
   resetLocalStateAfterRoomExit()
 }
 
-/**
- * @param {unknown} raw
- */
-function handleGuestWelcome(raw) {
-  const welcome = parseWelcome(raw)
-  if (!welcome) return
-  useMovieVoteStore().setMyParticipantId(welcome.participantId)
-}
+const guestOnlineWire = createGuestOnlineWire({
+  wireState,
+  roomChild,
+  setRtdb,
+  onDisconnect,
+  onChildAdded,
+  onValue,
+  trackFeatureUnsub,
+  scheduleTimer: (fn, ms) => setTimeout(fn, ms),
+  cancelTimer: (id) => clearTimeout(id),
+  isHostRole: () => core.isHostRole(),
+  getSessionPhase: () => sessionPhase.value,
+  tryCompileBallot,
+  tryFinishVoting,
+  hostBroadcastState,
+})
 
-/**
- * Dispatches inbound hub state on the guest (sequenced public payload).
- * @param {unknown} raw
- * @returns {void}
- */
-function handleGuestState(raw) {
-  const st = parseState(raw)
-  if (!st) return
-  if (st.seq <= lastSeenSeq) return
-  lastSeenSeq = st.seq
-  try {
-    handlers.applyPublicPayload(st.payload)
-  } catch {
-    return
-  }
-}
+const hostInboxWire = createHostInboxWire({
+  wireState,
+  roomChild,
+  setRtdb,
+  getSessionSuffix: () => sessionSuffix.value,
+  getNextSeq: () => nextSeq,
+  setNextSeq: (n) => {
+    nextSeq = n
+  },
+  buildPublicPayload,
+  hostBroadcastState,
+  tryCompileBallot,
+  tryFinishVoting,
+  cancelParticipantRemoval: guestOnlineWire.cancelParticipantRemoval,
+})
 
-/**
- * Dispatches inbound hub messages on the guest: room ended, ping, visibility, welcome, or sequenced state.
- * @param {unknown} raw
- * @returns {void}
- */
-export function handleGuestInbound(raw) {
-  if (isHostEndedNotice(raw)) {
-    handleGuestHostEnded()
-    return
+const guestInboundWire = createGuestInboundWire({
+  remoteHostTabVisible,
+  getLastSeenSeq: () => lastSeenSeq,
+  setLastSeenSeq: (n) => {
+    lastSeenSeq = n
+  },
+  applyPublicPayload: (payload) => handlers.applyPublicPayload(payload),
+  onGuestHostEnded: handleGuestHostEnded,
+})
+
+export const handleGuestInbound = guestInboundWire.handleGuestInbound
+
+const core = createStarRoomSession({
+  guestPresence: 'strict',
+  claimResetPaths: ROOM_CLAIM_RESET_PATHS,
+  getStableClientId,
+  roomChild,
+  rtdb: rtdbPort,
+  protocolAdapter: {
+    encodeGuestHello: encodeHello,
+    parseHostVisibility,
+    hasGuestJoinableState: (stateVal) => parseState(stateVal) != null,
+    encodeHostVisibility,
+  },
+  onPhaseChange: (phase) => {
+    sessionPhase.value = phase
+  },
+  onSuffixChange: (s) => {
+    sessionSuffix.value = s
+  },
+  onSessionEvent: (event) => {
+    if (event.type === 'host_ended_room') {
+      handleGuestHostEnded()
+      return
+    }
+    if (event.type === 'host_tab_visible') {
+      remoteHostTabVisible.value = event.visible
+      return
+    }
+    if (event.type === 'connectivity_offline') {
+      const suffix = core.getSuffix()
+      if (!suffix) return
+      if (event.role === 'guest') {
+        void guestReconnectLoop(suffix, core.getReconnectGeneration())
+      } else {
+        void hostReconnectLoop(suffix, core.getReconnectGeneration())
+      }
+    }
+  },
+  onHostInboxMessage: (stableId, raw) => hostInboxWire.handleHostInboxMessage(stableId, raw),
+  onGuestAuthorityMessage: (raw) => guestInboundWire.handleGuestState(raw),
+  hydrateHost: hydrateHostFromRtdb,
+  subscribeFirebaseConnected: (onOffline) => {
+    const connectedRef = dbRef(getMovieVoteDatabase(), '.info/connected')
+    return onValue(connectedRef, (snap) => {
+      if (snap.val() !== false) return
+      onOffline()
+    })
+  },
+})
+
+function destroyWireOnly() {
+  const suffix = core.getSuffix()
+  const sid = core.getGuestStableId()
+  if (!core.isHostRole() && suffix && sid) {
+    void guestOnlineWire.markGuestOffline(suffix, sid)
   }
-  if (isHostPing(raw)) {
-    return
-  }
-  const vis = parseHostVisibility(raw)
-  if (vis) {
-    remoteHostTabVisible.value = vis.visible
-    return
-  }
-  if (parseWelcome(raw)) {
-    handleGuestWelcome(raw)
-    return
-  }
-  handleGuestState(raw)
+
+  clearFeatureWireUnsubs()
+  resetMovieVoteWireState()
+  core.destroyWireOnly()
 }
 
 /**
@@ -590,40 +436,13 @@ export function bindMovieVoteP2PHandlers(h) {
 
 /**
  * @param {string} suffix
- */
-function wireHostGuestOnline(suffix) {
-  const guestOnlineRef = roomChild(suffix, 'guestOnline')
-  trackFeatureUnsub(
-    onChildAdded(guestOnlineRef, (snap) => {
-      const stableId = snap.key
-      if (!stableId) return
-      const onlineRef = snap.ref
-      trackFeatureUnsub(
-        onValue(onlineRef, (onlineSnap) => {
-          const pid = stableIdToParticipant.get(stableId)
-          if (!pid) return
-          if (onlineSnap.val() === true) {
-            activeGuestStableIds.add(stableId)
-            cancelParticipantRemoval(pid)
-          } else {
-            activeGuestStableIds.delete(stableId)
-            if (!activeGuestStableIds.has(stableId)) scheduleParticipantRemoval(pid)
-          }
-        }),
-      )
-    }),
-  )
-}
-
-/**
- * @param {string} suffix
  * @param {string} stableId
  */
 function wireGuestWelcome(suffix, stableId) {
   trackFeatureUnsub(
     onValue(roomChild(suffix, `welcome/${stableId}`), (snap) => {
       const raw = snap.val()
-      if (raw != null) handleGuestWelcome(raw)
+      if (raw != null) guestInboundWire.handleGuestWelcome(raw)
     }),
   )
 }
@@ -666,74 +485,6 @@ function hostReconnectLoop(suffix, gen) {
       notifyP2P('Could not restore hosting. Start a new room or try again later.', 'negative'),
     teardownSession,
   })
-}
-
-function scheduleParticipantRemoval(pid) {
-  if (!guestDrafts.has(pid)) return
-  const stableId = [...stableIdToParticipant.entries()].find(([, p]) => p === pid)?.[0]
-  if (stableId && activeGuestStableIds.has(stableId)) return
-  const existing = pendingRemovalTimers.get(pid)
-  if (existing) clearTimeout(existing)
-  const t = setTimeout(() => {
-    pendingRemovalTimers.delete(pid)
-    if (stableId && activeGuestStableIds.has(stableId)) return
-    guestDrafts.delete(pid)
-    if (stableId) {
-      stableIdToParticipant.delete(stableId)
-      activeGuestStableIds.delete(stableId)
-    }
-    if (core.isHostRole() && sessionPhase.value === 'hosting') {
-      useMovieVoteStore().removeParticipantFromVote(pid)
-      tryCompileBallot()
-      tryFinishVoting()
-      hostBroadcastState()
-    }
-  }, GUEST_REMOVAL_GRACE_MS)
-  pendingRemovalTimers.set(pid, t)
-}
-
-function cancelParticipantRemoval(pid) {
-  const t = pendingRemovalTimers.get(pid)
-  if (t) {
-    clearTimeout(t)
-    pendingRemovalTimers.delete(pid)
-  }
-}
-
-/**
- * @param {string} stableId
- */
-function onGuestHello(stableId) {
-  const existingPid = stableIdToParticipant.get(stableId)
-  const pid = existingPid ?? generateAnonymousVoterId()
-  const resumed = Boolean(existingPid)
-
-  if (!existingPid) {
-    stableIdToParticipant.set(stableId, pid)
-    guestDrafts.set(pid, { picks: [], ready: false })
-  } else {
-    cancelParticipantRemoval(pid)
-  }
-
-  activeGuestStableIds.add(stableId)
-
-  const suffix = sessionSuffix.value
-  if (!suffix) return
-
-  const welcomeRef = roomChild(suffix, `welcome/${stableId}`)
-  setRtdb(welcomeRef, encodeWelcome(pid, resumed)).catch(() => {})
-
-  const payload = buildPublicPayload()
-  if (nextSeq < 1) nextSeq = 1
-  setRtdb(roomChild(suffix, 'state'), encodeState(payload, nextSeq)).catch(() => {})
-
-  if (typeof document !== 'undefined') {
-    setRtdb(roomChild(suffix, 'hostVisible'), encodeHostVisibility(document.visibilityState === 'visible')).catch(
-      () => {},
-    )
-  }
-
-  if (resumed) hostBroadcastState()
 }
 
 /**
@@ -783,7 +534,7 @@ async function finishHostSession(suffix) {
   nextSeq = 0
   lastSeenSeq = 0
   await core.finishHostSession(suffix)
-  wireHostGuestOnline(suffix)
+  guestOnlineWire.wireHostGuestOnline(suffix)
   useMovieVoteStore().setMyParticipantId(HOST_PARTICIPANT_ID)
   try {
     useMovieVoteRoomSessionStore().setHost(suffix)
@@ -802,7 +553,7 @@ async function establishGuestSession(suffix) {
   await core.establishGuestSession(suffix)
   const stableId = core.getGuestStableId()
   if (!stableId) throw new Error('No active room for that code')
-  await markGuestOnline(suffix, stableId)
+  await guestOnlineWire.markGuestOnline(suffix, stableId)
   wireGuestWelcome(suffix, stableId)
   try {
     useMovieVoteRoomSessionStore().setGuest(suffix)
@@ -957,10 +708,9 @@ export function teardownSession() {
  *   core: ReturnType<typeof createStarRoomSession>,
  *   remoteHostTabVisible: typeof remoteHostTabVisible,
  *   clearFeatureWireUnsubs: typeof clearFeatureWireUnsubs,
- *   stableIdToParticipant: typeof stableIdToParticipant,
- *   activeGuestStableIds: typeof activeGuestStableIds,
- *   guestDrafts: typeof guestDrafts,
- *   pendingRemovalTimers: typeof pendingRemovalTimers,
+ *   resetMovieVoteWireState: typeof resetMovieVoteWireState,
+ *   seedGuestDraft: typeof wireState.seedGuestDraft,
+ *   getGuestDraftReady: typeof wireState.getGuestDraftReady,
  *   getHostStateBroadcastProbe: () => number,
  *   setHostStateBroadcastProbe: (n: number) => void,
  *   getNextSeq: () => number,
@@ -976,10 +726,9 @@ export function getMovieVoteSessionTestWireAccess() {
     core,
     remoteHostTabVisible,
     clearFeatureWireUnsubs,
-    stableIdToParticipant,
-    activeGuestStableIds,
-    guestDrafts,
-    pendingRemovalTimers,
+    resetMovieVoteWireState,
+    seedGuestDraft: wireState.seedGuestDraft,
+    getGuestDraftReady: wireState.getGuestDraftReady,
     getHostStateBroadcastProbe: () => hostStateBroadcastProbe,
     setHostStateBroadcastProbe: (n) => {
       hostStateBroadcastProbe = n

--- a/src/features/movie-vote/p2p/session.testExports.js
+++ b/src/features/movie-vote/p2p/session.testExports.js
@@ -1,0 +1,72 @@
+/**
+ * Test-only helpers for Movie Vote session facade contract tests.
+ * Import from tests only — not from production code.
+ */
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @returns {void}
+ */
+export function bumpMovieVoteReconnectGenerationForTests(sessionMod) {
+  sessionMod.getMovieVoteSessionTestWireAccess().core.bumpReconnectGeneration()
+}
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @returns {void}
+ */
+export function resetMovieVoteFacadeWireStateForTests(sessionMod) {
+  const access = sessionMod.getMovieVoteSessionTestWireAccess()
+  access.remoteHostTabVisible.value = true
+  access.clearFeatureWireUnsubs()
+  access.stableIdToParticipant.clear()
+  access.activeGuestStableIds.clear()
+  access.guestDrafts.clear()
+  for (const t of access.pendingRemovalTimers.values()) clearTimeout(t)
+  access.pendingRemovalTimers.clear()
+  access.setNextSeq(0)
+  access.setLastSeenSeq(0)
+  access.setHostStateBroadcastProbe(0)
+  access.core.destroyWireOnly()
+  access.core.setPhase('idle')
+  access.core.setSuffix(null)
+  access.setHandlers(access.emptyHandlers())
+}
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @returns {void}
+ */
+export function resetHostStateBroadcastProbeForTests(sessionMod) {
+  sessionMod.getMovieVoteSessionTestWireAccess().setHostStateBroadcastProbe(0)
+}
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @returns {number}
+ */
+export function drainHostStateBroadcastProbeForTests(sessionMod) {
+  const access = sessionMod.getMovieVoteSessionTestWireAccess()
+  const n = access.getHostStateBroadcastProbe()
+  access.setHostStateBroadcastProbe(0)
+  return n
+}
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @param {string} participantId
+ * @param {{ picks: import('../types.js').MoviePick[], ready: boolean }} entry
+ * @returns {void}
+ */
+export function setGuestDraftForTests(sessionMod, participantId, entry) {
+  sessionMod.getMovieVoteSessionTestWireAccess().guestDrafts.set(participantId, entry)
+}
+
+/**
+ * @param {{ getMovieVoteSessionTestWireAccess: () => ReturnType<typeof import('./session.js').getMovieVoteSessionTestWireAccess> }} sessionMod
+ * @param {string} participantId
+ * @returns {boolean | undefined}
+ */
+export function getGuestDraftReadyForTests(sessionMod, participantId) {
+  return sessionMod.getMovieVoteSessionTestWireAccess().guestDrafts.get(participantId)?.ready
+}

--- a/src/features/movie-vote/p2p/session.testExports.js
+++ b/src/features/movie-vote/p2p/session.testExports.js
@@ -19,13 +19,8 @@ export function resetMovieVoteFacadeWireStateForTests(sessionMod) {
   const access = sessionMod.getMovieVoteSessionTestWireAccess()
   access.remoteHostTabVisible.value = true
   access.clearFeatureWireUnsubs()
-  access.stableIdToParticipant.clear()
-  access.activeGuestStableIds.clear()
-  access.guestDrafts.clear()
-  for (const t of access.pendingRemovalTimers.values()) clearTimeout(t)
-  access.pendingRemovalTimers.clear()
+  access.resetMovieVoteWireState()
   access.setNextSeq(0)
-  access.setLastSeenSeq(0)
   access.setHostStateBroadcastProbe(0)
   access.core.destroyWireOnly()
   access.core.setPhase('idle')
@@ -59,7 +54,7 @@ export function drainHostStateBroadcastProbeForTests(sessionMod) {
  * @returns {void}
  */
 export function setGuestDraftForTests(sessionMod, participantId, entry) {
-  sessionMod.getMovieVoteSessionTestWireAccess().guestDrafts.set(participantId, entry)
+  sessionMod.getMovieVoteSessionTestWireAccess().seedGuestDraft(participantId, entry)
 }
 
 /**
@@ -68,5 +63,5 @@ export function setGuestDraftForTests(sessionMod, participantId, entry) {
  * @returns {boolean | undefined}
  */
 export function getGuestDraftReadyForTests(sessionMod, participantId) {
-  return sessionMod.getMovieVoteSessionTestWireAccess().guestDrafts.get(participantId)?.ready
+  return sessionMod.getMovieVoteSessionTestWireAccess().getGuestDraftReady(participantId)
 }

--- a/src/features/movie-vote/p2p/sessionFacadeDomainWire.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeDomainWire.test.js
@@ -10,15 +10,15 @@ import { createPinia, setActivePinia } from 'pinia'
 import { HOST_PARTICIPANT_ID } from '../core.js'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { encodeState, encodeWelcome, MSG_MV_STATE } from './protocol.js'
+import * as sessionMod from './session.js'
 import {
   bindMovieVoteP2PHandlers,
-  handleGuestInboundState,
-  handleGuestWelcomeInbound,
-  resetMovieVoteFacadeWireStateForTests,
+  handleGuestInbound,
   sessionPhase,
   sessionSuffix,
   teardownSession,
 } from './session.js'
+import { resetMovieVoteFacadeWireStateForTests } from './session.testExports.js'
 
 /** @returns {import('../types.js').BallotMovie} */
 function ballotMovie(publicId, title) {
@@ -106,16 +106,16 @@ test('guest inbound state applies only when seq strictly increases', () => {
   const suggestA = suggestPayload({ uniqueSuggestedMovieCount: 1 })
   const suggestB = suggestPayload({ uniqueSuggestedMovieCount: 2 })
 
-  handleGuestInboundState(encodeState(suggestA, 1))
+  handleGuestInbound(encodeState(suggestA, 1))
   assert.equal(wire.applyCount, 1)
   assert.equal(wire.mirror?.phase, 'suggest')
   assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 1)
 
-  handleGuestInboundState(encodeState(suggestB, 1))
+  handleGuestInbound(encodeState(suggestB, 1))
   assert.equal(wire.applyCount, 1, 'equal seq must not re-apply')
   assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 1)
 
-  handleGuestInboundState(encodeState(votingPayload(['m_a', 'm_b']), 2))
+  handleGuestInbound(encodeState(votingPayload(['m_a', 'm_b']), 2))
   assert.equal(wire.applyCount, 2)
   assert.equal(wire.mirror?.phase, 'voting')
   assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_a', 'm_b'])
@@ -125,21 +125,21 @@ test('guest inbound state ignores regressive seq without changing mirror', () =>
   const wire = bindFakeMirrorHandlers()
   const authoritative = votingPayload(['m_a', 'm_b'])
 
-  handleGuestInboundState(encodeState(authoritative, 5))
+  handleGuestInbound(encodeState(authoritative, 5))
   assert.equal(wire.applyCount, 1)
 
   wire.setLocalFork(votingPayload(['m_b', 'm_a']))
 
-  handleGuestInboundState(encodeState(votingPayload(['m_x', 'm_y']), 3))
+  handleGuestInbound(encodeState(votingPayload(['m_x', 'm_y']), 3))
   assert.equal(wire.applyCount, 1, 'regressive seq is a no-op on applyPublicPayload')
   assert.equal(wire.mirror?.phase, 'voting', 'regressive seq must not rewind phase')
   assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_b', 'm_a'])
 
-  handleGuestInboundState(encodeState(suggestPayload({ uniqueSuggestedMovieCount: 99 }), 4))
+  handleGuestInbound(encodeState(suggestPayload({ uniqueSuggestedMovieCount: 99 }), 4))
   assert.equal(wire.applyCount, 1, 'regressive suggest broadcast must not rewind voting phase')
   assert.equal(wire.mirror?.phase, 'voting')
 
-  handleGuestInboundState(encodeState(authoritative, 5))
+  handleGuestInbound(encodeState(authoritative, 5))
   assert.equal(wire.applyCount, 1, 'duplicate max seq is still ignored')
   assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_b', 'm_a'])
 })
@@ -148,7 +148,7 @@ test('guest inbound state ignores invalid and malformed wire shapes', () => {
   const wire = bindFakeMirrorHandlers()
   const valid = encodeState(suggestPayload(), 1)
 
-  handleGuestInboundState(valid)
+  handleGuestInbound(valid)
   assert.equal(wire.applyCount, 1)
 
   const malformed = [
@@ -162,7 +162,7 @@ test('guest inbound state ignores invalid and malformed wire shapes', () => {
   ]
 
   for (const raw of malformed) {
-    handleGuestInboundState(raw)
+    handleGuestInbound(raw)
   }
 
   assert.equal(wire.applyCount, 1, 'malformed host state must not touch mirror handlers')
@@ -181,7 +181,7 @@ test('guest reconnect coherence: welcome + sequenced state reattaches seat witho
     ],
   })
 
-  handleGuestInboundState(encodeState(beforeDisconnect, 1))
+  handleGuestInbound(encodeState(beforeDisconnect, 1))
   assert.equal(wire.mirror?.phase, 'suggest')
 
   store.setMyParticipantId('guest-seat-1')
@@ -211,7 +211,7 @@ test('guest reconnect coherence: welcome + sequenced state reattaches seat witho
   store.ballotOrderIds = ['m_b', 'm_a']
   store.myRanking = ['m_b', 'm_a']
 
-  handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
+  handleGuestInbound(encodeWelcome('guest-seat-1', true))
   assert.equal(store.myParticipantId, 'guest-seat-1')
 
   const afterReconnect = votingPayload(['m_a', 'm_b'], {
@@ -221,7 +221,7 @@ test('guest reconnect coherence: welcome + sequenced state reattaches seat witho
       { id: 'guest-seat-1', ready: true, pickCount: 1 },
     ],
   })
-  handleGuestInboundState(encodeState(afterReconnect, 2))
+  handleGuestInbound(encodeState(afterReconnect, 2))
 
   assert.equal(wire.applyCount, 2)
   assert.equal(wire.mirror?.phase, 'voting')
@@ -244,7 +244,7 @@ test('guest reconnect coherence: suggest-phase welcome + state reattaches draft 
   const store = useMovieVoteStore()
   const wire = bindFakeMirrorHandlers()
 
-  handleGuestInboundState(
+  handleGuestInbound(
     encodeState(
       suggestPayload({
         uniqueSuggestedMovieCount: 1,
@@ -277,7 +277,7 @@ test('guest reconnect coherence: suggest-phase welcome + state reattaches draft 
     }),
   )
 
-  handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
+  handleGuestInbound(encodeWelcome('guest-seat-1', true))
   assert.equal(store.myParticipantId, 'guest-seat-1')
 
   const hostTruth = suggestPayload({
@@ -287,7 +287,7 @@ test('guest reconnect coherence: suggest-phase welcome + state reattaches draft 
       { id: 'guest-seat-1', ready: false, pickCount: 1 },
     ],
   })
-  handleGuestInboundState(encodeState(hostTruth, 2))
+  handleGuestInbound(encodeState(hostTruth, 2))
 
   assert.equal(wire.applyCount, 2)
   assert.equal(wire.mirror?.phase, 'suggest')
@@ -309,7 +309,7 @@ test('guest outbound draft and vote sync do not promote local state as mirror tr
   const wire = bindFakeMirrorHandlers()
   const hostTruth = votingPayload(['m_a', 'm_b'])
 
-  handleGuestInboundState(encodeState(hostTruth, 1))
+  handleGuestInbound(encodeState(hostTruth, 1))
   assert.equal(wire.applyCount, 1)
 
   sessionSuffix.value = 'WIRE01'
@@ -339,5 +339,5 @@ test('guest outbound draft and vote sync do not promote local state as mirror tr
 
 afterEach(() => {
   teardownSession()
-  resetMovieVoteFacadeWireStateForTests()
+  resetMovieVoteFacadeWireStateForTests(sessionMod)
 })

--- a/src/features/movie-vote/p2p/sessionFacadeDomainWire.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeDomainWire.test.js
@@ -1,0 +1,343 @@
+/**
+ * Run: node --test src/features/movie-vote/p2p/sessionFacadeDomainWire.test.js
+ *
+ * Guest inbound monotonic authority broadcast on sequenced state — domain wire only
+ * (not connection posture; see posture contract tests separately).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { encodeState, encodeWelcome, MSG_MV_STATE } from './protocol.js'
+import {
+  bindMovieVoteP2PHandlers,
+  handleGuestInboundState,
+  handleGuestWelcomeInbound,
+  resetMovieVoteFacadeWireStateForTests,
+  sessionPhase,
+  sessionSuffix,
+  teardownSession,
+} from './session.js'
+
+/** @returns {import('../types.js').BallotMovie} */
+function ballotMovie(publicId, title) {
+  return {
+    publicId,
+    source: 'custom',
+    tmdbId: null,
+    customKey: title.toLowerCase(),
+    title,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+/** @returns {import('../types.js').MovieVotePublicPayload} */
+function suggestPayload(overrides = {}) {
+  return {
+    phase: 'suggest',
+    participants: [{ id: HOST_PARTICIPANT_ID, ready: false, pickCount: 0 }],
+    ballotMovies: null,
+    ballotOrderIds: null,
+    voteProgress: null,
+    irvResult: null,
+    uniqueSuggestedMovieCount: 0,
+    votingMethod: 'irv',
+    ...overrides,
+  }
+}
+
+/**
+ * @param {string[]} ballotOrderIds
+ * @param {Partial<import('../types.js').MovieVotePublicPayload>} [overrides]
+ * @returns {import('../types.js').MovieVotePublicPayload}
+ */
+function votingPayload(ballotOrderIds, overrides = {}) {
+  const movies = ballotOrderIds.map((id) =>
+    ballotMovie(id, id === 'm_a' ? 'Alpha' : id === 'm_b' ? 'Beta' : id),
+  )
+  return {
+    phase: 'voting',
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 1 },
+      { id: 'guest-seat-1', ready: true, pickCount: 1 },
+    ],
+    ballotMovies: movies,
+    ballotOrderIds: [...ballotOrderIds],
+    voteProgress: { submitted: 0, total: 2 },
+    irvResult: null,
+    uniqueSuggestedMovieCount: 0,
+    votingMethod: 'irv',
+    ...overrides,
+  }
+}
+
+function bindFakeMirrorHandlers() {
+  /** @type {import('../types.js').MovieVotePublicPayload | null} */
+  let mirror = null
+  let applyCount = 0
+
+  const outbound = bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      applyCount += 1
+      mirror = structuredClone(payload)
+    },
+    onWireTeardown: () => {},
+  })
+
+  return {
+    get mirror() {
+      return mirror
+    },
+    get applyCount() {
+      return applyCount
+    },
+    outbound,
+    /** Simulates local mirror drift without host authority (e.g. reconnect fork). */
+    setLocalFork(payload) {
+      mirror = structuredClone(payload)
+    },
+  }
+}
+
+test('guest inbound state applies only when seq strictly increases', () => {
+  const wire = bindFakeMirrorHandlers()
+  const suggestA = suggestPayload({ uniqueSuggestedMovieCount: 1 })
+  const suggestB = suggestPayload({ uniqueSuggestedMovieCount: 2 })
+
+  handleGuestInboundState(encodeState(suggestA, 1))
+  assert.equal(wire.applyCount, 1)
+  assert.equal(wire.mirror?.phase, 'suggest')
+  assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 1)
+
+  handleGuestInboundState(encodeState(suggestB, 1))
+  assert.equal(wire.applyCount, 1, 'equal seq must not re-apply')
+  assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 1)
+
+  handleGuestInboundState(encodeState(votingPayload(['m_a', 'm_b']), 2))
+  assert.equal(wire.applyCount, 2)
+  assert.equal(wire.mirror?.phase, 'voting')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_a', 'm_b'])
+})
+
+test('guest inbound state ignores regressive seq without changing mirror', () => {
+  const wire = bindFakeMirrorHandlers()
+  const authoritative = votingPayload(['m_a', 'm_b'])
+
+  handleGuestInboundState(encodeState(authoritative, 5))
+  assert.equal(wire.applyCount, 1)
+
+  wire.setLocalFork(votingPayload(['m_b', 'm_a']))
+
+  handleGuestInboundState(encodeState(votingPayload(['m_x', 'm_y']), 3))
+  assert.equal(wire.applyCount, 1, 'regressive seq is a no-op on applyPublicPayload')
+  assert.equal(wire.mirror?.phase, 'voting', 'regressive seq must not rewind phase')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_b', 'm_a'])
+
+  handleGuestInboundState(encodeState(suggestPayload({ uniqueSuggestedMovieCount: 99 }), 4))
+  assert.equal(wire.applyCount, 1, 'regressive suggest broadcast must not rewind voting phase')
+  assert.equal(wire.mirror?.phase, 'voting')
+
+  handleGuestInboundState(encodeState(authoritative, 5))
+  assert.equal(wire.applyCount, 1, 'duplicate max seq is still ignored')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_b', 'm_a'])
+})
+
+test('guest inbound state ignores invalid and malformed wire shapes', () => {
+  const wire = bindFakeMirrorHandlers()
+  const valid = encodeState(suggestPayload(), 1)
+
+  handleGuestInboundState(valid)
+  assert.equal(wire.applyCount, 1)
+
+  const malformed = [
+    null,
+    'not-an-object',
+    {},
+    { type: MSG_MV_STATE, seq: 0, payload: suggestPayload() },
+    { type: MSG_MV_STATE, seq: 1 },
+    { type: MSG_MV_STATE, seq: 1, payload: { phase: 'bad', participants: [] } },
+    { type: 'mv-wrong', seq: 2, payload: suggestPayload() },
+  ]
+
+  for (const raw of malformed) {
+    handleGuestInboundState(raw)
+  }
+
+  assert.equal(wire.applyCount, 1, 'malformed host state must not touch mirror handlers')
+  assert.equal(wire.mirror?.phase, 'suggest')
+})
+
+test('guest reconnect coherence: welcome + sequenced state reattaches seat without local ballot promotion', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const wire = bindFakeMirrorHandlers()
+  const beforeDisconnect = suggestPayload({
+    uniqueSuggestedMovieCount: 2,
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+      { id: 'guest-seat-1', ready: false, pickCount: 1 },
+    ],
+  })
+
+  handleGuestInboundState(encodeState(beforeDisconnect, 1))
+  assert.equal(wire.mirror?.phase, 'suggest')
+
+  store.setMyParticipantId('guest-seat-1')
+  store.readyToVote = true
+  store.myDraftPicks = [
+    {
+      localId: 'local-draft',
+      source: 'custom',
+      tmdbId: null,
+      customKey: 'local draft',
+      title: 'Local draft',
+      posterPath: null,
+      overview: '',
+    },
+    {
+      localId: 'local-draft-2',
+      source: 'custom',
+      tmdbId: null,
+      customKey: 'extra local',
+      title: 'Extra local',
+      posterPath: null,
+      overview: '',
+    },
+  ]
+  wire.setLocalFork(votingPayload(['m_b', 'm_a']))
+  store.phase = 'voting'
+  store.ballotOrderIds = ['m_b', 'm_a']
+  store.myRanking = ['m_b', 'm_a']
+
+  handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
+  assert.equal(store.myParticipantId, 'guest-seat-1')
+
+  const afterReconnect = votingPayload(['m_a', 'm_b'], {
+    voteProgress: { submitted: 1, total: 2 },
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+      { id: 'guest-seat-1', ready: true, pickCount: 1 },
+    ],
+  })
+  handleGuestInboundState(encodeState(afterReconnect, 2))
+
+  assert.equal(wire.applyCount, 2)
+  assert.equal(wire.mirror?.phase, 'voting')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_a', 'm_b'])
+  assert.deepEqual(wire.mirror?.voteProgress, { submitted: 1, total: 2 })
+  const guestRow = wire.mirror?.participants.find((p) => p.id === 'guest-seat-1')
+  assert.equal(guestRow?.pickCount, 1, 'draft payload seat reattach comes from host payload row')
+  assert.equal(guestRow?.ready, true)
+
+  sessionSuffix.value = 'WIRE01'
+  sessionPhase.value = 'guest_connected'
+  wire.outbound.guestPushDraft()
+  wire.outbound.guestSubmitVote(['m_b', 'm_a'])
+  assert.equal(wire.applyCount, 2, 'post-reconnect outbound must not promote local ballot or draft')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_a', 'm_b'])
+})
+
+test('guest reconnect coherence: suggest-phase welcome + state reattaches draft payload row', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const wire = bindFakeMirrorHandlers()
+
+  handleGuestInboundState(
+    encodeState(
+      suggestPayload({
+        uniqueSuggestedMovieCount: 1,
+        participants: [
+          { id: HOST_PARTICIPANT_ID, ready: false, pickCount: 1 },
+          { id: 'guest-seat-1', ready: false, pickCount: 0 },
+        ],
+      }),
+      1,
+    ),
+  )
+
+  store.setMyParticipantId('guest-seat-1')
+  store.readyToVote = true
+  store.myDraftPicks = [
+    {
+      localId: 'local-only',
+      source: 'custom',
+      tmdbId: null,
+      customKey: 'local only',
+      title: 'Local only',
+      posterPath: null,
+      overview: '',
+    },
+  ]
+  wire.setLocalFork(
+    suggestPayload({
+      uniqueSuggestedMovieCount: 99,
+      participants: [{ id: HOST_PARTICIPANT_ID, ready: true, pickCount: 99 }],
+    }),
+  )
+
+  handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
+  assert.equal(store.myParticipantId, 'guest-seat-1')
+
+  const hostTruth = suggestPayload({
+    uniqueSuggestedMovieCount: 2,
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 1 },
+      { id: 'guest-seat-1', ready: false, pickCount: 1 },
+    ],
+  })
+  handleGuestInboundState(encodeState(hostTruth, 2))
+
+  assert.equal(wire.applyCount, 2)
+  assert.equal(wire.mirror?.phase, 'suggest')
+  assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 2)
+  const guestRow = wire.mirror?.participants.find((p) => p.id === 'guest-seat-1')
+  assert.equal(guestRow?.pickCount, 1)
+  assert.equal(guestRow?.ready, false)
+
+  sessionSuffix.value = 'WIRE02'
+  sessionPhase.value = 'guest_connected'
+  wire.outbound.guestPushDraft()
+  assert.equal(wire.applyCount, 2, 'post-reconnect draft push must not promote local mirror')
+  assert.equal(wire.mirror?.uniqueSuggestedMovieCount, 2)
+})
+
+test('guest outbound draft and vote sync do not promote local state as mirror truth', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const wire = bindFakeMirrorHandlers()
+  const hostTruth = votingPayload(['m_a', 'm_b'])
+
+  handleGuestInboundState(encodeState(hostTruth, 1))
+  assert.equal(wire.applyCount, 1)
+
+  sessionSuffix.value = 'WIRE01'
+  sessionPhase.value = 'guest_connected'
+  store.setMyParticipantId('guest-seat-1')
+  store.phase = 'voting'
+  store.ballotOrderIds = ['m_b', 'm_a']
+  store.myDraftPicks = [
+    {
+      localId: 'local-1',
+      source: 'custom',
+      tmdbId: null,
+      customKey: 'local pick',
+      title: 'Local pick',
+      posterPath: null,
+      overview: '',
+    },
+  ]
+
+  wire.outbound.guestPushDraft()
+  wire.outbound.guestSubmitVote(['m_b', 'm_a'])
+
+  assert.equal(wire.applyCount, 1, 'guest outbound sync must not call applyPublicPayload')
+  assert.deepEqual(wire.mirror?.ballotOrderIds, ['m_a', 'm_b'])
+  assert.equal(wire.mirror?.phase, 'voting')
+})
+
+afterEach(() => {
+  teardownSession()
+  resetMovieVoteFacadeWireStateForTests()
+})

--- a/src/features/movie-vote/p2p/sessionFacadeHostInbox.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeHostInbox.test.js
@@ -11,6 +11,11 @@ import { HOST_PARTICIPANT_ID } from '../core.js'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { encodeDraft, encodeHello, parseState, parseWelcome } from './protocol.js'
 import {
+  maxStateSeq,
+  parseStateBroadcasts,
+  simulateHostInboxMessage,
+} from '../../p2p/test/hostInboxHarness.js'
+import {
   createRtdbLifecycleAfterEach,
   importMovieVoteSession,
   installRtdbLifecycleMocks,
@@ -20,47 +25,14 @@ import {
 const hostInboxTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
 
-/**
- * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
- * @param {string} suffix
- * @param {string} guestStableId
- * @param {unknown} payload
- */
-function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
-  const inboxParent = `movieVoteRooms/${suffix}/inbox`
-  const childPath = `${inboxParent}/${guestStableId}`
-  assert.ok(
-    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
-    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
-  )
-  harness.emitChildAdded(inboxParent, guestStableId)
-  assert.ok(
-    harness.listeners.has(childPath),
-    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
-  )
-  harness.emitValue(childPath, payload)
+/** @param {Array<{ path: string, value: unknown }>} sets */
+function mvStateBroadcasts(sets) {
+  return parseStateBroadcasts(sets, parseState, 'payload')
 }
 
-/**
- * @param {Array<{ path: string, value: unknown }>} sets
- * @returns {Array<{ seq: number, payload: import('../types.js').MovieVotePublicPayload }>}
- */
-function parseStateBroadcasts(sets) {
-  return sets
-    .filter((entry) => entry.path.endsWith('/state'))
-    .map((entry) => {
-      const parsed = parseState(entry.value)
-      assert.ok(parsed, 'state write must be a host snapshot message')
-      return { seq: parsed.seq, payload: parsed.payload }
-    })
-}
-
-/**
- * @param {Array<{ path: string, value: unknown }>} sets
- * @returns {number}
- */
-function maxStateSeq(sets) {
-  return parseStateBroadcasts(sets).reduce((max, entry) => Math.max(max, entry.seq), 0)
+/** @param {Array<{ path: string, value: unknown }>} sets */
+function mvMaxStateSeq(sets) {
+  return maxStateSeq(sets, parseState, 'payload')
 }
 
 /**
@@ -142,7 +114,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -157,7 +129,7 @@ test(
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, false)
 
       const setsBeforeReconnectHello = harness.sets.length
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
 
@@ -208,7 +180,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableA, encodeHello(guestStableA))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableA, encodeHello(guestStableA))
       harness.emitChildAdded(guestOnlineRoot, guestStableA)
       harness.emitValue(`${guestOnlineRoot}/${guestStableA}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -220,7 +192,7 @@ test(
       assert.ok(pidA)
 
       const setsBeforeSecondGuest = harness.sets.length
-      simulateHostInboxMessage(harness, suffix, guestStableB, encodeHello(guestStableB))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableB, encodeHello(guestStableB))
       harness.emitChildAdded(guestOnlineRoot, guestStableB)
       harness.emitValue(`${guestOnlineRoot}/${guestStableB}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -267,11 +239,11 @@ test(
 
       await startAsHost(3)
       assert.equal(sessionPhase.value, 'hosting')
-      assert.ok(maxStateSeq(harness.sets) >= 1, 'host start should publish initial room authority')
+      assert.ok(mvMaxStateSeq(harness.sets) >= 1, 'host start should publish initial room authority')
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -279,7 +251,7 @@ test(
       const guestPid = guestParticipantIds(store)[0]
       assert.ok(guestPid)
 
-      const baselineSeq = maxStateSeq(harness.sets)
+      const baselineSeq = mvMaxStateSeq(harness.sets)
 
       const guestPick = {
         localId: 'g1',
@@ -294,12 +266,13 @@ test(
       const setsBeforeDraft = harness.sets.length
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeDraft([guestPick], false, guestPid),
       )
 
-      const draftBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeDraft))
+      const draftBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeDraft))
       assert.ok(draftBroadcasts.length >= 1, 'draft inbox should rebroadcast room authority')
       const latestDraft = draftBroadcasts[draftBroadcasts.length - 1]
       assert.ok(

--- a/src/features/movie-vote/p2p/sessionFacadeHostInbox.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeHostInbox.test.js
@@ -1,0 +1,318 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionFacadeHostInbox.test.js
+ *
+ * Host inbox domain wire — guest hello participant remap and draft aggregation at the
+ * session facade boundary (separate from posture tests).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { encodeDraft, encodeHello, parseState, parseWelcome } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const hostInboxTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/**
+ * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {unknown} payload
+ */
+function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
+  const inboxParent = `movieVoteRooms/${suffix}/inbox`
+  const childPath = `${inboxParent}/${guestStableId}`
+  assert.ok(
+    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
+    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
+  )
+  harness.emitChildAdded(inboxParent, guestStableId)
+  assert.ok(
+    harness.listeners.has(childPath),
+    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
+  )
+  harness.emitValue(childPath, payload)
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {Array<{ seq: number, payload: import('../types.js').MovieVotePublicPayload }>}
+ */
+function parseStateBroadcasts(sets) {
+  return sets
+    .filter((entry) => entry.path.endsWith('/state'))
+    .map((entry) => {
+      const parsed = parseState(entry.value)
+      assert.ok(parsed, 'state write must be a host snapshot message')
+      return { seq: parsed.seq, payload: parsed.payload }
+    })
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {number}
+ */
+function maxStateSeq(sets) {
+  return parseStateBroadcasts(sets).reduce((max, entry) => Math.max(max, entry.seq), 0)
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @param {string} guestStableId
+ * @returns {Array<{ participantId: string, resumed: boolean }>}
+ */
+function parseWelcomeWrites(sets, guestStableId) {
+  return sets
+    .filter((entry) => entry.path.endsWith(`/welcome/${guestStableId}`))
+    .map((entry) => {
+      const parsed = parseWelcome(entry.value)
+      assert.ok(parsed, 'welcome write must be a welcome message')
+      return parsed
+    })
+}
+
+/**
+ * @param {ReturnType<typeof useMovieVoteStore>} store
+ * @returns {string[]}
+ */
+function guestParticipantIds(store) {
+  return store.participants
+    .filter((p) => p.id !== HOST_PARTICIPANT_ID)
+    .map((p) => p.id)
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ */
+function bindHostStoreHandlers(sessionMod) {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const outbound = sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: () => {},
+  })
+  return { store, outbound }
+}
+
+/** @param {ReturnType<typeof bindHostStoreHandlers>['outbound']} outbound */
+function hostSyncParticipantsFromRoom(outbound) {
+  outbound.hostLocalChanged()
+}
+
+test(
+  'guest hello remaps participant id via stable client identity on reconnect',
+  hostInboxTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTHELLO1'
+    const guestStableId = 'MVGUESTHELLO'
+    const suffix = 'HELLO1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`hello-remap-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = bindHostStoreHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
+
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      harness.emitChildAdded(guestOnlineRoot, guestStableId)
+      harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const welcomesAfterFirst = parseWelcomeWrites(harness.sets, guestStableId)
+      assert.equal(welcomesAfterFirst.length, 1)
+      assert.equal(welcomesAfterFirst[0].resumed, false)
+      const firstPid = welcomesAfterFirst[0].participantId
+      assert.ok(firstPid)
+      assert.deepEqual(guestParticipantIds(store), [firstPid])
+
+      harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, false)
+
+      const setsBeforeReconnectHello = harness.sets.length
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const welcomesAfterReconnect = parseWelcomeWrites(
+        harness.sets.slice(setsBeforeReconnectHello),
+        guestStableId,
+      )
+      assert.equal(welcomesAfterReconnect.length, 1)
+      assert.equal(welcomesAfterReconnect[0].participantId, firstPid)
+      assert.equal(welcomesAfterReconnect[0].resumed, true)
+      assert.deepEqual(guestParticipantIds(store), [firstPid])
+    })
+  },
+)
+
+test(
+  'guest hello allocates a new participant seat when stable client identity has no prior mapping',
+  hostInboxTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTNEW1'
+    const guestStableA = 'MVGUESTNEWA'
+    const guestStableB = 'MVGUESTNEWB'
+    const suffix = 'NEWSEAT1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`hello-new-seat-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = bindHostStoreHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+
+      const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
+
+      simulateHostInboxMessage(harness, suffix, guestStableA, encodeHello(guestStableA))
+      harness.emitChildAdded(guestOnlineRoot, guestStableA)
+      harness.emitValue(`${guestOnlineRoot}/${guestStableA}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const welcomeA = parseWelcomeWrites(harness.sets, guestStableA)
+      assert.equal(welcomeA.length, 1)
+      assert.equal(welcomeA[0].resumed, false)
+      const pidA = welcomeA[0].participantId
+      assert.ok(pidA)
+
+      const setsBeforeSecondGuest = harness.sets.length
+      simulateHostInboxMessage(harness, suffix, guestStableB, encodeHello(guestStableB))
+      harness.emitChildAdded(guestOnlineRoot, guestStableB)
+      harness.emitValue(`${guestOnlineRoot}/${guestStableB}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const welcomeB = parseWelcomeWrites(harness.sets.slice(setsBeforeSecondGuest), guestStableB)
+      assert.equal(welcomeB.length, 1)
+      assert.equal(welcomeB[0].resumed, false)
+      const pidB = welcomeB[0].participantId
+      assert.ok(pidB)
+      assert.notEqual(pidA, pidB)
+      assert.deepEqual(guestParticipantIds(store).sort(), [pidA, pidB].sort())
+    })
+  },
+)
+
+test(
+  'draft inbox aggregates into room authority and rebroadcasts with increasing seq',
+  hostInboxTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTDRAFT1'
+    const guestStableId = 'MVGUESTDRAFT'
+    const suffix = 'DRAFT1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`draft-agg-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = bindHostStoreHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.ok(maxStateSeq(harness.sets) >= 1, 'host start should publish initial room authority')
+
+      const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
+
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      harness.emitChildAdded(guestOnlineRoot, guestStableId)
+      harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const guestPid = guestParticipantIds(store)[0]
+      assert.ok(guestPid)
+
+      const baselineSeq = maxStateSeq(harness.sets)
+
+      const guestPick = {
+        localId: 'g1',
+        source: 'custom',
+        tmdbId: null,
+        customKey: 'gamma',
+        title: 'Gamma',
+        posterPath: null,
+        overview: '',
+      }
+
+      const setsBeforeDraft = harness.sets.length
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeDraft([guestPick], false, guestPid),
+      )
+
+      const draftBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeDraft))
+      assert.ok(draftBroadcasts.length >= 1, 'draft inbox should rebroadcast room authority')
+      const latestDraft = draftBroadcasts[draftBroadcasts.length - 1]
+      assert.ok(
+        latestDraft.seq > baselineSeq,
+        'monotonic authority broadcast seq must increase after draft aggregation',
+      )
+
+      const guestRow = latestDraft.payload.participants.find((p) => p.id === guestPid)
+      assert.ok(guestRow)
+      assert.equal(guestRow.pickCount, 1)
+      assert.equal(latestDraft.payload.uniqueSuggestedMovieCount, 1)
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionFacadePosture.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadePosture.test.js
@@ -1,0 +1,383 @@
+/**
+ * Movie Vote facade connection posture — structured shell events and strict guest presence.
+ * Separate from domain wire / RTDB lifecycle tests.
+ *
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionFacadePosture.test.js
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import { encodeState } from './protocol.js'
+import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  refPath,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const postureTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {import('../types.js').MovieVotePublicPayload} */
+const JOINABLE_SUGGEST_PAYLOAD = buildMovieVotePublicPayload(
+  {
+    phase: 'suggest',
+    readyToVote: false,
+    myDraftPicks: [],
+    ballotMovies: [],
+    ballotOrderIds: [],
+    voteProgress: null,
+    irvResult: null,
+    votingMethod: 'irv',
+  },
+  new Map(),
+)
+
+const JOINABLE_HOST_STATE = encodeState(JOINABLE_SUGGEST_PAYLOAD, 1)
+
+/**
+ * Production bridge shape without mounting Vue; fake inbound payload apply only.
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ */
+function bindPostureHandlers(sessionMod) {
+  setActivePinia(createPinia())
+  const room = useMovieVoteRoomSessionStore()
+  sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: () => {},
+    onWireTeardown: () => {},
+  })
+  return { room }
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @param {string} leaf
+ * @returns {(value: unknown) => void}
+ */
+function listenerAt(listeners, leaf) {
+  const path = [...listeners.keys()].find((p) => p.endsWith(leaf))
+  assert.ok(path, `expected listener on path ending with ${leaf}`)
+  const handler = listeners.get(path)
+  assert.ok(handler)
+  return (value) => handler({ val: () => value })
+}
+
+/**
+ * @param {() => string} readPhase
+ * @returns {Promise<void>}
+ */
+async function waitForReconnectExhaustion(readPhase) {
+  const deadline = Date.now() + 3_000
+  while (readPhase() !== 'idle' && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+test(
+  'fatal reconnect exhaustion clears persistence and returns tab to idle',
+  postureTests,
+  async () => {
+    mock.reset()
+
+    mock.module('../../p2p/starRoomReconnectDelay.js', {
+      namedExports: {
+        starRoomReconnectDelayMs: () => 5,
+      },
+    })
+    mock.module('../../p2p/starRoomTiming.js', {
+      namedExports: {
+        RECONNECT_MAX_ATTEMPTS: 3,
+        RECONNECT_INITIAL_PAUSE_MS: 5,
+        RECONNECT_BASE_DELAY_MS: 5,
+        RECONNECT_MAX_DELAY_MS: 5,
+      },
+    })
+
+    let roomJoinable = true
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => (roomJoinable ? Date.now() : null),
+      getState: () => (roomJoinable ? JOINABLE_HOST_STATE : null),
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`fatal-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('FATAL1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'FATAL1')
+
+      roomJoinable = false
+      listenerAt(listeners, 'connected')(false)
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      await waitForReconnectExhaustion(() => sessionPhase.value)
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+    })
+  },
+)
+
+test(
+  'connectivity_offline moves guest connection posture to reconnecting',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`offline-${Date.now()}`)
+      const { joinRoom, sessionPhase } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('OFFLN1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(listeners, 'connected')(false)
+
+      assert.equal(sessionPhase.value, 'reconnecting')
+    })
+  },
+)
+
+test(
+  'host_ended_room triggers room exit on guest tab',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`ended-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('END123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+
+      listenerAt(listeners, 'ended')(1_700_000_000_000)
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+    })
+  },
+)
+
+test(
+  'strict guest presence does not wire hostPing (Movie Vote; Game Timer uses loose attachment)',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`strict-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('STRICT')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(
+        [...listeners.keys()].some((p) => p.endsWith('hostPing')),
+        false,
+        'strict guest should not subscribe to hostPing',
+      )
+
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(sessionSuffix.value, 'STRICT')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'STRICT')
+    })
+  },
+)
+
+test(
+  'strict guest joins without hostPing when joinable state is present',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`state-only-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      const { room } = bindPostureHandlers(sessionMod)
+
+      await joinRoom('STATE1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(sessionSuffix.value, 'STATE1')
+      assert.equal(
+        [...listeners.keys()].some((p) => p.endsWith('hostPing')),
+        false,
+        'strict guest should not subscribe to hostPing',
+      )
+      assert.equal(room.role, 'guest')
+    })
+  },
+)
+
+test(
+  'guest establish marks guestOnline for stable client',
+  postureTests,
+  async () => {
+    mock.reset()
+    const stableId = 'MVPOSTUREGUEST'
+    /** @type {Array<{ path: string, value: unknown }>} */
+    const rtdbSets = []
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => stableId,
+        deriveStableHostSuffix: () => 'AAAAAA',
+      },
+    })
+
+    const actualRtdb = await import('../firebase/rtdb.js')
+    mock.module('../firebase/rtdb.js', {
+      namedExports: {
+        ...actualRtdb,
+        setRtdb: async (ref, value) => {
+          rtdbSets.push({ path: refPath(ref), value })
+          return actualRtdb.setRtdb(ref, value)
+        },
+      },
+    })
+
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`guest-online-${Date.now()}`)
+      const { joinRoom, sessionPhase } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('JOIN01')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      assert.ok(
+        rtdbSets.some(
+          (s) => s.path.includes('guestOnline') && s.path.includes(stableId) && s.value === true,
+        ),
+        'guest establish should mark guestOnline',
+      )
+    })
+  },
+)
+
+test(
+  'guest teardown clears guestOnline signal for stable client',
+  postureTests,
+  async () => {
+    mock.reset()
+    const stableId = 'MVPOSTUREOFF'
+    /** @type {Array<{ path: string, value: unknown }>} */
+    const rtdbSets = []
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => stableId,
+        deriveStableHostSuffix: () => 'AAAAAA',
+      },
+    })
+
+    const actualRtdb = await import('../firebase/rtdb.js')
+    mock.module('../firebase/rtdb.js', {
+      namedExports: {
+        ...actualRtdb,
+        setRtdb: async (ref, value) => {
+          rtdbSets.push({ path: refPath(ref), value })
+          return actualRtdb.setRtdb(ref, value)
+        },
+      },
+    })
+
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`guest-offline-${Date.now()}`)
+      const { joinRoom, sessionPhase, teardownSession } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('TEAR01')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      teardownSession()
+
+      assert.ok(
+        rtdbSets.some(
+          (s) => s.path.includes('guestOnline') && s.path.includes(stableId) && s.value === false,
+        ),
+        'guest teardown should mark guestOnline false',
+      )
+    })
+  },
+)
+
+test(
+  'host_tab_visible updates remoteHostTabVisible ref',
+  postureTests,
+  async () => {
+    mock.reset()
+    const { listeners } = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vis-${Date.now()}`)
+      const { joinRoom, remoteHostTabVisible, sessionPhase } = sessionMod
+      bindPostureHandlers(sessionMod)
+
+      await joinRoom('VIS001')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(remoteHostTabVisible.value, true)
+
+      const { encodeHostVisibility } = await import('./protocol.js')
+      listenerAt(listeners, 'hostVisible')(encodeHostVisibility(false))
+      assert.equal(remoteHostTabVisible.value, false)
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(listeners, 'hostVisible')(encodeHostVisibility(true))
+      assert.equal(remoteHostTabVisible.value, true)
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionFacadeReconnect.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeReconnect.test.js
@@ -17,6 +17,7 @@ import {
   refPath,
   withFirebaseEnv,
 } from './sessionRtdbLifecycleHarness.js'
+import { bumpMovieVoteReconnectGenerationForTests } from './session.testExports.js'
 
 const facadeReconnectTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
@@ -44,17 +45,6 @@ async function waitForPhase(condition, label) {
 }
 
 /**
- * @param {() => string} readPhase
- * @returns {Promise<void>}
- */
-async function waitForReconnectExhaustion(readPhase) {
-  const deadline = Date.now() + 3_000
-  while (readPhase() !== 'idle' && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 20))
-  }
-}
-
-/**
  * @param {import('../../p2p/starRoomShell.js').StarRoomGuestReconnectHandlers} h
  * @returns {Promise<void>}
  */
@@ -65,7 +55,7 @@ async function runGuestReconnectWithSupersedeHook(h) {
     sleep: async () => {},
     establishGuest: async () => {
       await h.establishGuest()
-      guestSessionForShellHook?.bumpMovieVoteReconnectGenerationForTests()
+      if (guestSessionForShellHook) bumpMovieVoteReconnectGenerationForTests(guestSessionForShellHook)
     },
   })
 }
@@ -94,20 +84,6 @@ async function installGuestReconnectShellHook() {
       ...shellActual,
       runGuestStarReconnectLoop: runGuestReconnectWithSupersedeHook,
       runHostStarReconnectLoop: shellActual.runHostStarReconnectLoop,
-    },
-  })
-}
-
-/**
- * @returns {Promise<void>}
- */
-async function installFastGuestReconnectShell() {
-  const shellActual = await import('../../p2p/starRoomShell.js')
-  mock.module('../../p2p/starRoomShell.js', {
-    namedExports: {
-      ...shellActual,
-      runGuestStarReconnectLoop: (h) =>
-        shellActual.runGuestStarReconnectLoop({ ...h, sleep: async () => {} }),
     },
   })
 }
@@ -421,10 +397,12 @@ test(
 )
 
 test(
-  'fatal reconnect exhaustion clears persistence and returns tab to idle',
+  'host fatal reconnect exhaustion clears persistence without deliberate room end',
   facadeReconnectTests,
   async () => {
     mock.reset()
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
 
     mock.module('../../p2p/starRoomReconnectDelay.js', {
       namedExports: {
@@ -440,43 +418,61 @@ test(
       },
     })
 
-    await installFastGuestReconnectShell()
+    const hostStableId = 'MVHOSTFATAL1'
+    const suffix = 'HFATAL1'
 
-    const actualRtdb = await import('../firebase/rtdb.js')
-    mock.module('../firebase/rtdb.js', {
-      namedExports: { ...actualRtdb },
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
     })
 
-    let roomJoinable = true
+    await installHostReconnectShellHook()
+
+    let roomOccupiedByOther = false
     const harness = await installRtdbLifecycleMocks({
-      getHostPing: () => (roomJoinable ? Date.now() : null),
-      getState: () => (roomJoinable ? JOINABLE_HOST_STATE : null),
+      getHostPing: () => (roomOccupiedByOther ? Date.now() : null),
+      getHostClientId: () => (roomOccupiedByOther ? 'occupant-other-host' : hostStableId),
       getEnded: () => null,
+      getState: () => JOINABLE_HOST_STATE,
     })
 
     await withFirebaseEnv(async () => {
-      const sessionMod = await importMovieVoteSession(`fatal-${Date.now()}`)
-      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
-      bindFakeHandlers(sessionMod)
-
       setActivePinia(createPinia())
-      const room = useMovieVoteRoomSessionStore()
+      const hostRoom = useMovieVoteRoomSessionStore()
 
-      await joinRoom('FATAL1')
-      assert.equal(sessionPhase.value, 'guest_connected')
-      assert.equal(room.role, 'guest')
-      assert.equal(room.suffix, 'FATAL1')
+      const hostMod = await importMovieVoteSession(`host-fatal-${Date.now()}`)
+      bindFakeHandlers(hostMod)
+      const { startAsHost, sessionPhase, sessionSuffix } = hostMod
 
-      roomJoinable = false
-      getConnectedEmitter(harness.listeners)(false)
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(hostRoom.role, 'host')
+
+      roomOccupiedByOther = true
+
+      const connectedPath = [...harness.listeners.keys()].find((p) => p.endsWith('connected'))
+      assert.ok(connectedPath)
+      const hostOnConnected = harness.listeners.get(connectedPath)
+      assert.ok(hostOnConnected)
+      hostOnConnected({ val: () => false })
       assert.equal(sessionPhase.value, 'reconnecting')
 
-      await waitForReconnectExhaustion(() => sessionPhase.value)
+      const deadline = Date.now() + 3_000
+      while (sessionPhase.value !== 'idle' && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      }
+      assert.equal(sessionPhase.value, 'idle', 'host fatal exhaustion')
 
-      assert.equal(sessionPhase.value, 'idle')
       assert.equal(sessionSuffix.value, null)
-      assert.equal(room.role, null)
-      assert.equal(room.suffix, null)
+      assert.equal(hostRoom.role, null)
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'host fatal exhaustion must not broadcast deliberate room end',
+      )
     })
   },
 )

--- a/src/features/movie-vote/p2p/sessionFacadeReconnect.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeReconnect.test.js
@@ -1,0 +1,484 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionFacadeReconnect.test.js
+ *
+ * Star-room shell reconnect integration at the Movie Vote session facade — teardown
+ * ordering and persistence/posture outcomes only (no Quasar Notify assertions).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import { encodeState } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  refPath,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const facadeReconnectTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {Awaited<ReturnType<typeof importMovieVoteSession>> | null} */
+let guestSessionForShellHook = null
+
+/** @type {typeof import('../../p2p/starRoomShell.js').runGuestStarReconnectLoop | null} */
+let realGuestStarReconnectLoop = null
+
+/** @type {typeof import('../../p2p/starRoomShell.js').runHostStarReconnectLoop | null} */
+let realHostStarReconnectLoop = null
+
+/**
+ * @param {() => boolean} condition
+ * @param {string} label
+ * @returns {Promise<void>}
+ */
+async function waitForPhase(condition, label) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error(`timed out waiting for ${label}`)
+}
+
+/**
+ * @param {() => string} readPhase
+ * @returns {Promise<void>}
+ */
+async function waitForReconnectExhaustion(readPhase) {
+  const deadline = Date.now() + 3_000
+  while (readPhase() !== 'idle' && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+/**
+ * @param {import('../../p2p/starRoomShell.js').StarRoomGuestReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+async function runGuestReconnectWithSupersedeHook(h) {
+  assert.ok(realGuestStarReconnectLoop)
+  return realGuestStarReconnectLoop({
+    ...h,
+    sleep: async () => {},
+    establishGuest: async () => {
+      await h.establishGuest()
+      guestSessionForShellHook?.bumpMovieVoteReconnectGenerationForTests()
+    },
+  })
+}
+
+/**
+ * @param {import('../../p2p/starRoomShell.js').StarRoomHostReconnectHandlers} h
+ * @returns {Promise<void>}
+ */
+async function runHostReconnectWithoutBackoff(h) {
+  assert.ok(realHostStarReconnectLoop)
+  return realHostStarReconnectLoop({
+    ...h,
+    sleep: async () => {},
+  })
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function installGuestReconnectShellHook() {
+  const shellActual = await import('../../p2p/starRoomShell.js')
+  realGuestStarReconnectLoop = shellActual.runGuestStarReconnectLoop
+  realHostStarReconnectLoop = shellActual.runHostStarReconnectLoop
+  mock.module('../../p2p/starRoomShell.js', {
+    namedExports: {
+      ...shellActual,
+      runGuestStarReconnectLoop: runGuestReconnectWithSupersedeHook,
+      runHostStarReconnectLoop: shellActual.runHostStarReconnectLoop,
+    },
+  })
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function installFastGuestReconnectShell() {
+  const shellActual = await import('../../p2p/starRoomShell.js')
+  mock.module('../../p2p/starRoomShell.js', {
+    namedExports: {
+      ...shellActual,
+      runGuestStarReconnectLoop: (h) =>
+        shellActual.runGuestStarReconnectLoop({ ...h, sleep: async () => {} }),
+    },
+  })
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function installHostReconnectShellHook() {
+  const shellActual = await import('../../p2p/starRoomShell.js')
+  if (!realGuestStarReconnectLoop) {
+    realGuestStarReconnectLoop = shellActual.runGuestStarReconnectLoop
+    realHostStarReconnectLoop = shellActual.runHostStarReconnectLoop
+  }
+  mock.module('../../p2p/starRoomShell.js', {
+    namedExports: {
+      ...shellActual,
+      runGuestStarReconnectLoop: realGuestStarReconnectLoop,
+      runHostStarReconnectLoop: runHostReconnectWithoutBackoff,
+    },
+  })
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ * @returns {{ applied: import('../types.js').MovieVotePublicPayload[] }}
+ */
+function bindFakeHandlers(sessionMod) {
+  /** @type {import('../types.js').MovieVotePublicPayload[]} */
+  const applied = []
+  sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (p) => {
+      applied.push(p)
+    },
+    onWireTeardown: () => {},
+  })
+  return { applied }
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @returns {(connected: boolean) => void}
+ */
+function getConnectedEmitter(listeners) {
+  const connectedPath = [...listeners.keys()].find((p) => p.endsWith('connected'))
+  assert.ok(connectedPath, 'session should subscribe to Firebase .info/connected')
+  const onConnected = listeners.get(connectedPath)
+  assert.ok(onConnected)
+  return (connected) => onConnected({ val: () => connected })
+}
+
+/** @type {import('../types.js').MovieVotePublicPayload} */
+const JOINABLE_SUGGEST_PAYLOAD = buildMovieVotePublicPayload(
+  {
+    phase: 'suggest',
+    readyToVote: false,
+    myDraftPicks: [],
+    ballotMovies: [],
+    ballotOrderIds: [],
+    voteProgress: null,
+    irvResult: null,
+    votingMethod: 'irv',
+  },
+  new Map(),
+)
+
+const JOINABLE_HOST_STATE = encodeState(JOINABLE_SUGGEST_PAYLOAD, 1)
+
+test(
+  'superseded guest reconnect loop tears down wire only and keeps join persistence',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+    guestSessionForShellHook = null
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
+    await installGuestReconnectShellHook()
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`supersede-guest-${Date.now()}`)
+      guestSessionForShellHook = sessionMod
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      bindFakeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const room = useMovieVoteRoomSessionStore()
+
+      await joinRoom('SUP001')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'SUP001')
+
+      const emitConnected = getConnectedEmitter(harness.listeners)
+      emitConnected(false)
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      await waitForPhase(() => sessionPhase.value === 'idle', 'superseded loop unwind')
+
+      assert.equal(room.role, 'guest', 'superseded unwind must not clear join persistence')
+      assert.equal(room.suffix, 'SUP001')
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'superseded guest loop must not broadcast deliberate room end',
+      )
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+    })
+  },
+)
+
+test(
+  'host reconnect recovery does not end room for connected guests',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+    realGuestStarReconnectLoop = null
+    realHostStarReconnectLoop = null
+
+    const hostStableId = 'MVHOSTRCV01'
+    const guestStableId = 'MVGUESTRCV1'
+    const suffix = 'HRECV1'
+    let clientId = hostStableId
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => clientId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    await installHostReconnectShellHook()
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getHostClientId: () => hostStableId,
+      getEnded: () => null,
+      getState: () => JOINABLE_HOST_STATE,
+    })
+
+    await withFirebaseEnv(async () => {
+      const hostPinia = createPinia()
+      setActivePinia(hostPinia)
+
+      const hostMod = await importMovieVoteSession(`host-recover-${Date.now()}`)
+      bindFakeHandlers(hostMod)
+      const { startAsHost, sessionPhase: hostPhase } = hostMod
+
+      await startAsHost(3)
+      assert.equal(hostPhase.value, 'hosting')
+
+      const connectedPath = [...harness.listeners.keys()].find((p) => p.endsWith('connected'))
+      assert.ok(connectedPath)
+      const hostOnConnected = harness.listeners.get(connectedPath)
+      assert.ok(hostOnConnected)
+
+      clientId = guestStableId
+      const guestPinia = createPinia()
+      setActivePinia(guestPinia)
+
+      const guestMod = await importMovieVoteSession(`guest-recover-${Date.now()}`)
+      bindFakeHandlers(guestMod)
+      const { joinRoom, sessionPhase: guestPhase, sessionSuffix: guestSuffix } = guestMod
+      const guestRoom = useMovieVoteRoomSessionStore()
+
+      await joinRoom(suffix)
+      assert.equal(guestPhase.value, 'guest_connected')
+      assert.equal(guestRoom.role, 'guest')
+
+      setActivePinia(hostPinia)
+      hostOnConnected({ val: () => false })
+      assert.equal(hostPhase.value, 'reconnecting')
+
+      await waitForPhase(() => hostPhase.value === 'hosting', 'host reconnect recovery')
+
+      setActivePinia(guestPinia)
+      assert.equal(guestPhase.value, 'guest_connected')
+      assert.equal(guestSuffix.value, suffix)
+      assert.equal(guestRoom.role, 'guest')
+      assert.equal(
+        harness.sets.some((s) => s.path.endsWith('/ended')),
+        false,
+        'host reconnect recovery must not write deliberate room end',
+      )
+    })
+  },
+)
+
+test(
+  'host reclaim applies preserved payload and continues broadcast seq from RTDB',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVRECLAIM01'
+    const suffix = 'RECLM1'
+    /** @type {import('../types.js').MovieVotePublicPayload} */
+    const preservedPayload = buildMovieVotePublicPayload(
+      {
+        phase: 'voting',
+        readyToVote: true,
+        myDraftPicks: [
+          {
+            localId: 'h1',
+            source: 'custom',
+            tmdbId: null,
+            customKey: 'alpha',
+            title: 'Alpha',
+            posterPath: null,
+            overview: '',
+          },
+        ],
+        ballotMovies: [
+          {
+            publicId: 'm-alpha',
+            source: 'custom',
+            tmdbId: null,
+            customKey: 'alpha',
+            title: 'Alpha',
+            posterPath: null,
+            overview: '',
+          },
+          {
+            publicId: 'm-beta',
+            source: 'custom',
+            tmdbId: null,
+            customKey: 'beta',
+            title: 'Beta',
+            posterPath: null,
+            overview: '',
+          },
+        ],
+        ballotOrderIds: ['m-alpha', 'm-beta'],
+        voteProgress: { submitted: 1, total: 2 },
+        irvResult: null,
+        votingMethod: 'irv',
+      },
+      new Map([['guest-1', { picks: [], ready: true }]]),
+    )
+    const preservedState = encodeState(preservedPayload, 5)
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getHostClientId: () => hostStableId,
+      getEnded: () => null,
+      getState: () => preservedState,
+    })
+
+    /** @type {Array<{ path: string, value: { seq?: number } }>} */
+    const broadcastSets = []
+    const actualRtdb = await import('../firebase/rtdb.js')
+    mock.module('../firebase/rtdb.js', {
+      namedExports: {
+        ...actualRtdb,
+        setRtdb: async (ref, value) => {
+          broadcastSets.push({
+            path: refPath(ref),
+            value: /** @type {{ seq?: number }} */ (value),
+          })
+        },
+      },
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`reclaim-seq-${Date.now()}`)
+      const { resumeAsHost, sessionPhase, bindMovieVoteP2PHandlers } = sessionMod
+      const { applied } = bindFakeHandlers(sessionMod)
+      const outbound = bindMovieVoteP2PHandlers({})
+
+      setActivePinia(createPinia())
+      useMovieVoteRoomSessionStore().setHost(suffix)
+
+      const result = await resumeAsHost(suffix, 1)
+      assert.equal(result.suffix, suffix)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(applied.length, 1)
+      assert.equal(applied[0].phase, preservedPayload.phase)
+      assert.equal(applied[0].voteProgress?.submitted, preservedPayload.voteProgress?.submitted)
+      assert.deepEqual(applied[0].ballotOrderIds, preservedPayload.ballotOrderIds)
+
+      const resumePublish = broadcastSets.find((s) => s.path.endsWith('/state'))
+      assert.ok(resumePublish, 'host reclaim should publish hydrated authoritative state')
+      assert.equal(
+        resumePublish.value.seq,
+        6,
+        'first publish after reclaim should continue from RTDB seq',
+      )
+
+      broadcastSets.length = 0
+      outbound.hostLocalChanged()
+
+      const nextPublish = broadcastSets.find((s) => s.path.endsWith('/state'))
+      assert.ok(nextPublish, 'host broadcast should write authoritative state')
+      assert.equal(nextPublish.value.seq, 7, 'subsequent broadcast should monotonically advance seq')
+    })
+  },
+)
+
+test(
+  'fatal reconnect exhaustion clears persistence and returns tab to idle',
+  facadeReconnectTests,
+  async () => {
+    mock.reset()
+
+    mock.module('../../p2p/starRoomReconnectDelay.js', {
+      namedExports: {
+        starRoomReconnectDelayMs: () => 5,
+      },
+    })
+    mock.module('../../p2p/starRoomTiming.js', {
+      namedExports: {
+        RECONNECT_MAX_ATTEMPTS: 3,
+        RECONNECT_INITIAL_PAUSE_MS: 5,
+        RECONNECT_BASE_DELAY_MS: 5,
+        RECONNECT_MAX_DELAY_MS: 5,
+      },
+    })
+
+    await installFastGuestReconnectShell()
+
+    const actualRtdb = await import('../firebase/rtdb.js')
+    mock.module('../firebase/rtdb.js', {
+      namedExports: { ...actualRtdb },
+    })
+
+    let roomJoinable = true
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => (roomJoinable ? Date.now() : null),
+      getState: () => (roomJoinable ? JOINABLE_HOST_STATE : null),
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`fatal-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      bindFakeHandlers(sessionMod)
+
+      setActivePinia(createPinia())
+      const room = useMovieVoteRoomSessionStore()
+
+      await joinRoom('FATAL1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+      assert.equal(room.role, 'guest')
+      assert.equal(room.suffix, 'FATAL1')
+
+      roomJoinable = false
+      getConnectedEmitter(harness.listeners)(false)
+      assert.equal(sessionPhase.value, 'reconnecting')
+
+      await waitForReconnectExhaustion(() => sessionPhase.value)
+
+      assert.equal(sessionPhase.value, 'idle')
+      assert.equal(sessionSuffix.value, null)
+      assert.equal(room.role, null)
+      assert.equal(room.suffix, null)
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionFacadeRoomExit.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeRoomExit.test.js
@@ -1,0 +1,458 @@
+/**
+ * Movie Vote facade room exit survival contracts — distinct from Game Timer semantics.
+ *
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionFacadeRoomExit.test.js
+ *
+ * Unit-level leaveSession contracts live in sessionRoomLifecycle.test.js (no RTDB mocks).
+ * This file covers RTDB wire paths and cross-feature survival contrast.
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { DEFAULT_VOTING_METHOD } from '../votingMethod.js'
+import { useGameTimerStore } from '../../../stores/gameTimer.js'
+import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import { encodeState } from './protocol.js'
+import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const facadeRoomExitTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/** @type {import('../types.js').MovieVotePublicPayload} */
+const JOINABLE_SUGGEST_PAYLOAD = buildMovieVotePublicPayload(
+  {
+    phase: 'suggest',
+    readyToVote: false,
+    myDraftPicks: [],
+    ballotMovies: [],
+    ballotOrderIds: [],
+    voteProgress: null,
+    irvResult: null,
+    votingMethod: 'irv',
+  },
+  new Map(),
+)
+
+const JOINABLE_HOST_STATE = encodeState(JOINABLE_SUGGEST_PAYLOAD, 1)
+
+/** @returns {import('../types.js').MoviePick} */
+function customPick(localId, title) {
+  return {
+    localId,
+    source: 'custom',
+    tmdbId: null,
+    customKey: title.toLowerCase(),
+    title,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+/** @param {string} publicId */
+function ballotMovie(publicId) {
+  return {
+    publicId,
+    source: /** @type {const} */ ('custom'),
+    tmdbId: null,
+    customKey: publicId,
+    title: publicId,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+/**
+ * @param {ReturnType<typeof useMovieVoteStore>} store
+ */
+function seedCollaborationState(store) {
+  store.phase = 'voting'
+  store.readyToVote = true
+  store.setMyParticipantId('guest-1')
+  store.setParticipants([
+    { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+    { id: 'guest-1', ready: true, pickCount: 1 },
+  ])
+  store.setVotingMethod('borda')
+  store.setVotingState(
+    [ballotMovie('m-a'), ballotMovie('m-b')],
+    ['m-a', 'm-b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+  store.myRanking = ['m-a', 'm-b']
+  store.myVoteSubmitted = true
+  store.votesByParticipant = {
+    [HOST_PARTICIPANT_ID]: ['m-a', 'm-b'],
+    'guest-1': ['m-b', 'm-a'],
+  }
+  store.voteProgress = { submitted: 2, total: 2 }
+  store.uniqueSuggestedMovieCount = 3
+  store.phase = 'results'
+  store.irvResult = {
+    winnerId: 'm-a',
+    tieWinnerIds: null,
+    rounds: [{ activeIds: ['m-a', 'm-b'], ballotsWithVote: 2, eliminatedIds: [] }],
+    votingMethod: 'borda',
+  }
+}
+
+/**
+ * @param {{
+ *   phase: { value: string },
+ *   suffix: { value: string | null },
+ *   room: ReturnType<typeof useMovieVoteRoomSessionStore>,
+ *   store: ReturnType<typeof useMovieVoteStore>,
+ *   expectedDraftLocalIds?: string[],
+ *   expectedFullscreen?: boolean,
+ *   expectedRoomSuffix?: string | null,
+ * }} ctx
+ */
+function assertMovieVoteRoomExitSurvival(ctx) {
+  assert.equal(ctx.phase.value, 'idle', 'connection posture should be idle after room exit')
+  assert.equal(ctx.suffix.value, null, 'session suffix should clear after room exit')
+  assert.equal(ctx.room.role, null, 'persisted room role should clear after room exit')
+  if (ctx.expectedRoomSuffix === undefined) {
+    assert.equal(ctx.room.suffix, null, 'persisted room suffix should clear after room exit')
+  } else {
+    assert.equal(
+      ctx.room.suffix,
+      ctx.expectedRoomSuffix,
+      'persisted room suffix should match host reuse contract',
+    )
+  }
+  assert.equal(ctx.store.phase, 'suggest', 'collaboration phase should reset to suggest')
+  assert.equal(ctx.store.readyToVote, false, 'ready flag should clear after room exit')
+  assert.equal(ctx.store.myParticipantId, null, 'participant seat should clear after room exit')
+  assert.equal(ctx.store.participants.length, 0, 'participants should clear after room exit')
+  assert.equal(ctx.store.ballotMovies.length, 0, 'ballot movies should clear after room exit')
+  assert.equal(ctx.store.ballotOrderIds.length, 0, 'ballot order should clear after room exit')
+  assert.equal(ctx.store.myVoteSubmitted, false, 'vote submission should clear after room exit')
+  assert.equal(ctx.store.voterIds.length, 0, 'voter ids should clear after room exit')
+  assert.equal(
+    Object.keys(ctx.store.votesByParticipant).length,
+    0,
+    'votes by participant should clear after room exit',
+  )
+  assert.equal(ctx.store.myRanking.length, 0, 'personal ranking should clear after room exit')
+  assert.equal(ctx.store.irvResult, null, 'election results should clear after room exit')
+  assert.equal(ctx.store.voteProgress, null, 'vote progress should clear after room exit')
+  assert.equal(
+    ctx.store.uniqueSuggestedMovieCount,
+    0,
+    'suggested movie count should clear after room exit',
+  )
+  assert.equal(
+    ctx.store.votingMethod,
+    DEFAULT_VOTING_METHOD,
+    'voting method should reset to default after room exit',
+  )
+  if (ctx.expectedDraftLocalIds) {
+    assert.deepEqual(
+      ctx.store.myDraftPicks.map((p) => p.localId),
+      ctx.expectedDraftLocalIds,
+      'personal draft picks should survive room exit',
+    )
+  }
+  if (ctx.expectedFullscreen !== undefined) {
+    assert.equal(
+      ctx.store.fullscreenEnabled,
+      ctx.expectedFullscreen,
+      'fullscreen preference should survive room exit',
+    )
+  }
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof installRtdbLifecycleMocks>>} harness
+ * @param {string} [suffixHint]
+ */
+function assertDeliberateHostEndWirePaths(harness, suffixHint) {
+  const endedWrite = harness.sets.find((s) => s.path.endsWith('/ended'))
+  assert.ok(endedWrite, 'deliberate host end should write ended marker')
+  if (suffixHint) {
+    assert.ok(
+      endedWrite.path.includes(suffixHint),
+      `ended marker should target room suffix ${suffixHint}`,
+    )
+  }
+  assert.ok(
+    typeof endedWrite.value === 'number' && endedWrite.value > 0,
+    'ended marker should be a positive timestamp',
+  )
+  assert.ok(
+    harness.removes.some((r) => r.path.endsWith('/hostPing')),
+    'deliberate host end should remove hostPing',
+  )
+}
+
+/**
+ * @param {Map<string, (snap: { val: () => unknown }) => void>} listeners
+ * @param {string} leaf
+ * @returns {(value: unknown) => void}
+ */
+function listenerAt(listeners, leaf) {
+  const path = [...listeners.keys()].find((p) => p.endsWith(leaf))
+  assert.ok(path, `expected listener on path ending with ${leaf}`)
+  const handler = listeners.get(path)
+  assert.ok(handler)
+  return (value) => handler({ val: () => value })
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ * @param {{ onWireTeardown?: () => void }} [opts]
+ */
+function bindFacadeHandlers(sessionMod, opts = {}) {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const room = useMovieVoteRoomSessionStore()
+  sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: opts.onWireTeardown ?? (() => {}),
+  })
+  return { store, room }
+}
+
+/**
+ * @param {{ sets: Array<{ path: string, value: unknown }> }} harness
+ */
+function activeRtdbSetsClear(harness) {
+  harness.sets.length = 0
+  harness.removes.length = 0
+}
+
+test(
+  'host leaveSession writes deliberate end wire paths and resets collaboration',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVEXITHOST1'
+    const suffix = 'EXIT01'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`host-exit-${Date.now()}`)
+      const { startAsHost, leaveSession: hostLeave, sessionPhase, sessionSuffix } = sessionMod
+      let teardownCalls = 0
+      const { store, room } = bindFacadeHandlers(sessionMod, {
+        onWireTeardown: () => {
+          teardownCalls += 1
+        },
+      })
+
+      seedCollaborationState(store)
+      store.addDraftPick(customPick('d1', 'Nomination One'))
+      store.addDraftPick(customPick('d2', 'Nomination Two'))
+      const draftLocalIds = store.myDraftPicks.map((p) => p.localId)
+      store.setFullscreenEnabled(true)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      activeRtdbSetsClear(harness)
+
+      hostLeave()
+
+      assert.equal(teardownCalls, 1, 'room exit should invoke onWireTeardown handler')
+      assertDeliberateHostEndWirePaths(harness, suffix)
+      assertMovieVoteRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedDraftLocalIds: draftLocalIds,
+        expectedFullscreen: true,
+        expectedRoomSuffix: suffix,
+      })
+    })
+  },
+)
+
+test(
+  'guest RTDB ended marker matches deliberate host end survival contract',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`guest-ended-${Date.now()}`)
+      const { joinRoom, sessionPhase, sessionSuffix } = sessionMod
+      let teardownCalls = 0
+      const { store, room } = bindFacadeHandlers(sessionMod, {
+        onWireTeardown: () => {
+          teardownCalls += 1
+        },
+      })
+
+      seedCollaborationState(store)
+      store.addDraftPick(customPick('g1', 'Guest nomination'))
+      const draftLocalIds = store.myDraftPicks.map((p) => p.localId)
+      store.setFullscreenEnabled(true)
+
+      await joinRoom('END123')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      listenerAt(harness.listeners, 'ended')(1_700_000_000_000)
+
+      assert.equal(teardownCalls, 1, 'host ended room should invoke onWireTeardown handler')
+      assertMovieVoteRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedDraftLocalIds: draftLocalIds,
+        expectedFullscreen: true,
+      })
+    })
+  },
+)
+
+test(
+  'guest leaveSession after join clears persistence and collaboration state',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`guest-leave-${Date.now()}`)
+      const { joinRoom, leaveSession: guestLeave, sessionPhase, sessionSuffix } = sessionMod
+      let teardownCalls = 0
+      const { store, room } = bindFacadeHandlers(sessionMod, {
+        onWireTeardown: () => {
+          teardownCalls += 1
+        },
+      })
+
+      seedCollaborationState(store)
+      store.addDraftPick(customPick('l1', 'Leaver pick'))
+      const draftLocalIds = store.myDraftPicks.map((p) => p.localId)
+
+      await joinRoom('LEAVE1')
+      assert.equal(sessionPhase.value, 'guest_connected')
+
+      guestLeave()
+
+      assert.equal(teardownCalls, 1, 'guest leave should invoke onWireTeardown handler')
+      assertMovieVoteRoomExitSurvival({
+        phase: sessionPhase,
+        suffix: sessionSuffix,
+        room,
+        store,
+        expectedDraftLocalIds: draftLocalIds,
+      })
+    })
+  },
+)
+
+test(
+  'room exit survival clears movie vote collaboration but keeps game timer roster',
+  facadeRoomExitTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => JOINABLE_HOST_STATE,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const mv = await importMovieVoteSession(`mv-exit-contrast-${Date.now()}`)
+      let mvTeardownCalls = 0
+      const { store: mvStore, room: mvRoom } = bindFacadeHandlers(mv, {
+        onWireTeardown: () => {
+          mvTeardownCalls += 1
+        },
+      })
+
+      mvStore.setParticipants([
+        { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+        { id: 'guest-1', ready: false, pickCount: 1 },
+      ])
+      mvStore.phase = 'voting'
+      mvStore.addDraftPick(customPick('c1', 'Contrast pick'))
+      const draftLocalIds = mvStore.myDraftPicks.map((p) => p.localId)
+      mvRoom.setGuest('MVROOM')
+      mv.sessionPhase.value = 'guest_connected'
+
+      mv.leaveSession()
+
+      assert.equal(mvTeardownCalls, 1)
+      assertMovieVoteRoomExitSurvival({
+        phase: mv.sessionPhase,
+        suffix: mv.sessionSuffix,
+        room: mvRoom,
+        store: mvStore,
+        expectedDraftLocalIds: draftLocalIds,
+      })
+
+      const gt = await import(`../../game-timer/p2p/session.js?gt-exit-contrast=${Date.now()}`)
+
+      setActivePinia(createPinia())
+      const gtStore = useGameTimerStore()
+      const gtRoom = useGameTimerRoomSessionStore()
+      gtStore.addPlayer({ name: 'Timer Player', color: '#111111' })
+      const gtIds = gtStore.players.map((p) => p.id)
+      const gtNames = gtStore.players.map((p) => p.name)
+      gtRoom.setGuest('GTROOM')
+      gt.sessionPhase.value = 'guest_connected'
+
+      gt.bindGameTimerP2PHandlers({
+        getSnapshot: () => ({
+          players: [],
+          activePlayerId: null,
+          turnStartedAt: null,
+          turnStartedRound: null,
+          round: 1,
+          playerOrderByRound: {},
+        }),
+        applySnapshot: () => {},
+      })
+
+      gt.leaveSession()
+
+      assert.equal(gt.sessionPhase.value, 'idle')
+      assert.equal(gt.sessionSuffix.value, null)
+      assert.equal(gtRoom.role, null)
+      assert.equal(gtStore.players.length, 1, 'game timer room exit should keep player roster')
+      assert.deepEqual(gtStore.players.map((p) => p.id), gtIds)
+      assert.deepEqual(gtStore.players.map((p) => p.name), gtNames)
+      assert.equal(mvStore.participants.length, 0, 'movie vote room exit should clear participants')
+      assert.equal(mvStore.phase, 'suggest')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
@@ -12,6 +12,11 @@ import { runElection } from '../election.js'
 import { useMovieVoteStore } from '../../../stores/movieVote.js'
 import { encodeHello, encodeState, encodeVote, MSG_MV_DRAFT, parseState, encodeWelcome } from './protocol.js'
 import {
+  maxStateSeq,
+  parseStateBroadcasts,
+  simulateHostInboxMessage,
+} from '../../p2p/test/hostInboxHarness.js'
+import {
   createRtdbLifecycleAfterEach,
   importMovieVoteSession,
   installRtdbLifecycleMocks,
@@ -21,47 +26,14 @@ import {
 const voteAuthorityTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
 
-/**
- * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
- * @param {string} suffix
- * @param {string} guestStableId
- * @param {unknown} payload
- */
-function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
-  const inboxParent = `movieVoteRooms/${suffix}/inbox`
-  const childPath = `${inboxParent}/${guestStableId}`
-  assert.ok(
-    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
-    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
-  )
-  harness.emitChildAdded(inboxParent, guestStableId)
-  assert.ok(
-    harness.listeners.has(childPath),
-    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
-  )
-  harness.emitValue(childPath, payload)
+/** @param {Array<{ path: string, value: unknown }>} sets */
+function mvStateBroadcasts(sets) {
+  return parseStateBroadcasts(sets, parseState, 'payload')
 }
 
-/**
- * @param {Array<{ path: string, value: unknown }>} sets
- * @returns {Array<{ seq: number, payload: import('../types.js').MovieVotePublicPayload }>}
- */
-function parseStateBroadcasts(sets) {
-  return sets
-    .filter((entry) => entry.path.endsWith('/state'))
-    .map((entry) => {
-      const parsed = parseState(entry.value)
-      assert.ok(parsed, 'state write must be a host snapshot message')
-      return { seq: parsed.seq, payload: parsed.payload }
-    })
-}
-
-/**
- * @param {Array<{ path: string, value: unknown }>} sets
- * @returns {number}
- */
-function maxStateSeq(sets) {
-  return parseStateBroadcasts(sets).reduce((max, entry) => Math.max(max, entry.seq), 0)
+/** @param {Array<{ path: string, value: unknown }>} sets */
+function mvMaxStateSeq(sets) {
+  return maxStateSeq(sets, parseState, 'payload')
 }
 
 /**
@@ -128,7 +100,7 @@ async function bootstrapHostVotingWithGuest(harness, suffix, guestStableId, sess
 
   const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-  simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+  simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
   harness.emitChildAdded(guestOnlineRoot, guestStableId)
   harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
   hostSyncParticipantsFromRoom(outbound)
@@ -136,7 +108,7 @@ async function bootstrapHostVotingWithGuest(harness, suffix, guestStableId, sess
   const guestPid = guestParticipantIds(store)[0]
   assert.ok(guestPid)
 
-  simulateHostInboxMessage(harness, suffix, guestStableId, {
+  simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, {
     v: 1,
     type: MSG_MV_DRAFT,
     participantId: guestPid,
@@ -185,17 +157,18 @@ test(
         sessionMod,
       )
 
-      const baselineSeq = maxStateSeq(harness.sets)
+      const baselineSeq = mvMaxStateSeq(harness.sets)
       const setsBeforeVote = harness.sets.length
 
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ballotOrderIds),
       )
 
-      const voteBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeVote))
+      const voteBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeVote))
       assert.ok(voteBroadcasts.length >= 1, 'valid vote should rebroadcast room authority')
       const latest = voteBroadcasts[voteBroadcasts.length - 1]
       assert.ok(latest.seq > baselineSeq, 'monotonic authority broadcast seq must increase after vote merge')
@@ -243,7 +216,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -251,19 +224,20 @@ test(
       const guestPid = guestParticipantIds(store)[0]
       assert.ok(guestPid)
 
-      const baselineSeq = maxStateSeq(harness.sets)
+      const baselineSeq = mvMaxStateSeq(harness.sets)
       const setsBeforeVote = harness.sets.length
 
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ['fake-a', 'fake-b']),
       )
 
-      const strayBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeVote))
+      const strayBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeVote))
       assert.equal(strayBroadcasts.length, 0, 'suggest-phase vote must not rebroadcast authority')
-      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(mvMaxStateSeq(harness.sets), baselineSeq)
       assert.equal(Object.keys(store.votesByParticipant).length, 0)
       assert.equal(store.phase, 'suggest')
     })
@@ -312,34 +286,35 @@ test(
       ]
 
       for (const ranking of invalidRankings) {
-        const baselineSeq = maxStateSeq(harness.sets)
+        const baselineSeq = mvMaxStateSeq(harness.sets)
         const setsBefore = harness.sets.length
 
-        simulateHostInboxMessage(harness, suffix, guestStableId, encodeVote(guestPid, ranking))
+        simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeVote(guestPid, ranking))
 
-        const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+        const broadcasts = mvStateBroadcasts(harness.sets.slice(setsBefore))
         assert.equal(broadcasts.length, 0, `invalid ranking must not rebroadcast (${ranking.join(',')})`)
-        assert.equal(maxStateSeq(harness.sets), baselineSeq)
+        assert.equal(mvMaxStateSeq(harness.sets), baselineSeq)
         assert.equal(Object.keys(store.votesByParticipant).length, 0)
         assert.equal(store.voteProgress?.submitted, 0)
       }
 
-      const validSeq = maxStateSeq(harness.sets)
+      const validSeq = mvMaxStateSeq(harness.sets)
       const setsBeforeValid = harness.sets.length
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ballotOrderIds),
       )
-      const validBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeValid))
+      const validBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeValid))
       assert.ok(validBroadcasts.length >= 1, 'valid vote after rejects should still merge')
       assert.ok(validBroadcasts[validBroadcasts.length - 1].seq > validSeq)
       assert.equal(store.voteProgress?.submitted, 1)
 
       store.submitMyVoteLocal([...ballotOrderIds])
       outbound.hostAfterVoteSubmit()
-      const resultsBroadcast = parseStateBroadcasts(harness.sets).find((b) => b.payload.phase === 'results')
+      const resultsBroadcast = mvStateBroadcasts(harness.sets).find((b) => b.payload.phase === 'results')
       assert.ok(resultsBroadcast, 'complete valid votes commit via hostAfterVoteSubmit path')
     })
   },
@@ -433,19 +408,20 @@ test(
         sessionMod,
       )
 
-      const baselineSeq = maxStateSeq(harness.sets)
+      const baselineSeq = mvMaxStateSeq(harness.sets)
       const setsBefore = harness.sets.length
 
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(`${guestPid}-spoof`, ballotOrderIds),
       )
 
-      const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+      const broadcasts = mvStateBroadcasts(harness.sets.slice(setsBefore))
       assert.equal(broadcasts.length, 0, 'mismatched participant id must not rebroadcast authority')
-      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(mvMaxStateSeq(harness.sets), baselineSeq)
       assert.equal(Object.keys(store.votesByParticipant).length, 0)
       assert.equal(store.voteProgress?.submitted, 0)
     })
@@ -488,19 +464,20 @@ test(
       store.removeParticipantFromVote(guestPid)
       assert.ok(!store.voterIds.includes(guestPid))
 
-      const baselineSeq = maxStateSeq(harness.sets)
+      const baselineSeq = mvMaxStateSeq(harness.sets)
       const setsBefore = harness.sets.length
 
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ballotOrderIds),
       )
 
-      const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+      const broadcasts = mvStateBroadcasts(harness.sets.slice(setsBefore))
       assert.equal(broadcasts.length, 0, 'departed voter vote must not rebroadcast authority')
-      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(mvMaxStateSeq(harness.sets), baselineSeq)
       assert.equal(Object.keys(store.votesByParticipant).length, 0)
       assert.equal(store.voteProgress?.submitted, 0)
     })
@@ -596,6 +573,7 @@ test(
       const setsBeforeGuestVote = harness.sets.length
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ballotOrderIds),
@@ -603,7 +581,7 @@ test(
       assert.equal(store.phase, 'voting')
       assert.equal(store.voteProgress?.submitted, 1)
 
-      const guestVoteBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
+      const guestVoteBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
       assert.ok(
         guestVoteBroadcasts.every((b) => b.payload.phase === 'voting'),
         'partial votes must not commit results',
@@ -653,7 +631,7 @@ test(
       const setsBeforeCommit = harness.sets.length
       outbound.hostAfterVoteSubmit()
 
-      const commitBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeCommit))
+      const commitBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeCommit))
       assert.ok(commitBroadcasts.length >= 1, 'hostAfterVoteSubmit should rebroadcast committed results')
       const committed = commitBroadcasts[commitBroadcasts.length - 1]
       assert.equal(committed.payload.phase, 'results')
@@ -703,12 +681,13 @@ test(
       const setsBeforeGuestVote = harness.sets.length
       simulateHostInboxMessage(
         harness,
+        'movieVoteRooms',
         suffix,
         guestStableId,
         encodeVote(guestPid, ballotOrderIds),
       )
 
-      const commitBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
+      const commitBroadcasts = mvStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
       assert.ok(commitBroadcasts.length >= 1, 'final inbox vote should auto-commit via host tally path')
       const committed = commitBroadcasts[commitBroadcasts.length - 1]
       assert.equal(committed.payload.phase, 'results')

--- a/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
@@ -1,0 +1,722 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
+ *
+ * Host inbox vote validation and election results-entry authority at the session
+ * facade boundary (separate from posture and guest inbound domain wire tests).
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { runElection } from '../election.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { encodeHello, encodeState, encodeVote, MSG_MV_DRAFT, parseState, encodeWelcome } from './protocol.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const voteAuthorityTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+/**
+ * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {unknown} payload
+ */
+function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
+  const inboxParent = `movieVoteRooms/${suffix}/inbox`
+  const childPath = `${inboxParent}/${guestStableId}`
+  assert.ok(
+    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
+    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
+  )
+  harness.emitChildAdded(inboxParent, guestStableId)
+  assert.ok(
+    harness.listeners.has(childPath),
+    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
+  )
+  harness.emitValue(childPath, payload)
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {Array<{ seq: number, payload: import('../types.js').MovieVotePublicPayload }>}
+ */
+function parseStateBroadcasts(sets) {
+  return sets
+    .filter((entry) => entry.path.endsWith('/state'))
+    .map((entry) => {
+      const parsed = parseState(entry.value)
+      assert.ok(parsed, 'state write must be a host snapshot message')
+      return { seq: parsed.seq, payload: parsed.payload }
+    })
+}
+
+/**
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @returns {number}
+ */
+function maxStateSeq(sets) {
+  return parseStateBroadcasts(sets).reduce((max, entry) => Math.max(max, entry.seq), 0)
+}
+
+/**
+ * @param {ReturnType<typeof useMovieVoteStore>} store
+ * @returns {string[]}
+ */
+function guestParticipantIds(store) {
+  return store.participants
+    .filter((p) => p.id !== HOST_PARTICIPANT_ID)
+    .map((p) => p.id)
+}
+
+/**
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ */
+function bindHostStoreHandlers(sessionMod) {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const outbound = sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: () => {},
+  })
+  return { store, outbound }
+}
+
+/** @param {ReturnType<typeof bindHostStoreHandlers>['outbound']} outbound */
+function hostSyncParticipantsFromRoom(outbound) {
+  outbound.hostLocalChanged()
+}
+
+/**
+ * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ */
+async function bootstrapHostVotingWithGuest(harness, suffix, guestStableId, sessionMod) {
+  const { startAsHost, sessionPhase } = sessionMod
+  const { store, outbound } = bindHostStoreHandlers(sessionMod)
+
+  await startAsHost(3)
+  assert.equal(sessionPhase.value, 'hosting')
+
+  store.addDraftPick({
+    localId: 'h1',
+    source: 'custom',
+    tmdbId: null,
+    customKey: 'alpha',
+    title: 'Alpha',
+    posterPath: null,
+    overview: '',
+  })
+  store.addDraftPick({
+    localId: 'h2',
+    source: 'custom',
+    tmdbId: null,
+    customKey: 'beta',
+    title: 'Beta',
+    posterPath: null,
+    overview: '',
+  })
+
+  const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
+
+  simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+  harness.emitChildAdded(guestOnlineRoot, guestStableId)
+  harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
+  hostSyncParticipantsFromRoom(outbound)
+
+  const guestPid = guestParticipantIds(store)[0]
+  assert.ok(guestPid)
+
+  simulateHostInboxMessage(harness, suffix, guestStableId, {
+    v: 1,
+    type: MSG_MV_DRAFT,
+    participantId: guestPid,
+    ready: true,
+  })
+
+  store.setReadyToVote(true)
+  hostSyncParticipantsFromRoom(outbound)
+
+  assert.equal(store.phase, 'voting')
+  assert.ok(store.ballotOrderIds.length >= 2)
+
+  return { store, outbound, guestPid, ballotOrderIds: [...store.ballotOrderIds] }
+}
+
+test(
+  'valid vote during voting phase merges into authority and advances broadcast seq',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTVOTE1'
+    const guestStableId = 'MVGUESTVOTE1'
+    const suffix = 'VOTEOK1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-valid-${Date.now()}`)
+      const { store, guestPid, ballotOrderIds } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      const baselineSeq = maxStateSeq(harness.sets)
+      const setsBeforeVote = harness.sets.length
+
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ballotOrderIds),
+      )
+
+      const voteBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeVote))
+      assert.ok(voteBroadcasts.length >= 1, 'valid vote should rebroadcast room authority')
+      const latest = voteBroadcasts[voteBroadcasts.length - 1]
+      assert.ok(latest.seq > baselineSeq, 'monotonic authority broadcast seq must increase after vote merge')
+      assert.equal(latest.payload.phase, 'voting')
+      assert.equal(latest.payload.voteProgress?.submitted, 1)
+      assert.equal(latest.payload.voteProgress?.total, 2)
+      assert.ok(guestPid in store.votesByParticipant)
+      assert.deepEqual(store.votesByParticipant[guestPid], ballotOrderIds)
+    })
+  },
+)
+
+test(
+  'vote outside voting phase is rejected without tally corruption',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTPHASE1'
+    const guestStableId = 'MVGUESTPHASE'
+    const suffix = 'VOTEPH1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-phase-${Date.now()}`)
+      const { startAsHost, sessionPhase } = sessionMod
+      const { store, outbound } = bindHostStoreHandlers(sessionMod)
+
+      await startAsHost(3)
+      assert.equal(sessionPhase.value, 'hosting')
+      assert.equal(store.phase, 'suggest')
+
+      const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
+
+      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      harness.emitChildAdded(guestOnlineRoot, guestStableId)
+      harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
+      hostSyncParticipantsFromRoom(outbound)
+
+      const guestPid = guestParticipantIds(store)[0]
+      assert.ok(guestPid)
+
+      const baselineSeq = maxStateSeq(harness.sets)
+      const setsBeforeVote = harness.sets.length
+
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ['fake-a', 'fake-b']),
+      )
+
+      const strayBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeVote))
+      assert.equal(strayBroadcasts.length, 0, 'suggest-phase vote must not rebroadcast authority')
+      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(Object.keys(store.votesByParticipant).length, 0)
+      assert.equal(store.phase, 'suggest')
+    })
+  },
+)
+
+test(
+  'invalid ranking shape is rejected without tally corruption',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTBAD1'
+    const guestStableId = 'MVGUESTBAD1'
+    const suffix = 'VOTEBAD1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-invalid-${Date.now()}`)
+      const { store, guestPid, ballotOrderIds, outbound } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      /** @type {string[][]} */
+      const invalidRankings = [
+        ballotOrderIds.slice(0, -1),
+        [...ballotOrderIds, 'extra-id'],
+        [ballotOrderIds[0], ballotOrderIds[0]],
+        ['not-on-ballot', ...ballotOrderIds.slice(1)],
+      ]
+
+      for (const ranking of invalidRankings) {
+        const baselineSeq = maxStateSeq(harness.sets)
+        const setsBefore = harness.sets.length
+
+        simulateHostInboxMessage(harness, suffix, guestStableId, encodeVote(guestPid, ranking))
+
+        const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+        assert.equal(broadcasts.length, 0, `invalid ranking must not rebroadcast (${ranking.join(',')})`)
+        assert.equal(maxStateSeq(harness.sets), baselineSeq)
+        assert.equal(Object.keys(store.votesByParticipant).length, 0)
+        assert.equal(store.voteProgress?.submitted, 0)
+      }
+
+      const validSeq = maxStateSeq(harness.sets)
+      const setsBeforeValid = harness.sets.length
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ballotOrderIds),
+      )
+      const validBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeValid))
+      assert.ok(validBroadcasts.length >= 1, 'valid vote after rejects should still merge')
+      assert.ok(validBroadcasts[validBroadcasts.length - 1].seq > validSeq)
+      assert.equal(store.voteProgress?.submitted, 1)
+
+      store.submitMyVoteLocal([...ballotOrderIds])
+      outbound.hostAfterVoteSubmit()
+      const resultsBroadcast = parseStateBroadcasts(harness.sets).find((b) => b.payload.phase === 'results')
+      assert.ok(resultsBroadcast, 'complete valid votes commit via hostAfterVoteSubmit path')
+    })
+  },
+)
+
+/**
+ * @param {Awaited<ReturnType<typeof importMovieVoteSession>>} sessionMod
+ * @param {string[]} ballotOrderIds
+ */
+function bindGuestMirrorHandlers(sessionMod, ballotOrderIds) {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  /** @type {import('../types.js').MovieVotePublicPayload | null} */
+  let mirror = null
+
+  sessionMod.bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      mirror = structuredClone(payload)
+    },
+    onWireTeardown: () => {},
+  })
+
+  const votingPayload = {
+    phase: /** @type {const} */ ('voting'),
+    participants: [
+      { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+      { id: 'guest-seat-1', ready: true, pickCount: 0 },
+    ],
+    ballotMovies: ballotOrderIds.map((id) => ({
+      publicId: id,
+      source: /** @type {const} */ ('custom'),
+      tmdbId: null,
+      customKey: id,
+      title: id,
+      posterPath: null,
+      overview: '',
+    })),
+    ballotOrderIds: [...ballotOrderIds],
+    voteProgress: { submitted: 0, total: 2 },
+    irvResult: null,
+    uniqueSuggestedMovieCount: 0,
+    votingMethod: /** @type {const} */ ('irv'),
+  }
+
+  sessionMod.handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
+  sessionMod.handleGuestInboundState(encodeState(votingPayload, 1))
+  store.setMyParticipantId('guest-seat-1')
+  store.phase = 'voting'
+  store.ballotOrderIds = [...ballotOrderIds]
+  store.myRanking = [...ballotOrderIds]
+
+  return {
+    get mirror() {
+      return mirror
+    },
+    store,
+    sessionMod,
+  }
+}
+
+test(
+  'mismatched participant id in vote is rejected without tally corruption',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTPID1'
+    const guestStableId = 'MVGUESTPID1'
+    const suffix = 'VOTEPID1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-pid-${Date.now()}`)
+      const { store, guestPid, ballotOrderIds } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      const baselineSeq = maxStateSeq(harness.sets)
+      const setsBefore = harness.sets.length
+
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(`${guestPid}-spoof`, ballotOrderIds),
+      )
+
+      const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+      assert.equal(broadcasts.length, 0, 'mismatched participant id must not rebroadcast authority')
+      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(Object.keys(store.votesByParticipant).length, 0)
+      assert.equal(store.voteProgress?.submitted, 0)
+    })
+  },
+)
+
+test(
+  'vote from participant not in voterIds is rejected without tally corruption',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTVOT1'
+    const guestStableId = 'MVGUESTVOT1'
+    const suffix = 'VOTEVOT1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-voter-${Date.now()}`)
+      const { store, guestPid, ballotOrderIds } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      store.removeParticipantFromVote(guestPid)
+      assert.ok(!store.voterIds.includes(guestPid))
+
+      const baselineSeq = maxStateSeq(harness.sets)
+      const setsBefore = harness.sets.length
+
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ballotOrderIds),
+      )
+
+      const broadcasts = parseStateBroadcasts(harness.sets.slice(setsBefore))
+      assert.equal(broadcasts.length, 0, 'departed voter vote must not rebroadcast authority')
+      assert.equal(maxStateSeq(harness.sets), baselineSeq)
+      assert.equal(Object.keys(store.votesByParticipant).length, 0)
+      assert.equal(store.voteProgress?.submitted, 0)
+    })
+  },
+)
+
+test(
+  'guest local election recompute does not become mirror authority truth',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const ballotOrderIds = ['m_a', 'm_b']
+    const guestWire = bindGuestMirrorHandlers(
+      await importMovieVoteSession(`vote-guest-local-${Date.now()}`),
+      ballotOrderIds,
+    )
+
+    assert.equal(guestWire.mirror?.phase, 'voting')
+    assert.equal(guestWire.mirror?.irvResult, null)
+
+    const forgedLocal = runElection(
+      'irv',
+      [[ballotOrderIds[1], ballotOrderIds[0]], [ballotOrderIds[1], ballotOrderIds[0]]],
+      ballotOrderIds,
+    )
+    guestWire.store.setResults(forgedLocal)
+
+    assert.equal(guestWire.store.phase, 'results')
+    assert.ok(guestWire.store.irvResult)
+    assert.equal(guestWire.mirror?.phase, 'voting', 'local recompute must not promote mirror to results')
+    assert.equal(guestWire.mirror?.irvResult, null)
+
+    guestWire.sessionMod.handleGuestInboundState(
+      encodeState(
+        {
+          phase: 'results',
+          participants: guestWire.mirror?.participants ?? [],
+          ballotMovies: guestWire.mirror?.ballotMovies ?? null,
+          ballotOrderIds: [...ballotOrderIds],
+          voteProgress: { submitted: 2, total: 2 },
+          irvResult: runElection(
+            'irv',
+            [[ballotOrderIds[0], ballotOrderIds[1]], [ballotOrderIds[0], ballotOrderIds[1]]],
+            ballotOrderIds,
+          ),
+          uniqueSuggestedMovieCount: 0,
+          votingMethod: 'irv',
+        },
+        2,
+      ),
+    )
+
+    assert.equal(guestWire.mirror?.phase, 'results')
+    assert.ok(guestWire.mirror?.irvResult)
+    assert.equal(guestWire.mirror?.irvResult?.winnerId, ballotOrderIds[0])
+  },
+)
+
+test(
+  'election results enter authority only via hostAfterVoteSubmit, not partial votes or state replay',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTRES1'
+    const guestStableId = 'MVGUESTRES1'
+    const suffix = 'VOTERES1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-results-${Date.now()}`)
+      const { store, outbound, guestPid, ballotOrderIds } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      const setsBeforeGuestVote = harness.sets.length
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ballotOrderIds),
+      )
+      assert.equal(store.phase, 'voting')
+      assert.equal(store.voteProgress?.submitted, 1)
+
+      const guestVoteBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
+      assert.ok(
+        guestVoteBroadcasts.every((b) => b.payload.phase === 'voting'),
+        'partial votes must not commit results',
+      )
+      assert.ok(guestVoteBroadcasts.every((b) => b.payload.irvResult == null))
+
+      const guestWire = bindGuestMirrorHandlers(
+        await importMovieVoteSession(`vote-results-guest-${Date.now()}`),
+        ballotOrderIds,
+      )
+      guestWire.sessionMod.handleGuestInboundState(
+        encodeState(
+          {
+            phase: 'voting',
+            participants: guestWire.mirror?.participants ?? [],
+            ballotMovies: guestWire.mirror?.ballotMovies ?? null,
+            ballotOrderIds: [...ballotOrderIds],
+            voteProgress: { submitted: 1, total: 2 },
+            irvResult: null,
+            uniqueSuggestedMovieCount: 0,
+            votingMethod: 'irv',
+          },
+          2,
+        ),
+      )
+      assert.equal(guestWire.mirror?.phase, 'voting')
+
+      const forgedResults = {
+        phase: /** @type {const} */ ('results'),
+        participants: guestWire.mirror?.participants ?? [],
+        ballotMovies: guestWire.mirror?.ballotMovies ?? null,
+        ballotOrderIds: [...ballotOrderIds],
+        voteProgress: { submitted: 2, total: 2 },
+        irvResult: { winnerId: ballotOrderIds[0], rounds: [], declaredTie: false },
+        uniqueSuggestedMovieCount: 0,
+        votingMethod: /** @type {const} */ ('irv'),
+      }
+      guestWire.sessionMod.handleGuestInboundState(encodeState(forgedResults, 1))
+      assert.equal(
+        guestWire.mirror?.phase,
+        'voting',
+        'regressive results replay must not overwrite voting mirror',
+      )
+      assert.equal(guestWire.mirror?.irvResult, null)
+
+      store.submitMyVoteLocal([...ballotOrderIds])
+      const setsBeforeCommit = harness.sets.length
+      outbound.hostAfterVoteSubmit()
+
+      const commitBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeCommit))
+      assert.ok(commitBroadcasts.length >= 1, 'hostAfterVoteSubmit should rebroadcast committed results')
+      const committed = commitBroadcasts[commitBroadcasts.length - 1]
+      assert.equal(committed.payload.phase, 'results')
+      assert.ok(committed.payload.irvResult)
+      assert.equal(store.phase, 'results')
+      assert.ok(store.irvResult)
+    })
+  },
+)
+
+test(
+  'last guest vote via inbox auto-commits results when host vote already recorded',
+  voteAuthorityTests,
+  async () => {
+    mock.reset()
+
+    const hostStableId = 'MVHOSTAUTO1'
+    const guestStableId = 'MVGUESTAUTO1'
+    const suffix = 'VOTEAUTO1'
+
+    mock.module('../../p2p/identity.js', {
+      namedExports: {
+        ...(await import('../../p2p/identity.js')),
+        getStableClientId: () => hostStableId,
+        deriveStableHostSuffix: () => suffix,
+      },
+    })
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => null,
+      getEnded: () => null,
+      getHostClientId: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`vote-auto-${Date.now()}`)
+      const { store, guestPid, ballotOrderIds } = await bootstrapHostVotingWithGuest(
+        harness,
+        suffix,
+        guestStableId,
+        sessionMod,
+      )
+
+      store.submitMyVoteLocal([...ballotOrderIds])
+      assert.equal(store.voteProgress?.submitted, 1)
+
+      const setsBeforeGuestVote = harness.sets.length
+      simulateHostInboxMessage(
+        harness,
+        suffix,
+        guestStableId,
+        encodeVote(guestPid, ballotOrderIds),
+      )
+
+      const commitBroadcasts = parseStateBroadcasts(harness.sets.slice(setsBeforeGuestVote))
+      assert.ok(commitBroadcasts.length >= 1, 'final inbox vote should auto-commit via host tally path')
+      const committed = commitBroadcasts[commitBroadcasts.length - 1]
+      assert.equal(committed.payload.phase, 'results')
+      assert.ok(committed.payload.irvResult)
+      assert.equal(store.phase, 'results')
+      assert.ok(store.irvResult)
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
+++ b/src/features/movie-vote/p2p/sessionFacadeVoteAuthority.test.js
@@ -384,8 +384,8 @@ function bindGuestMirrorHandlers(sessionMod, ballotOrderIds) {
     votingMethod: /** @type {const} */ ('irv'),
   }
 
-  sessionMod.handleGuestWelcomeInbound(encodeWelcome('guest-seat-1', true))
-  sessionMod.handleGuestInboundState(encodeState(votingPayload, 1))
+  sessionMod.handleGuestInbound(encodeWelcome('guest-seat-1', true))
+  sessionMod.handleGuestInbound(encodeState(votingPayload, 1))
   store.setMyParticipantId('guest-seat-1')
   store.phase = 'voting'
   store.ballotOrderIds = [...ballotOrderIds]
@@ -534,7 +534,7 @@ test(
     assert.equal(guestWire.mirror?.phase, 'voting', 'local recompute must not promote mirror to results')
     assert.equal(guestWire.mirror?.irvResult, null)
 
-    guestWire.sessionMod.handleGuestInboundState(
+    guestWire.sessionMod.handleGuestInbound(
       encodeState(
         {
           phase: 'results',
@@ -614,7 +614,7 @@ test(
         await importMovieVoteSession(`vote-results-guest-${Date.now()}`),
         ballotOrderIds,
       )
-      guestWire.sessionMod.handleGuestInboundState(
+      guestWire.sessionMod.handleGuestInbound(
         encodeState(
           {
             phase: 'voting',
@@ -641,7 +641,7 @@ test(
         uniqueSuggestedMovieCount: 0,
         votingMethod: /** @type {const} */ ('irv'),
       }
-      guestWire.sessionMod.handleGuestInboundState(encodeState(forgedResults, 1))
+      guestWire.sessionMod.handleGuestInbound(encodeState(forgedResults, 1))
       assert.equal(
         guestWire.mirror?.phase,
         'voting',

--- a/src/features/movie-vote/p2p/sessionRoomLifecycle.test.js
+++ b/src/features/movie-vote/p2p/sessionRoomLifecycle.test.js
@@ -1,0 +1,211 @@
+/**
+ * Movie Vote facade room exit survival contracts — unit level (no RTDB mocks).
+ *
+ * Run: node --test src/features/movie-vote/p2p/sessionRoomLifecycle.test.js
+ *
+ * RTDB wire paths and cross-feature survival contrast live in sessionFacadeRoomExit.test.js.
+ */
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { HOST_PARTICIPANT_ID } from '../core.js'
+import { DEFAULT_VOTING_METHOD } from '../votingMethod.js'
+import { useMovieVoteStore } from '../../../stores/movieVote.js'
+import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSession.js'
+import {
+  bindMovieVoteP2PHandlers,
+  leaveSession,
+  sessionPhase,
+  sessionSuffix,
+  teardownSession,
+} from './session.js'
+
+/** @returns {import('../types.js').MoviePick} */
+function customPick(localId, title) {
+  return {
+    localId,
+    source: 'custom',
+    tmdbId: null,
+    customKey: title.toLowerCase(),
+    title,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+/** @param {string} publicId */
+function ballotMovie(publicId) {
+  return {
+    publicId,
+    source: /** @type {const} */ ('custom'),
+    tmdbId: null,
+    customKey: publicId,
+    title: publicId,
+    posterPath: null,
+    overview: '',
+  }
+}
+
+/**
+ * @param {ReturnType<typeof useMovieVoteStore>} store
+ */
+function seedCollaborationState(store) {
+  store.phase = 'voting'
+  store.readyToVote = true
+  store.setMyParticipantId('guest-1')
+  store.setParticipants([
+    { id: HOST_PARTICIPANT_ID, ready: true, pickCount: 2 },
+    { id: 'guest-1', ready: true, pickCount: 1 },
+  ])
+  store.setVotingMethod('borda')
+  store.setVotingState(
+    [ballotMovie('m-a'), ballotMovie('m-b')],
+    ['m-a', 'm-b'],
+    [HOST_PARTICIPANT_ID, 'guest-1'],
+  )
+  store.myRanking = ['m-a', 'm-b']
+  store.myVoteSubmitted = true
+  store.votesByParticipant = {
+    [HOST_PARTICIPANT_ID]: ['m-a', 'm-b'],
+    'guest-1': ['m-b', 'm-a'],
+  }
+  store.voteProgress = { submitted: 2, total: 2 }
+  store.uniqueSuggestedMovieCount = 3
+  store.phase = 'results'
+  store.irvResult = {
+    winnerId: 'm-a',
+    tieWinnerIds: null,
+    rounds: [{ activeIds: ['m-a', 'm-b'], ballotsWithVote: 2, eliminatedIds: [] }],
+    votingMethod: 'borda',
+  }
+}
+
+/**
+ * @param {{
+ *   phase: { value: string },
+ *   suffix: { value: string | null },
+ *   room: ReturnType<typeof useMovieVoteRoomSessionStore>,
+ *   store: ReturnType<typeof useMovieVoteStore>,
+ *   expectedDraftLocalIds?: string[],
+ *   expectedFullscreen?: boolean,
+ * }} ctx
+ */
+function assertMovieVoteRoomExitSurvival(ctx) {
+  assert.equal(ctx.phase.value, 'idle', 'connection posture should be idle after room exit')
+  assert.equal(ctx.suffix.value, null, 'session suffix should clear after room exit')
+  assert.equal(ctx.room.role, null, 'persisted room role should clear after room exit')
+  assert.equal(ctx.room.suffix, null, 'persisted room suffix should clear after room exit')
+  assert.equal(ctx.store.phase, 'suggest', 'collaboration phase should reset to suggest')
+  assert.equal(ctx.store.readyToVote, false, 'ready flag should clear after room exit')
+  assert.equal(ctx.store.myParticipantId, null, 'participant seat should clear after room exit')
+  assert.equal(ctx.store.participants.length, 0, 'participants should clear after room exit')
+  assert.equal(ctx.store.ballotMovies.length, 0, 'ballot movies should clear after room exit')
+  assert.equal(ctx.store.ballotOrderIds.length, 0, 'ballot order should clear after room exit')
+  assert.equal(ctx.store.myVoteSubmitted, false, 'vote submission should clear after room exit')
+  assert.equal(ctx.store.voterIds.length, 0, 'voter ids should clear after room exit')
+  assert.equal(
+    Object.keys(ctx.store.votesByParticipant).length,
+    0,
+    'votes by participant should clear after room exit',
+  )
+  assert.equal(ctx.store.myRanking.length, 0, 'personal ranking should clear after room exit')
+  assert.equal(ctx.store.irvResult, null, 'election results should clear after room exit')
+  assert.equal(ctx.store.voteProgress, null, 'vote progress should clear after room exit')
+  assert.equal(
+    ctx.store.uniqueSuggestedMovieCount,
+    0,
+    'suggested movie count should clear after room exit',
+  )
+  assert.equal(
+    ctx.store.votingMethod,
+    DEFAULT_VOTING_METHOD,
+    'voting method should reset to default after room exit',
+  )
+  if (ctx.expectedDraftLocalIds) {
+    assert.deepEqual(
+      ctx.store.myDraftPicks.map((p) => p.localId),
+      ctx.expectedDraftLocalIds,
+      'personal draft picks should survive room exit',
+    )
+  }
+  if (ctx.expectedFullscreen !== undefined) {
+    assert.equal(
+      ctx.store.fullscreenEnabled,
+      ctx.expectedFullscreen,
+      'fullscreen preference should survive room exit',
+    )
+  }
+}
+
+test('leaveSession clears collaboration but keeps personal drafts and fullscreen', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const room = useMovieVoteRoomSessionStore()
+  seedCollaborationState(store)
+  store.addDraftPick(customPick('d1', 'Nomination One'))
+  store.addDraftPick(customPick('d2', 'Nomination Two'))
+  const draftLocalIds = store.myDraftPicks.map((p) => p.localId)
+  store.setFullscreenEnabled(true)
+  room.setGuest('MVROOM1')
+
+  let teardownCalls = 0
+  bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: () => {
+      teardownCalls += 1
+    },
+  })
+
+  leaveSession()
+
+  assert.equal(teardownCalls, 1, 'room exit should invoke onWireTeardown handler')
+  assertMovieVoteRoomExitSurvival({
+    phase: sessionPhase,
+    suffix: sessionSuffix,
+    room,
+    store,
+    expectedDraftLocalIds: draftLocalIds,
+    expectedFullscreen: true,
+  })
+})
+
+test('leaveSession as host clears room persistence and collaboration state', () => {
+  setActivePinia(createPinia())
+  const store = useMovieVoteStore()
+  const room = useMovieVoteRoomSessionStore()
+  seedCollaborationState(store)
+  store.addDraftPick(customPick('h1', 'Host pick'))
+  const draftLocalIds = store.myDraftPicks.map((p) => p.localId)
+  room.setHost('HOST01')
+
+  let teardownCalls = 0
+  bindMovieVoteP2PHandlers({
+    applyPublicPayload: (payload) => {
+      store.applyPublicPayload(payload)
+    },
+    onWireTeardown: () => {
+      teardownCalls += 1
+    },
+  })
+
+  leaveSession()
+
+  assert.equal(teardownCalls, 1, 'room exit should invoke onWireTeardown handler')
+  assertMovieVoteRoomExitSurvival({
+    phase: sessionPhase,
+    suffix: sessionSuffix,
+    room,
+    store,
+    expectedDraftLocalIds: draftLocalIds,
+  })
+})
+
+afterEach(() => {
+  teardownSession()
+  bindMovieVoteP2PHandlers({
+    applyPublicPayload: () => {},
+    onWireTeardown: () => {},
+  })
+})

--- a/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
@@ -14,30 +14,10 @@ import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSessi
 import { encodeHello, encodeState, MSG_MV_DRAFT } from './protocol.js'
 import { ROOM_CLAIM_RESET_PATHS } from './sessionRoomRtdb.js'
 import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import { simulateHostInboxMessage } from '../../p2p/test/hostInboxHarness.js'
 import { installRtdbLifecycleMocks, withFirebaseEnv, refPath, importMovieVoteSession, createRtdbLifecycleAfterEach } from './sessionRtdbLifecycleHarness.js'
 
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
-
-/**
- * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
- * @param {string} suffix
- * @param {string} guestStableId
- * @param {unknown} payload
- */
-function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
-  const inboxParent = `movieVoteRooms/${suffix}/inbox`
-  const childPath = `${inboxParent}/${guestStableId}`
-  assert.ok(
-    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
-    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
-  )
-  harness.emitChildAdded(inboxParent, guestStableId)
-  assert.ok(
-    harness.listeners.has(childPath),
-    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
-  )
-  harness.emitValue(childPath, payload)
-}
 
 /** @param {string} nonce */
 async function importSession(nonce) {
@@ -445,7 +425,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -518,7 +498,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)
@@ -526,7 +506,7 @@ test(
       const guestPid = guestParticipantIds(store)[0]
       assert.ok(guestPid)
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, {
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, {
         v: 1,
         type: MSG_MV_DRAFT,
         participantId: guestPid,
@@ -580,7 +560,7 @@ test(
 
       const guestOnlineRoot = `movieVoteRooms/${suffix}/guestOnline`
 
-      simulateHostInboxMessage(harness, suffix, guestStableId, encodeHello(guestStableId))
+      simulateHostInboxMessage(harness, 'movieVoteRooms', suffix, guestStableId, encodeHello(guestStableId))
       harness.emitChildAdded(guestOnlineRoot, guestStableId)
       harness.emitValue(`${guestOnlineRoot}/${guestStableId}`, true)
       hostSyncParticipantsFromRoom(outbound)

--- a/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
+++ b/src/features/movie-vote/p2p/sessionRoomLifecycleRtdb.test.js
@@ -14,21 +14,9 @@ import { useMovieVoteRoomSessionStore } from '../../../stores/movieVoteRoomSessi
 import { encodeHello, encodeState, MSG_MV_DRAFT } from './protocol.js'
 import { ROOM_CLAIM_RESET_PATHS } from './sessionRoomRtdb.js'
 import { buildMovieVotePublicPayload } from '../publicPayload.js'
-import { installRtdbLifecycleMocks, withFirebaseEnv } from './sessionRtdbLifecycleHarness.js'
+import { installRtdbLifecycleMocks, withFirebaseEnv, refPath, importMovieVoteSession, createRtdbLifecycleAfterEach } from './sessionRtdbLifecycleHarness.js'
 
-/**
- * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
- * @returns {string}
- */
-function refPath(ref) {
-  const parts = []
-  let cur = ref
-  while (cur) {
-    if (cur.key) parts.unshift(cur.key)
-    cur = cur.parent ?? null
-  }
-  return parts.join('/')
-}
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
 
 /**
  * @param {ReturnType<typeof installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
@@ -53,7 +41,7 @@ function simulateHostInboxMessage(harness, suffix, guestStableId, payload) {
 
 /** @param {string} nonce */
 async function importSession(nonce) {
-  return import(`./session.js?mv-rtdb-lifecycle=${nonce}`)
+  return importMovieVoteSession(nonce)
 }
 
 /**
@@ -613,7 +601,4 @@ test(
   },
 )
 
-afterEach(async () => {
-  mock.timers.reset()
-  mock.reset()
-})
+afterEach(rtdbAfterEach)

--- a/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.js
+++ b/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.js
@@ -1,5 +1,5 @@
 /**
- * Shared RTDB mocks for Movie Vote P2P lifecycle / facade contract tests.
+ * Movie Vote RTDB lifecycle harness — thin wrapper over shared star-room test mocks.
  * Requires `node --experimental-test-module-mocks`.
  *
  * ## Module hygiene
@@ -7,203 +7,18 @@
  * - Prefer {@link importMovieVoteSession} with a unique nonce per test so each case gets a fresh
  *   `session.js` instance (isolated maps, seq counters, and listener registrations).
  * - When reusing one session module (e.g. static `import('./session.js')`), call
- *   `teardownSession()` then {@link resetMovieVoteFacadeWireStateForTests} from that module in
- *   `afterEach` so parallel runs do not leak handlers, `nextSeq`, or `lastSeenSeq`.
+ *   `teardownSession()` then reset helpers from `session.testExports.js` in `afterEach`.
  * - Use {@link createRtdbLifecycleAfterEach} for standard mock/timer cleanup after each case.
  */
 
-import { mock } from 'node:test'
-
-/** @type {Array<{ path: string, value: unknown }>} */
-let activeRtdbSets = []
-/** @type {Array<{ path: string }>} */
-let activeRtdbRemoves = []
-
-const REQUIRED_FIREBASE_ENV = {
-  VITE_FIREBASE_API_KEY: 'test-api-key',
-  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
-  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
-  VITE_FIREBASE_PROJECT_ID: 'test-project',
-  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
-}
-
-/** @param {() => void | Promise<void>} fn */
-export async function withFirebaseEnv(fn) {
-  const saved = {}
-  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-    saved[key] = process.env[key]
-    process.env[key] = REQUIRED_FIREBASE_ENV[key]
-  }
-  try {
-    await fn()
-  } finally {
-    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
-      if (saved[key] === undefined) delete process.env[key]
-      else process.env[key] = saved[key]
-    }
-  }
-}
-
-/**
- * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
- * @returns {string}
- */
-export function refPath(ref) {
-  const parts = []
-  let cur = ref
-  while (cur) {
-    if (cur.key) parts.unshift(cur.key)
-    cur = cur.parent ?? null
-  }
-  return parts.join('/')
-}
-
-/**
- * @param {string} dotPath
- * @returns {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }}
- */
-function buildRef(dotPath) {
-  const parts = dotPath.split('/').filter(Boolean)
-  /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null} */
-  let node = null
-  for (const part of parts) {
-    node = { key: part, parent: node }
-  }
-  return /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} */ (
-    node ?? { key: null, parent: null }
-  )
-}
-
-/**
- * @param {{
- *   getHostPing?: () => unknown,
- *   getEnded?: () => unknown,
- *   getHostClientId?: () => unknown,
- *   getState?: () => unknown,
- *   getWelcome?: () => unknown,
- *   getGuestOnline?: () => unknown,
- * }} [opts]
- * @returns {Promise<{
- *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
- *   sets: Array<{ path: string, value: unknown }>,
- *   removes: Array<{ path: string }>,
- *   childAddedParentPaths: () => string[],
- *   emitChildAdded: (parentPath: string, childKey: string) => void,
- *   emitValue: (path: string, value: unknown) => void,
- * }>}
- */
-export async function installRtdbLifecycleMocks(opts = {}) {
-  activeRtdbSets = []
-  activeRtdbRemoves = []
-
-  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
-  const listeners = new Map()
-  /** @type {Map<string, Set<(snap: { key: string | null, ref: ReturnType<typeof buildRef> }) => void>>} */
-  const childAddedHandlers = new Map()
-
-  /**
-   * @param {string} parentPath
-   * @param {string} childKey
-   */
-  function emitChildAdded(parentPath, childKey) {
-    const handlers = childAddedHandlers.get(parentPath)
-    if (!handlers?.size) return
-    const childPath = `${parentPath}/${childKey}`
-    const snap = { key: childKey, ref: buildRef(childPath) }
-    for (const handler of handlers) handler(snap)
-  }
-
-  /**
-   * @param {string} path
-   * @param {unknown} value
-   */
-  function emitValue(path, value) {
-    const handler = listeners.get(path)
-    if (handler) handler({ val: () => value })
-  }
-
-  const actual = await import('firebase/database')
-
-  mock.module('firebase/database', {
-    namedExports: {
-      ...actual,
-      get: async (ref) => {
-        if (ref.key === 'hostPing') {
-          return {
-            val: () => (opts.getHostPing !== undefined ? opts.getHostPing() : Date.now()),
-          }
-        }
-        if (ref.key === 'ended') {
-          return { val: () => (opts.getEnded !== undefined ? opts.getEnded() : null) }
-        }
-        if (ref.key === 'hostClientId') {
-          return {
-            val: () => (opts.getHostClientId !== undefined ? opts.getHostClientId() : null),
-          }
-        }
-        if (ref.key === 'state') {
-          return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
-        }
-        if (ref.key === 'welcome') {
-          return { val: () => (opts.getWelcome !== undefined ? opts.getWelcome() : null) }
-        }
-        if (ref.key === 'guestOnline') {
-          return {
-            val: () => (opts.getGuestOnline !== undefined ? opts.getGuestOnline() : null),
-          }
-        }
-        return { val: () => null }
-      },
-      set: async (ref, value) => {
-        activeRtdbSets.push({ path: refPath(ref), value })
-      },
-      remove: async (ref) => {
-        activeRtdbRemoves.push({ path: refPath(ref) })
-      },
-      onDisconnect: () => ({
-        remove: () => Promise.resolve(),
-        set: () => Promise.resolve(),
-      }),
-      onChildAdded: (ref, cb) => {
-        const path = refPath(ref)
-        if (!childAddedHandlers.has(path)) childAddedHandlers.set(path, new Set())
-        childAddedHandlers.get(path)?.add(cb)
-        return () => childAddedHandlers.get(path)?.delete(cb)
-      },
-      onValue: (ref, cb) => {
-        const path = refPath(ref)
-        listeners.set(path, cb)
-        return () => listeners.delete(path)
-      },
-    },
-  })
-
-  return {
-    listeners,
-    get sets() {
-      return activeRtdbSets
-    },
-    get removes() {
-      return activeRtdbRemoves
-    },
-    childAddedParentPaths: () => [...childAddedHandlers.keys()],
-    emitChildAdded,
-    emitValue,
-  }
-}
+export {
+  createRtdbLifecycleAfterEach,
+  installRtdbLifecycleMocks,
+  refPath,
+  withFirebaseEnv,
+} from '../../p2p/test/rtdbLifecycleHarness.js'
 
 /** @param {string} nonce */
 export async function importMovieVoteSession(nonce) {
   return import(`./session.js?mv-rtdb-lifecycle=${nonce}`)
-}
-
-/**
- * @param {typeof import('node:test').mock} mockRef
- * @returns {() => Promise<void>}
- */
-export function createRtdbLifecycleAfterEach(mockRef) {
-  return async () => {
-    mockRef.timers?.reset?.()
-    mockRef.reset()
-  }
 }

--- a/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.test.js
+++ b/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.test.js
@@ -12,6 +12,7 @@ import {
   installRtdbLifecycleMocks,
   withFirebaseEnv,
 } from './sessionRtdbLifecycleHarness.js'
+import { resetMovieVoteFacadeWireStateForTests } from './session.testExports.js'
 
 const harnessTests = { skip: !mock.module }
 const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
@@ -63,12 +64,7 @@ test(
 
     await withFirebaseEnv(async () => {
       const sessionMod = await importMovieVoteSession(`last-seen-${Date.now()}`)
-      const {
-        joinRoom,
-        teardownSession,
-        resetMovieVoteFacadeWireStateForTests,
-        bindMovieVoteP2PHandlers,
-      } = sessionMod
+      const { joinRoom, teardownSession, bindMovieVoteP2PHandlers } = sessionMod
 
       setActivePinia(createPinia())
       let applyCount = 0
@@ -89,7 +85,7 @@ test(
       assert.equal(applyCount, 1, 'duplicate seq should be ignored while module is live')
 
       teardownSession()
-      resetMovieVoteFacadeWireStateForTests()
+      resetMovieVoteFacadeWireStateForTests(sessionMod)
       applyCount = 0
       bindMovieVoteP2PHandlers({
         applyPublicPayload: () => {

--- a/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.test.js
+++ b/src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.test.js
@@ -1,0 +1,110 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/movie-vote/p2p/sessionRtdbLifecycleHarness.test.js
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+import { encodeState } from './protocol.js'
+import { buildMovieVotePublicPayload } from '../publicPayload.js'
+import {
+  createRtdbLifecycleAfterEach,
+  importMovieVoteSession,
+  installRtdbLifecycleMocks,
+  withFirebaseEnv,
+} from './sessionRtdbLifecycleHarness.js'
+
+const harnessTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+test(
+  'importMovieVoteSession loads isolated session module per nonce',
+  harnessTests,
+  async () => {
+    mock.reset()
+    await installRtdbLifecycleMocks()
+
+    await withFirebaseEnv(async () => {
+      const modA = await importMovieVoteSession(`iso-a-${Date.now()}`)
+      const modB = await importMovieVoteSession(`iso-b-${Date.now()}`)
+      assert.notEqual(modA, modB)
+      assert.equal(modA.sessionPhase.value, 'idle')
+      assert.equal(modB.sessionPhase.value, 'idle')
+    })
+  },
+)
+
+test(
+  'resetMovieVoteFacadeWireStateForTests clears guest lastSeenSeq between inbound applies',
+  harnessTests,
+  async () => {
+    mock.reset()
+    const joinableState = encodeState(
+      buildMovieVotePublicPayload(
+        {
+          phase: 'suggest',
+          readyToVote: false,
+          myDraftPicks: [],
+          ballotMovies: [],
+          ballotOrderIds: [],
+          voteProgress: null,
+          irvResult: null,
+          votingMethod: 'irv',
+        },
+        new Map(),
+      ),
+      3,
+    )
+
+    const harness = await installRtdbLifecycleMocks({
+      getHostPing: () => Date.now(),
+      getState: () => joinableState,
+      getEnded: () => null,
+    })
+
+    await withFirebaseEnv(async () => {
+      const sessionMod = await importMovieVoteSession(`last-seen-${Date.now()}`)
+      const {
+        joinRoom,
+        teardownSession,
+        resetMovieVoteFacadeWireStateForTests,
+        bindMovieVoteP2PHandlers,
+      } = sessionMod
+
+      setActivePinia(createPinia())
+      let applyCount = 0
+      bindMovieVoteP2PHandlers({
+        applyPublicPayload: () => {
+          applyCount += 1
+        },
+        onWireTeardown: () => {},
+      })
+
+      await joinRoom('LAST01')
+      const statePath = [...harness.listeners.keys()].find((p) => p.endsWith('/state'))
+      assert.ok(statePath)
+      harness.emitValue(statePath, joinableState)
+      assert.equal(applyCount, 1)
+
+      harness.emitValue(statePath, joinableState)
+      assert.equal(applyCount, 1, 'duplicate seq should be ignored while module is live')
+
+      teardownSession()
+      resetMovieVoteFacadeWireStateForTests()
+      applyCount = 0
+      bindMovieVoteP2PHandlers({
+        applyPublicPayload: () => {
+          applyCount += 1
+        },
+        onWireTeardown: () => {},
+      })
+
+      await joinRoom('LAST01')
+      const statePathAfterReset = [...harness.listeners.keys()].find((p) => p.endsWith('/state'))
+      assert.ok(statePathAfterReset)
+      harness.emitValue(statePathAfterReset, joinableState)
+      assert.equal(applyCount, 1, 'reset should allow the same seq to apply again on reuse')
+    })
+  },
+)
+
+afterEach(rtdbAfterEach)

--- a/src/features/p2p/CONTEXT.md
+++ b/src/features/p2p/CONTEXT.md
@@ -42,17 +42,29 @@ Cross-feature wiring for backoff-based reconnect loops; individual products supp
 
 **Presence-mode-agnostic** — one shared reconnect orchestration for all star-room **projects**; **loose guest attachment**, **strict guest presence**, and future per-**project** quorum rules live in establish/wire hooks and the **star-room session core**, not forked shell loops.
 
-On reconnect exhaustion (**fatal session error**), the shell invokes role-specific failure hooks—**guest** copy steers toward **Join room** / **Host room**; **host** copy steers toward starting a new **room**. Same fatal outcome, different recovery guidance; not one neutral message for both roles.
+On reconnect exhaustion (**fatal session error**), the shell invokes role-specific failure hooks—**guest** recovery affordance category steers toward **Join room** / **Host room**; **host** category steers toward starting a new **room**. Same fatal outcome, different guidance category; not one neutral path for both roles. Exact **user-visible session messaging** is facade-owned.
 
 **Host** and **guest** share one reconnect budget—same initial pause, attempt count, and backoff curve; no role-specific longer or shorter recovery window.
 
-During **non-fatal disconnect** recovery, attempt 1 is silent after the initial pause; **warning** attempt-progress toasts (“attempt *n* of *max*”) start at **attempt 2** onward so brief blips that recover immediately never flash UI. Wording is shared across star-room **projects**; fatal failure still uses role-specific exhaustion copy.
+During **non-fatal disconnect** recovery, attempt 1 is silent after the initial pause; attempt-progress **user-visible session messaging** at **warning** severity starts at **attempt 2** onward so brief blips that recover immediately never flash UI. That pacing rule is behavioral; exact strings are not.
 
 A superseded in-flight loop that momentarily succeeds on the wire must unwind with **wire-only teardown** only—never **leaveSession** on the **host** path, which would broadcast **room** end to **guests** while a newer recovery owns the session.
 
+### Structured session event
+
+Machine-facing signal from the **star-room session core** to a feature facade (`host_ended_room`, `connectivity_offline`, `host_ping_present`, `host_tab_visible`, …)—part of the behavioral contract alongside **connection posture** outcomes.
+
+_Avoid_: Branching logic on toast strings; treating Notify copy as API.
+
+### User-visible session messaging
+
+Toast and banner copy a feature facade renders from **structured session events** and **star-room shell** hooks—outside the behavioral contract; wording may change without semantic regression.
+
+_Avoid_: Locking exact strings in logic, tests, or architecture decisions.
+
 ### Star-room session core
 
-Shared implementation-layer wiring for **room** claim, RTDB listeners, host ping, guest hello, and visibility broadcast—sitting above the **star-room shell** reconnect loops (`createStarRoomSession` in this package). Star-room **projects** inject domain messages and user-visible notifications; the core does not own product state stores. Guest observers follow a **guest presence mode** (**loose guest attachment** vs **strict guest presence**) so wire policy is explicit, not inferred from the **project**.
+Shared implementation-layer wiring for **room** claim, RTDB listeners, host ping, guest hello, and visibility broadcast—sitting above the **star-room shell** reconnect loops (`createStarRoomSession` in this package). Star-room **projects** inject domain messages and **user-visible session messaging**; the core emits **structured session events** only. Guest observers follow a **guest presence mode** (**loose guest attachment** vs **strict guest presence**) so wire policy is explicit, not inferred from the **project**.
 
 ### Room code
 
@@ -112,7 +124,17 @@ Logical counter incremented when a fatal session error clears the **room**, used
 
 ### Host abrupt disconnect
 
-When the **host** browser loses connection without a deliberate leave, the **room** should still signal closure—clearing **host** presence and marking the **room** **ended** so **guests** are not left on a dead hub.
+When the **host** browser loses connection without a deliberate leave—refresh, network blip, sleep—the **host** clears **hostPing** on the wire. This is **not** **room exit**: **guests** stay in the **room** with **connection posture** `guest_connected` and keep the last authoritative **project** state until the **host** returns or explicitly ends the **room**.
+
+Each star-room **project** may differ in what stalls or flickers while the **host** is away (**loose guest attachment** vs **strict guest presence**); shared rule is never treating **host** absence alone as **fatal session error** for **guests**.
+
+_Avoid_: Ending the **room** for **guests** when **hostPing** clears; forcing **guests** to `idle` on **host** refresh.
+
+### Connection posture
+
+Star-room transport and listener state (`idle`, `connecting`, `reconnecting`, `hosting`, `guest_connected`)—independent from any star-room **project**’s collaborative flow (Movie Vote **phase**, Game Timer **snapshot** play).
+
+_Avoid_: **Phase** for this concept in Movie Vote contexts; **session phase** in Game Timer names the same posture.
 
 ### Fatal session error
 
@@ -127,6 +149,36 @@ Treatable interruption where **guest** reconnect logic may run while **host** re
 ### Transient disconnect
 
 Failure bucket treated like other non-fatal signals—eligible for **star-room shell** reconnect orchestration rather than immediate session teardown.
+
+### Monotonic authority broadcast
+
+Every **host** authority rebroadcast carries a strictly increasing **seq**; **guests** apply a message only when its **seq** exceeds the last applied value—duplicates and out-of-order arrivals are dropped. Authority never rolls backward on the wire.
+
+_Avoid_: Last-write-wins or regressive **snapshot** / **room** state after reconnect races.
+
+### Guest reconnect coherence
+
+When a **guest** refreshes or reattaches, the **host** stays authoritative—the **guest** tab never promotes local state as truth until the **host** acknowledges it on the wire. Each star-room **project** defines merge rules on **guest hello**; reconnect replays identity and mirrors the latest **host** broadcast rather than elevating the **guest** copy.
+
+_Avoid_: **Guest** self-authorizing collaborative state after reconnect.
+
+### Deliberate host end
+
+The **host** explicitly ends the **room**—sets the RTDB `ended` marker and clears **hostPing**. Every still-connected **guest** receives `host_ended_room` and undergoes **room exit**. **Room**-wide, not tab-local.
+
+### Fatal session error (tab-local)
+
+This browser tab exhausts reconnect or hits an unrecoverable attach failure—**connection posture** → `idle`, join persistence cleared, **room exit** survival rules apply on this tab only. The RTDB **room** may remain live for other **participants** who did not fail.
+
+_Avoid_: Treating tab-local fatal give-up as **deliberate host end** for the whole **room**.
+
+### Room exit
+
+**Connection posture** returning to `idle` because the user left, **deliberate host end** was received, or a **fatal session error** fired on this tab—not a **non-fatal disconnect** still in reconnect.
+
+Each star-room **project** defines what local state survives **room exit** on the affected tab; persisted **room** join role/suffix always clears there.
+
+**Deliberate host end** and **fatal session error** share the same tab-local **room exit** outcome but differ in **room**-wide scope—only **deliberate host end** ends the collaboration for everyone still connected.
 
 ### Wire-only teardown
 
@@ -159,8 +211,14 @@ _Avoid_: “Firebase secured the room” (suffix secrecy is the gate, not accoun
 - **Host reclaim** preserves in-**room** authority and payloads for the same **host** principal; only an un-**ended** **room** with a matching host id qualifies—missing `hostPing` after refresh still counts as reclaim, not a contested takeover.
 - **Host occupancy guard** runs on every **host** finish path in the **star-room session core**, including Movie Vote resume flows that skipped it before.
 - **Stable client identity** ties reconnecting browsers to prior participation without exposing account sign-in.
-- **Host abrupt disconnect** clears **hostPing** only (refresh or tab close); **guests** stay in the **room** until the **host** explicitly ends it or the RTDB **ended** marker is set via **leaveSession**.
+- **Host abrupt disconnect** clears **hostPing** only; **guests** stay in the **room** with last **project** authority until **host** reclaim or explicit end—**loose guest attachment** and **strict guest presence** differ in quorum/stall rules, not in whether the **room** survives.
 - **Loose guest attachment** and **strict guest presence** are intentional alternatives—do not unify guest `hostPing` teardown or online tracking across **projects**; future star-room **projects** may add further presence rules without changing **star-room shell** backoff/reconnect shape.
+- **Connection posture** and each **project**’s collaborative flow are independent contracts—regressions in reconnect banners must not be conflated with regressions in ballots or timer **snapshots**.
+- On **room exit**, persisted **room** join info always clears; facilitator **roster** (Game Timer) or personal nomination drafts and display preferences (Movie Vote) may survive per **project** rules—see those glossaries.
+- **Guest reconnect coherence** is host-authoritative in every star-room **project**; only merge rules differ (Game Timer **snapshot** + **guest intent**; Movie Vote **participant id** remap + payloads).
+- **Monotonic authority broadcast** applies to every star-room **project** **host**→**guest** authority channel—shared semantics, different payloads.
+- **Structured session events** and **connection posture** outcomes are the contract; **user-visible session messaging** is not—logic and decisions must never depend on copy.
+- **Deliberate host end** ends the **room** for all connected **guests**; **fatal session error** is tab-local—the **room** may persist for others.
 - **Fatal session error** resets persistence and ends the collaboration; **non-fatal disconnect** and **transient disconnect** paths feed reconnect instead of immediate teardown.
 - **Reconnect generation** must match across sleep/backoff slices or the client abandons stale attempts **silently**—no user-visible toast; a newer recovery path, user-initiated **Host room** / **Join room**, or **fatal session error** superseded the in-flight loop. If an obsolete loop briefly re-establishes the wire before noticing the mismatch, it performs **wire-only teardown**—not **leaveSession**—so a superseded **host** reconnect cannot mark the **room** **ended** for **guests**.
 - **Path-scoped RTDB access** applies to all star-room **projects** and the Dungeon Runner replay archive on the shared Firebase project; see [dungeon-runner RTDB ingest access](https://github.com/enmaku/dungeon-runner/blob/main/CONTEXT.md) for maintainer read paths.

--- a/src/features/p2p/test/hostInboxHarness.js
+++ b/src/features/p2p/test/hostInboxHarness.js
@@ -1,0 +1,55 @@
+/**
+ * Presence-agnostic helpers for host inbox contract tests at the RTDB seam.
+ */
+
+import assert from 'node:assert/strict'
+
+/**
+ * @param {ReturnType<import('./rtdbLifecycleHarness.js').installRtdbLifecycleMocks> extends Promise<infer T> ? T : never} harness
+ * @param {string} roomsCollection e.g. `movieVoteRooms` or `gameTimerRooms`
+ * @param {string} suffix
+ * @param {string} guestStableId
+ * @param {unknown} payload
+ */
+export function simulateHostInboxMessage(harness, roomsCollection, suffix, guestStableId, payload) {
+  const inboxParent = `${roomsCollection}/${suffix}/inbox`
+  const childPath = `${inboxParent}/${guestStableId}`
+  assert.ok(
+    harness.childAddedParentPaths().some((p) => p === inboxParent || p.endsWith('/inbox')),
+    `host should wire inbox listener (${harness.childAddedParentPaths().join(', ')})`,
+  )
+  harness.emitChildAdded(inboxParent, guestStableId)
+  assert.ok(
+    harness.listeners.has(childPath),
+    `host should subscribe to inbox child (${[...harness.listeners.keys()].join(', ')})`,
+  )
+  harness.emitValue(childPath, payload)
+}
+
+/**
+ * @template {string} K
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @param {(raw: unknown) => { seq: number } & Record<K, unknown> | null} parseFn
+ * @param {K} valueKey
+ * @returns {Array<{ seq: number } & Record<K, unknown>>}
+ */
+export function parseStateBroadcasts(sets, parseFn, valueKey) {
+  return sets
+    .filter((entry) => entry.path.endsWith('/state'))
+    .map((entry) => {
+      const parsed = parseFn(entry.value)
+      assert.ok(parsed, 'state write must be a host snapshot message')
+      return { seq: parsed.seq, [valueKey]: parsed[valueKey] }
+    })
+}
+
+/**
+ * @template {string} K
+ * @param {Array<{ path: string, value: unknown }>} sets
+ * @param {(raw: unknown) => { seq: number } & Record<K, unknown> | null} parseFn
+ * @param {K} valueKey
+ * @returns {number}
+ */
+export function maxStateSeq(sets, parseFn, valueKey) {
+  return parseStateBroadcasts(sets, parseFn, valueKey).reduce((max, entry) => Math.max(max, entry.seq), 0)
+}

--- a/src/features/p2p/test/rtdbLifecycleHarness.js
+++ b/src/features/p2p/test/rtdbLifecycleHarness.js
@@ -1,0 +1,195 @@
+/**
+ * Presence-agnostic RTDB mocks for star-room facade / lifecycle contract tests.
+ * Requires `node --experimental-test-module-mocks`.
+ */
+
+import { mock } from 'node:test'
+
+/** @type {Array<{ path: string, value: unknown }>} */
+let activeRtdbSets = []
+/** @type {Array<{ path: string }>} */
+let activeRtdbRemoves = []
+
+const REQUIRED_FIREBASE_ENV = {
+  VITE_FIREBASE_API_KEY: 'test-api-key',
+  VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  VITE_FIREBASE_DATABASE_URL: 'https://test-default-rtdb.firebaseio.com',
+  VITE_FIREBASE_PROJECT_ID: 'test-project',
+  VITE_FIREBASE_APP_ID: '1:123456789:web:abc',
+}
+
+/** @param {() => void | Promise<void>} fn */
+export async function withFirebaseEnv(fn) {
+  const saved = {}
+  for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+    saved[key] = process.env[key]
+    process.env[key] = REQUIRED_FIREBASE_ENV[key]
+  }
+  try {
+    await fn()
+  } finally {
+    for (const key of Object.keys(REQUIRED_FIREBASE_ENV)) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
+/**
+ * @param {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} ref
+ * @returns {string}
+ */
+export function refPath(ref) {
+  const parts = []
+  let cur = ref
+  while (cur) {
+    if (cur.key) parts.unshift(cur.key)
+    cur = cur.parent ?? null
+  }
+  return parts.join('/')
+}
+
+/**
+ * @param {string} dotPath
+ * @returns {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }}
+ */
+function buildRef(dotPath) {
+  const parts = dotPath.split('/').filter(Boolean)
+  /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null } | null} */
+  let node = null
+  for (const part of parts) {
+    node = { key: part, parent: node }
+  }
+  return /** @type {{ key?: string | null, parent?: { key?: string | null, parent?: unknown } | null }} */ (
+    node ?? { key: null, parent: null }
+  )
+}
+
+/**
+ * @param {{
+ *   getHostPing?: () => unknown,
+ *   getEnded?: () => unknown,
+ *   getHostClientId?: () => unknown,
+ *   getState?: () => unknown,
+ *   getWelcome?: () => unknown,
+ *   getGuestOnline?: () => unknown,
+ * }} [opts]
+ * @returns {Promise<{
+ *   listeners: Map<string, (snap: { val: () => unknown }) => void>,
+ *   sets: Array<{ path: string, value: unknown }>,
+ *   removes: Array<{ path: string }>,
+ *   childAddedParentPaths: () => string[],
+ *   emitChildAdded: (parentPath: string, childKey: string) => void,
+ *   emitValue: (path: string, value: unknown) => void,
+ * }>}
+ */
+export async function installRtdbLifecycleMocks(opts = {}) {
+  activeRtdbSets = []
+  activeRtdbRemoves = []
+
+  /** @type {Map<string, (snap: { val: () => unknown }) => void>} */
+  const listeners = new Map()
+  /** @type {Map<string, Set<(snap: { key: string | null, ref: ReturnType<typeof buildRef> }) => void>>} */
+  const childAddedHandlers = new Map()
+
+  /**
+   * @param {string} parentPath
+   * @param {string} childKey
+   */
+  function emitChildAdded(parentPath, childKey) {
+    const handlers = childAddedHandlers.get(parentPath)
+    if (!handlers?.size) return
+    const childPath = `${parentPath}/${childKey}`
+    const snap = { key: childKey, ref: buildRef(childPath) }
+    for (const handler of handlers) handler(snap)
+  }
+
+  /**
+   * @param {string} path
+   * @param {unknown} value
+   */
+  function emitValue(path, value) {
+    const handler = listeners.get(path)
+    if (handler) handler({ val: () => value })
+  }
+
+  const actual = await import('firebase/database')
+
+  mock.module('firebase/database', {
+    namedExports: {
+      ...actual,
+      get: async (ref) => {
+        if (ref.key === 'hostPing') {
+          return {
+            val: () => (opts.getHostPing !== undefined ? opts.getHostPing() : Date.now()),
+          }
+        }
+        if (ref.key === 'ended') {
+          return { val: () => (opts.getEnded !== undefined ? opts.getEnded() : null) }
+        }
+        if (ref.key === 'hostClientId') {
+          return {
+            val: () => (opts.getHostClientId !== undefined ? opts.getHostClientId() : null),
+          }
+        }
+        if (ref.key === 'state') {
+          return { val: () => (opts.getState !== undefined ? opts.getState() : null) }
+        }
+        if (ref.key === 'welcome') {
+          return { val: () => (opts.getWelcome !== undefined ? opts.getWelcome() : null) }
+        }
+        if (ref.key === 'guestOnline') {
+          return {
+            val: () => (opts.getGuestOnline !== undefined ? opts.getGuestOnline() : null),
+          }
+        }
+        return { val: () => null }
+      },
+      set: async (ref, value) => {
+        activeRtdbSets.push({ path: refPath(ref), value })
+      },
+      remove: async (ref) => {
+        activeRtdbRemoves.push({ path: refPath(ref) })
+      },
+      onDisconnect: () => ({
+        remove: () => Promise.resolve(),
+        set: () => Promise.resolve(),
+      }),
+      onChildAdded: (ref, cb) => {
+        const path = refPath(ref)
+        if (!childAddedHandlers.has(path)) childAddedHandlers.set(path, new Set())
+        childAddedHandlers.get(path)?.add(cb)
+        return () => childAddedHandlers.get(path)?.delete(cb)
+      },
+      onValue: (ref, cb) => {
+        const path = refPath(ref)
+        listeners.set(path, cb)
+        return () => listeners.delete(path)
+      },
+    },
+  })
+
+  return {
+    listeners,
+    get sets() {
+      return activeRtdbSets
+    },
+    get removes() {
+      return activeRtdbRemoves
+    },
+    childAddedParentPaths: () => [...childAddedHandlers.keys()],
+    emitChildAdded,
+    emitValue,
+  }
+}
+
+/**
+ * @param {typeof import('node:test').mock} mockRef
+ * @returns {() => Promise<void>}
+ */
+export function createRtdbLifecycleAfterEach(mockRef) {
+  return async () => {
+    mockRef.timers?.reset?.()
+    mockRef.reset()
+  }
+}

--- a/src/features/p2p/test/rtdbLifecycleHarness.test.js
+++ b/src/features/p2p/test/rtdbLifecycleHarness.test.js
@@ -1,0 +1,62 @@
+/**
+ * Run: node --experimental-test-module-mocks --test src/features/p2p/test/rtdbLifecycleHarness.test.js
+ */
+import assert from 'node:assert/strict'
+import { afterEach, mock, test } from 'node:test'
+import {
+  createRtdbLifecycleAfterEach,
+  installRtdbLifecycleMocks,
+  refPath,
+  withFirebaseEnv,
+} from './rtdbLifecycleHarness.js'
+
+const harnessTests = { skip: !mock.module }
+const rtdbAfterEach = createRtdbLifecycleAfterEach(mock)
+
+test('installRtdbLifecycleMocks captures set and remove writes', harnessTests, async () => {
+  mock.reset()
+  const harness = await installRtdbLifecycleMocks()
+  const { set, remove } = await import('firebase/database')
+
+  const stateRef = { key: 'state', parent: { key: 'ABC', parent: { key: 'rooms', parent: null } } }
+  const hostPingRef = {
+    key: 'hostPing',
+    parent: { key: 'ABC', parent: { key: 'rooms', parent: null } },
+  }
+
+  await set(stateRef, { seq: 1 })
+  await remove(hostPingRef)
+
+  assert.equal(harness.sets.length, 1)
+  assert.equal(harness.sets[0].path, 'rooms/ABC/state')
+  assert.equal(harness.removes.length, 1)
+  assert.equal(harness.removes[0].path, 'rooms/ABC/hostPing')
+})
+
+test('refPath joins ref keys from leaf to root', () => {
+  assert.equal(
+    refPath({ key: 'state', parent: { key: 'ABC', parent: { key: 'rooms', parent: null } } }),
+    'rooms/ABC/state',
+  )
+})
+
+test('withFirebaseEnv restores process.env after run', async () => {
+  const prior = process.env.VITE_FIREBASE_API_KEY
+  await withFirebaseEnv(async () => {
+    assert.equal(process.env.VITE_FIREBASE_API_KEY, 'test-api-key')
+  })
+  assert.equal(process.env.VITE_FIREBASE_API_KEY, prior)
+})
+
+test('emitValue delivers to onValue listener', harnessTests, async () => {
+  mock.reset()
+  const harness = await installRtdbLifecycleMocks()
+  let seen = null
+  harness.listeners.set('rooms/ROOM/state', (snap) => {
+    seen = snap.val()
+  })
+  harness.emitValue('rooms/ROOM/state', { seq: 2 })
+  assert.deepEqual(seen, { seq: 2 })
+})
+
+afterEach(rtdbAfterEach)


### PR DESCRIPTION
## Summary

- Adds dedicated P2P **session facade contract tests** for Game Timer and Movie Vote, organized around **connection posture** and **domain wire** layers per #214.
- Introduces shared RTDB lifecycle harness at `src/features/p2p/test/rtdbLifecycleHarness.js` with thin per-project wrappers.
- Consolidates test-only facade hooks in `session.testExports.js` (both features) via `get*SessionTestWireAccess()`.
- Movie Vote adds unified `handleGuestInbound` dispatcher (replaces thin guest inbound exports).
- Small production fix: Game Timer host inbox only rebroadcasts when a guest snapshot actually applies.

**PR #261 review remediation:**
- Shared presence-agnostic RTDB harness (reduced duplication)
- `session.testExports.js` test seam; reset hooks use `core.setPhase` / `core.setSuffix`
- Host-side fatal reconnect exhaustion facade tests (both projects)
- Deduped Movie Vote guest fatal test (posture only)
- Expanded Game Timer `sessionRoomLifecycleRtdb.test.js` (host establish, guest hello rebroadcast, leave/end)

Closes #214

## Test plan

- [x] `npx eslint --max-warnings 0` on touched `src/features/*/p2p/*.js` and `src/features/p2p/test/*.js`
- [x] `node --experimental-test-module-mocks --test` on facade, lifecycle, and harness suites (85 tests)
- [ ] Optional smoke: host + join in Game Timer and Movie Vote with two browser contexts