### PR TITLE
docs: AGENTS.md env guidance and Firebase RTDB probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ VITE_TMDB_API_KEY=
 
 # Firebase — Movie Vote, Game Timer, Dungeon Runner replay archive (RTDB), and match outcomes (Firestore).
 # Share VITE_FIREBASE_* below in one Firebase project; path-scoped RTDB rules in database.rules.json; Firestore rules in firestore.rules.
+# VITE_FIREBASE_DATABASE_URL must be the Realtime Database URL (Build → Realtime Database), not Firestore.
+# After changing rules locally, deploy: `npx firebase-tools deploy --only database --project <project-id>`
+# Probe live RTDB from the CLI: `npm run check:firebase-rtdb` (after filling this file).
 # Local emulators: `firebase emulators:start --only database,firestore` (RTDB :9001, Firestore :8080).
 # Console: Project settings → Your apps → Web app config + Realtime Database URL.
 # GitHub Actions: add the same names as repository secrets (see publish.yml).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+Single-package Vue 3 / Quasar 2 SPA (`portfolio-site`). No custom backend — Firebase RTDB/Firestore from the browser for multiplayer projects. See [README.md](README.md) and [CONTEXT-MAP.md](CONTEXT-MAP.md).
+
+### Services
+
+| Service | Command | URL | Notes |
+| --- | --- | --- | --- |
+| Dev server (required) | `npx quasar dev` or `npm run dev` | `http://localhost:9000/#/` | **Use the hash URL** (`/#/`, `/#/about`, …). Router is hash mode; opening bare `http://localhost:9000/` can show a blank page in the Desktop browser. |
+| Dev (slow FS / VMs) | `npm run dev:poll` | same | Enables Chokidar polling; equivalent to `quasar dev` with `CHOKIDAR_USEPOLLING=1`. |
+
+Only the Quasar dev server is required for gallery/about and most local dev. Firebase and TMDB env vars are optional unless testing those features (see `.env.example`).
+
+### Git LFS (gallery photos)
+
+Gallery source images under `src/assets/photos/*.jpg` are Git LFS objects. Cloud VMs often set `GIT_LFS_SKIP_SMUDGE=1`, so clones leave tiny pointer files until LFS is pulled explicitly:
+
+```bash
+git lfs pull
+```
+
+Verify with `file src/assets/photos/10010.jpg` — should report `JPEG image data`, not `ASCII text`. Thumbnails for dev/build: `npm run generate-thumbs` (also runs in `prebuild`).
+
+### Lint / test / build
+
+Standard commands from [README.md](README.md):
+
+- `npm run lint`
+- `npm test`
+- `npm run build` → `dist/spa`
+
+Firebase rules tests (`npm run test:database-rules`, `test:firestore-rules`) need the Firebase CLI and emulators; not required for routine app dev.
+
+### Environment file (`.env`) vs Cursor Secrets
+
+Quasar/Vite reads **`/workspace/.env`** at dev-server startup (`import.meta.env.VITE_*`). This is separate from **Cursor Secrets** (Environment tab):
+
+| Mechanism | Persists where | Used by Quasar dev? |
+| --- | --- | --- |
+| **`.env`** (gitignored) | Cloud workspace volume / VM snapshot | **Yes** — preferred for local dev |
+| **Cursor Secrets** | Cursor project settings | **No** — not auto-written to `.env`; not visible to Vite unless you materialize them |
+
+**Before debugging Firebase/RTDB as “misconfigured”:**
+
+1. Check whether `/workspace/.env` exists (copy from `.env.example` if missing).
+2. Confirm all five `VITE_FIREBASE_*` vars are set for Game Timer / Movie Vote.
+3. Restart the dev server after any `.env` edit (`npx quasar dev`). A running server does not hot-reload env changes.
+4. Run `npm run check:firebase-rtdb` to probe live RTDB read/write on `gameTimerRooms/`.
+
+**Persistence across agents:** `.env` survives on the same cloud workspace as long as the VM volume is retained. It is **not** in git — fresh environments need `.env` recreated (paste from Cursor Secrets or Firebase Console). Do not commit `.env`.
+
+**Game Timer RTDB errors with secrets “set” but app failing:** usually (a) no `.env` on disk, (b) dev server started before `.env` existed, (c) wrong `VITE_FIREBASE_DATABASE_URL` (must be **Realtime Database**, not Firestore), or (d) `database.rules.json` not deployed (`npx firebase-tools deploy --only database --project <project-id>`).

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "node --experimental-test-module-mocks --test \"src/composables/**/*.test.js\" \"src/features/**/*.test.js\" \"src/features/**/*.test.mjs\" \"src/layouts/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\" \"scripts/sync-dungeon-runner-model.test.mjs\" \"scripts/dungeon-runner-model-catalog.test.mjs\" \"scripts/convert-dungeon-runner-h5.test.mjs\" \"scripts/dungeon-runner-model-artifacts.test.mjs\"",
+    "test": "node --experimental-test-module-mocks --test \"src/composables/**/*.test.js\" \"src/features/**/*.test.js\" \"src/features/**/*.test.mjs\" \"src/layouts/**/*.test.js\" \"src/share-metadata.test.js\" \"src/router/**/*.test.js\" \"scripts/generate-share-pages.test.mjs\" \"scripts/sync-dungeon-runner-model.test.mjs\" \"scripts/dungeon-runner-model-catalog.test.mjs\" \"scripts/convert-dungeon-runner-h5.test.mjs\" \"scripts/dungeon-runner-model-artifacts.test.mjs\" \"scripts/check-firebase-rtdb.test.mjs\"",
     "test:database-rules": "firebase emulators:exec --only database \"node --test database.rules.test.mjs\"",
     "test:firestore-rules": "firebase emulators:exec --only firestore \"node --test firestore.rules.test.mjs\"",
+    "check:firebase-rtdb": "node ./scripts/check-firebase-rtdb.mjs",
     "dev": "quasar dev",
     "dev:poll": "CHOKIDAR_USEPOLLING=1 CHOKIDAR_INTERVAL=300 quasar dev",
     "convert-dungeon-runner-h5": "node ./scripts/convert-dungeon-runner-h5.mjs",

--- a/scripts/check-firebase-rtdb.mjs
+++ b/scripts/check-firebase-rtdb.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Probe live Firebase RTDB with the same VITE_FIREBASE_* vars the Quasar app uses.
+ * Writes then deletes gameTimerRooms/_connectivity_probe_* to mirror Game Timer hosting.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { deleteApp, initializeApp } from 'firebase/app'
+import { get, getDatabase, ref, remove, set } from 'firebase/database'
+
+const REQUIRED_ENV = [
+  'VITE_FIREBASE_API_KEY',
+  'VITE_FIREBASE_AUTH_DOMAIN',
+  'VITE_FIREBASE_DATABASE_URL',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_APP_ID',
+]
+
+function loadDotEnv(envPath) {
+  if (!existsSync(envPath)) return
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eq = trimmed.indexOf('=')
+    if (eq <= 0) continue
+    const key = trimmed.slice(0, eq).trim()
+    if (!key || process.env[key] !== undefined) continue
+    let value = trimmed.slice(eq + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    process.env[key] = value
+  }
+}
+
+function envValue(key) {
+  return String(process.env[key] ?? '').trim()
+}
+
+function maskDatabaseUrl(url) {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+  } catch {
+    return '(invalid URL)'
+  }
+}
+
+function printMissingEnv(missing) {
+  console.error(`Missing required env vars: ${missing.join(', ')}`)
+  console.error('')
+  console.error('Local dev: copy .env.example → .env, fill VITE_FIREBASE_*, restart `quasar dev`.')
+  console.error('Secret names must include the VITE_ prefix (not FIREBASE_API_KEY alone).')
+}
+
+function printPermissionHelp(projectId) {
+  console.error('')
+  console.error('Permission denied usually means database.rules.json is not deployed.')
+  console.error('Deploy RTDB rules from this repo:')
+  console.error('  npx firebase-tools login')
+  console.error(`  npx firebase-tools deploy --only database --project ${projectId}`)
+}
+
+function printDatabaseUrlHelp() {
+  console.error('')
+  console.error('Use the Realtime Database URL from Firebase Console → Build → Realtime Database.')
+  console.error('It is not the Firestore URL. Common shapes:')
+  console.error('  https://<project-id>-default-rtdb.firebaseio.com')
+  console.error('  https://<project-id>-default-rtdb.<region>.firebasedatabase.app')
+}
+
+async function main() {
+  loadDotEnv(path.join(process.cwd(), '.env'))
+
+  const missing = REQUIRED_ENV.filter((key) => !envValue(key))
+  if (missing.length > 0) {
+    printMissingEnv(missing)
+    process.exit(1)
+  }
+
+  const databaseURL = envValue('VITE_FIREBASE_DATABASE_URL')
+  const projectId = envValue('VITE_FIREBASE_PROJECT_ID')
+
+  if (/firestore\.googleapis\.com/i.test(databaseURL)) {
+    console.error('VITE_FIREBASE_DATABASE_URL looks like a Firestore endpoint, not RTDB.')
+    printDatabaseUrlHelp()
+    process.exit(1)
+  }
+
+  const config = {
+    apiKey: envValue('VITE_FIREBASE_API_KEY'),
+    authDomain: envValue('VITE_FIREBASE_AUTH_DOMAIN'),
+    databaseURL,
+    projectId,
+    appId: envValue('VITE_FIREBASE_APP_ID'),
+  }
+
+  const storageBucket = envValue('VITE_FIREBASE_STORAGE_BUCKET')
+  if (storageBucket) config.storageBucket = storageBucket
+
+  const messagingSenderId = envValue('VITE_FIREBASE_MESSAGING_SENDER_ID')
+  if (messagingSenderId) config.messagingSenderId = messagingSenderId
+
+  const app = initializeApp(config, `rtdb-probe-${Date.now()}`)
+  const db = getDatabase(app)
+  const probeRef = ref(db, `gameTimerRooms/_connectivity_probe_${Date.now()}`)
+
+  try {
+    await set(probeRef, { ok: true, at: Date.now() })
+    const snap = await get(probeRef)
+    if (!snap.exists()) {
+      throw new Error('Write succeeded but read returned empty')
+    }
+    await remove(probeRef)
+    console.log('OK: RTDB read/write on gameTimerRooms/{suffix} works.')
+    console.log(`  database: ${maskDatabaseUrl(databaseURL)}`)
+    console.log(`  project:  ${projectId}`)
+  } catch (err) {
+    const code = err && typeof err === 'object' && 'code' in err ? String(err.code) : ''
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`RTDB probe failed: ${code || message}`)
+
+    if (code === 'PERMISSION_DENIED' || /permission/i.test(message)) {
+      printPermissionHelp(projectId)
+    } else if (/invalid.*url|404|not found|Failed to get/i.test(message)) {
+      printDatabaseUrlHelp()
+    }
+
+    process.exit(1)
+  } finally {
+    await deleteApp(app).catch(() => {})
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/scripts/check-firebase-rtdb.test.mjs
+++ b/scripts/check-firebase-rtdb.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+test('check-firebase-rtdb exits 1 with missing env listing VITE_FIREBASE keys', () => {
+  const result = spawnSync('node', ['./scripts/check-firebase-rtdb.mjs'], {
+    cwd: process.cwd(),
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+    },
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /VITE_FIREBASE_API_KEY/)
+  assert.match(result.stderr, /\.env\.example/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds cloud-agent documentation and a small RTDB connectivity check.

## AGENTS.md

- Dev server hash URLs, Git LFS, lint/test/build
- **`.env` vs Cursor Secrets`** — explains why Environment-tab secrets do not automatically configure Quasar, persistence on cloud workspaces vs fresh VMs, and RTDB troubleshooting checklist

## Tooling

- `npm run check:firebase-rtdb` — probes read/write on `gameTimerRooms/{suffix}` using `.env`
- `.env.example` notes for RTDB URL shape and rules deploy

No application runtime changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a128527c-9e42-4227-8287-20cfa51d1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a128527c-9e42-4227-8287-20cfa51d1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

