### PR TITLE
docs: add AGENTS.md for Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+Single-package Vue 3 / Quasar 2 SPA (`portfolio-site`). No custom backend — Firebase RTDB/Firestore from the browser for multiplayer projects. See [README.md](README.md) and [CONTEXT-MAP.md](CONTEXT-MAP.md).
+
+### Services
+
+| Service | Command | URL | Notes |
+| --- | --- | --- | --- |
+| Dev server (required) | `npx quasar dev` or `npm run dev` | `http://localhost:9000/#/` | **Use the hash URL** (`/#/`, `/#/about`, …). Router is hash mode; opening bare `http://localhost:9000/` can show a blank page in the Desktop browser. |
+| Dev (slow FS / VMs) | `npm run dev:poll` | same | Enables Chokidar polling; equivalent to `quasar dev` with `CHOKIDAR_USEPOLLING=1`. |
+
+Only the Quasar dev server is required for gallery/about and most local dev. Firebase and TMDB env vars are optional unless testing those features (see `.env.example`).
+
+### Git LFS (gallery photos)
+
+Gallery source images under `src/assets/photos/*.jpg` are Git LFS objects. Cloud VMs often set `GIT_LFS_SKIP_SMUDGE=1`, so clones leave tiny pointer files until LFS is pulled explicitly:
+
+```bash
+git lfs pull
+```
+
+Verify with `file src/assets/photos/10010.jpg` — should report `JPEG image data`, not `ASCII text`. Thumbnails for dev/build: `npm run generate-thumbs` (also runs in `prebuild`).
+
+### Lint / test / build
+
+Standard commands from [README.md](README.md):
+
+- `npm run lint`
+- `npm test`
+- `npm run build` → `dist/spa`
+
+Firebase rules tests (`npm run test:database-rules`, `test:firestore-rules`) need the Firebase CLI and emulators; not required for routine app dev.
+
+### Environment file
+
+Copy `.env.example` → `.env` only when testing Movie Vote, Game Timer, or Firebase-backed Dungeon Runner flows. Restart the dev server after changes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud–specific development notes discovered during VM environment setup.

## Contents

- Dev server commands and the **hash-route URL requirement** (`http://localhost:9000/#/`)
- Git LFS pull instructions for gallery photos (`GIT_LFS_SKIP_SMUDGE` on cloud VMs)
- Pointers to standard lint/test/build commands from README

No application code changes.

## VM verification (this session)

- `npm ci` + `git lfs pull` (90 LFS photos)
- `npm run lint` — pass
- `npm test` — 1571 tests pass
- `npm run build` — pass
- `npx quasar dev` — gallery and about pages load at `/#/` and `/#/about`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a128527c-9e42-4227-8287-20cfa51d1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a128527c-9e42-4227-8287-20cfa51d1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

