### PR TITLE
Game Timer: domain tests and UI/store thinning (#218)

### DIFF
--- a/src/features/game-timer/CONTEXT.md
+++ b/src/features/game-timer/CONTEXT.md
@@ -42,7 +42,9 @@ Optional coupling where the sequence from **hard pass** events informs who goes 
 
 ### Snapshot
 
-Exchangeable authoritative slice of timer state (**players**, **active player**, **round**, timings, toggles such as hard-pass flags) kept in one **room**-level copy the **host** owns and **guests** mirror. Each **host** broadcast uses **monotonic authority broadcast** **seq**; **guests** never apply a regressive **snapshot**.
+Exchangeable authoritative slice of timer state (**players**, **active player**, **round**, timings, toggles such as hard-pass flags) kept in one **room**-level copy the **host** owns and **guests** mirror. Each **host** broadcast uses **monotonic authority broadcast** **seq**; **guests** never apply a regressive **snapshot**. Progress bars, formatted durations, and timing-strip totals are derived locally from the **snapshot** plus wall clock—not separately synced.
+
+_Avoid_: Treating on-screen bar fill or `m:ss` labels as fields collaborators must agree on beyond the underlying **banked time** and live-turn fields in the **snapshot**.
 
 ### Guest intent
 

--- a/src/features/game-timer/components/GameTimerPlayerList.vue
+++ b/src/features/game-timer/components/GameTimerPlayerList.vue
@@ -43,8 +43,8 @@
               class="gt-player-row rounded-borders relative-position overflow-hidden column"
               :class="{
                 'gt-player-row--active': rowForPlayer(player)?.isActive,
-                'gt-player-row--hard-passed': isHardPassed(player),
-                'gt-player-row--paused-turn': isPausedHeldTurn(player),
+                'gt-player-row--hard-passed': rowForPlayer(player)?.isHardPassed,
+                'gt-player-row--paused-turn': rowForPlayer(player)?.isPausedHeldTurn,
               }"
               :style="rowSurfaceStyle(player)"
               :data-gt-player-id="player.id"
@@ -53,7 +53,7 @@
                 <div class="gt-player-row__turn col-auto row flex-center" aria-hidden="true">
                   <q-icon
                     v-if="rowForPlayer(player)?.isActive"
-                    :name="isPausedHeldTurn(player) ? 'pause' : 'play_arrow'"
+                    :name="rowForPlayer(player)?.isPausedHeldTurn ? 'pause' : 'play_arrow'"
                     class="gt-player-row__turn-icon"
                   />
                 </div>
@@ -76,9 +76,9 @@
                   round
                   dense
                   padding="sm"
-                  :icon="isHardPassed(player) ? 'undo' : 'sports_score'"
+                  :icon="rowForPlayer(player)?.isHardPassed ? 'undo' : 'sports_score'"
                   class="gt-player-row__hard-pass gt-hard-pass-hit"
-                  :aria-label="isHardPassed(player) ? 'Undo hard pass' : 'Hard pass for this round'"
+                  :aria-label="rowForPlayer(player)?.isHardPassed ? 'Undo hard pass' : 'Hard pass for this round'"
                   @click.stop="onHardPassButton(player)"
                 />
               </div>
@@ -166,13 +166,16 @@ const $q = useQuasar()
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
 const now = useGameTimerNow(100)
-const { hasMultipleRounds, playerRowsById, isHardPassed, isPausedHeldTurn } =
-  useGameTimerPlayerListPresentation({ now })
+const { hasMultipleRounds, playerRowsById } = useGameTimerPlayerListPresentation({ now })
 
 const { hardPassEnabled } = storeToRefs(store)
 
+function rowForPlayer(player) {
+  return playerRowsById.value.get(player.id)
+}
+
 function onHardPassButton(player) {
-  if (isHardPassed(player)) {
+  if (rowForPlayer(player)?.isHardPassed) {
     store.undoHardPass(player.id)
   } else {
     store.registerHardPass(player.id)
@@ -215,10 +218,6 @@ const editDialogOpen = ref(false)
 const editPlayerId = ref(null)
 const editName = ref('')
 const editColor = ref(DEFAULT_PLAYER_COLORS[0])
-
-function rowForPlayer(player) {
-  return playerRowsById.value.get(player.id)
-}
 
 function rowTimeLabel(player) {
   const r = rowForPlayer(player)

--- a/src/features/game-timer/components/GameTimerPlayerList.vue
+++ b/src/features/game-timer/components/GameTimerPlayerList.vue
@@ -6,6 +6,7 @@
         item-key="id"
         tag="div"
         class="gt-draggable"
+        handle=".gt-player-row__turn"
         :disabled="isGuest"
         @contextmenu.prevent
         :animation="200"
@@ -150,6 +151,7 @@ import { storeToRefs } from 'pinia'
 import { useQuasar } from 'quasar'
 import Draggable from 'vuedraggable'
 import { useGameTimerPlayerListPresentation } from '../composables/useGameTimerPlayerListPresentation.js'
+import { useGameTimerNow } from '../composables/useGameTimerNow.js'
 import { useGameTimerP2P } from '../composables/useGameTimerP2P.js'
 import {
   DEFAULT_PLAYER_COLORS,
@@ -163,8 +165,9 @@ import { useGameTimerStore } from '../../../stores/gameTimer.js'
 const $q = useQuasar()
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
+const now = useGameTimerNow(100)
 const { hasMultipleRounds, playerRowsById, isHardPassed, isPausedHeldTurn } =
-  useGameTimerPlayerListPresentation()
+  useGameTimerPlayerListPresentation({ now })
 
 const { hardPassEnabled } = storeToRefs(store)
 
@@ -333,6 +336,7 @@ function progressRoundFillStyle(player) {
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+  touch-action: pan-x pinch-zoom;
 }
 
 .gt-sortable-ghost {
@@ -460,6 +464,12 @@ function progressRoundFillStyle(player) {
   width: 30px;
   flex-shrink: 0;
   align-self: stretch;
+  cursor: grab;
+  touch-action: none;
+}
+
+.gt-player-row__turn:active {
+  cursor: grabbing;
 }
 
 .gt-player-row__turn-icon {

--- a/src/features/game-timer/components/GameTimerPlayerList.vue
+++ b/src/features/game-timer/components/GameTimerPlayerList.vue
@@ -149,43 +149,24 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useQuasar } from 'quasar'
 import Draggable from 'vuedraggable'
-import { useGameTimerNow } from '../composables/useGameTimerNow.js'
+import { useGameTimerPlayerListPresentation } from '../composables/useGameTimerPlayerListPresentation.js'
 import { useGameTimerP2P } from '../composables/useGameTimerP2P.js'
 import {
   DEFAULT_PLAYER_COLORS,
-  displayedMsForPlayer,
-  displayedMsForPlayerInRound,
   formatDurationMs,
-  maxDisplayedMs,
-  maxDisplayedMsInRound,
   playerBarFillColor,
   playerBarRailColor,
   playerBarTrackColor,
-  progressRatio,
 } from '../core.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 
 const $q = useQuasar()
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
-const now = useGameTimerNow(100)
+const { hasMultipleRounds, playerRowsById, isHardPassed, isPausedHeldTurn } =
+  useGameTimerPlayerListPresentation()
 
-const { hasMultipleRounds, hardPassEnabled, round, activePlayerId, turnStartedAt } = storeToRefs(store)
-
-const hardPassIdsThisRound = computed(() => {
-  const arr = store.hardPassOrderByRound[String(round.value)]
-  return new Set(Array.isArray(arr) ? arr : [])
-})
-
-function isHardPassed(player) {
-  return hardPassEnabled.value && hardPassIdsThisRound.value.has(player.id)
-}
-
-/** Active row, clock paused; mild dim (hard-pass uses stronger styling). */
-function isPausedHeldTurn(player) {
-  if (isHardPassed(player)) return false
-  return activePlayerId.value === player.id && turnStartedAt.value == null
-}
+const { hardPassEnabled } = storeToRefs(store)
 
 function onHardPassButton(player) {
   if (isHardPassed(player)) {
@@ -231,39 +212,6 @@ const editDialogOpen = ref(false)
 const editPlayerId = ref(null)
 const editName = ref('')
 const editColor = ref(DEFAULT_PLAYER_COLORS[0])
-
-/**
- * @type {import('vue').ComputedRef<Map<string, import('../types.js').GameTimerPlayerRow>>}
- */
-const playerRowsById = computed(() => {
-  const session = {
-    activePlayerId: store.activePlayerId,
-    turnStartedAt: store.turnStartedAt,
-    turnStartedRound: store.turnStartedRound,
-  }
-  const currentRound = store.round
-  const nowMs = now.value
-  const list = store.players
-  const maxMs = maxDisplayedMs(list, session, nowMs)
-  const multi = hasMultipleRounds.value
-  const maxRoundMs = multi ? maxDisplayedMsInRound(list, session, nowMs, currentRound) : 0
-  const map = new Map()
-  for (const p of list) {
-    const displayedMs = displayedMsForPlayer(p, session, nowMs)
-    const displayedMsRound = multi ? displayedMsForPlayerInRound(p, session, nowMs, currentRound) : 0
-    map.set(p.id, {
-      id: p.id,
-      name: p.name,
-      color: p.color,
-      displayedMs,
-      progress: progressRatio(displayedMs, maxMs),
-      displayedMsRound,
-      progressRound: multi ? progressRatio(displayedMsRound, maxRoundMs) : 0,
-      isActive: session.activePlayerId === p.id,
-    })
-  }
-  return map
-})
 
 function rowForPlayer(player) {
   return playerRowsById.value.get(player.id)

--- a/src/features/game-timer/components/GameTimerRoundBar.vue
+++ b/src/features/game-timer/components/GameTimerRoundBar.vue
@@ -112,7 +112,7 @@
 import { computed, ref, unref } from 'vue'
 import { storeToRefs } from 'pinia'
 import GameTimerSyncControl from './GameTimerSyncControl.vue'
-import { displayedMsForPlayer, formatDurationMs } from '../core.js'
+import { formatDurationMs, nonPlayerElapsedMs, totalGameElapsedMs } from '../core.js'
 import { useGameTimerNow } from '../composables/useGameTimerNow.js'
 import { useGameTimerP2P } from '../composables/useGameTimerP2P.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
@@ -135,27 +135,25 @@ const settingsModel = computed(() =>
     fullscreenChromeExposed: unref(fullscreenChromeExposed),
   }),
 )
-const totalGameElapsedMs = computed(() => {
-  if (store.totalGameStartedAt == null) return 0
-  return Math.max(0, now.value - store.totalGameStartedAt)
-})
-const playerTotalElapsedMs = computed(() => {
-  const session = {
-    activePlayerId: store.activePlayerId,
-    turnStartedAt: store.turnStartedAt,
-  }
-  let total = 0
-  for (const p of store.players) {
-    total += displayedMsForPlayer(p, session, now.value)
-  }
-  return total
-})
-const nonPlayerElapsedMs = computed(() => Math.max(0, totalGameElapsedMs.value - playerTotalElapsedMs.value))
+const timingSnapshot = computed(() => ({
+  totalGameStartedAt: store.totalGameStartedAt,
+  players: store.players,
+  activePlayerId: store.activePlayerId,
+  turnStartedAt: store.turnStartedAt,
+}))
+const totalGameElapsedMsValue = computed(() =>
+  totalGameElapsedMs(timingSnapshot.value, now.value),
+)
+const nonPlayerElapsedMsValue = computed(() =>
+  nonPlayerElapsedMs(timingSnapshot.value, now.value),
+)
 const timingStripLabel = computed(() =>
   timingStripMode.value === 'non-player' ? 'Non-player' : 'Total game',
 )
 const timingStripValue = computed(() =>
-  formatDurationMs(timingStripMode.value === 'non-player' ? nonPlayerElapsedMs.value : totalGameElapsedMs.value),
+  formatDurationMs(
+    timingStripMode.value === 'non-player' ? nonPlayerElapsedMsValue.value : totalGameElapsedMsValue.value,
+  ),
 )
 
 const hardPassEnabledModel = computed({

--- a/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
+++ b/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
@@ -37,21 +37,8 @@ export function useGameTimerPlayerListPresentation({ now }) {
     }),
   )
 
-  function isHardPassed(player) {
-    if (!hardPassEnabled.value) return false
-    const arr = store.hardPassOrderByRound[String(round.value)]
-    return Array.isArray(arr) && arr.includes(player.id)
-  }
-
-  function isPausedHeldTurn(player) {
-    if (isHardPassed(player)) return false
-    return activePlayerId.value === player.id && turnStartedAt.value == null
-  }
-
   return {
     hasMultipleRounds: hasMultipleRoundsFlag,
     playerRowsById,
-    isHardPassed,
-    isPausedHeldTurn,
   }
 }

--- a/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
+++ b/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
@@ -1,16 +1,15 @@
-import { computed } from 'vue'
+import { computed, unref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { hasMultipleRounds } from '../core.js'
 import { createPlayerListViewModel } from '../ui/createPlayerListViewModel.js'
-import { useGameTimerNow } from './useGameTimerNow.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 
 /**
  * Wires reactive store snapshot + wall clock into the player list view model.
+ * @param {{ now: import('vue').MaybeRefOrGetter<number> }} sources
  */
-export function useGameTimerPlayerListPresentation() {
+export function useGameTimerPlayerListPresentation({ now }) {
   const store = useGameTimerStore()
-  const now = useGameTimerNow(100)
   const { hardPassEnabled, round, activePlayerId, turnStartedAt, turnStartedRound, players } =
     storeToRefs(store)
 
@@ -34,7 +33,7 @@ export function useGameTimerPlayerListPresentation() {
       hardPassEnabled: hardPassEnabled.value,
       hardPassOrderByRound: store.hardPassOrderByRound,
       hasMultipleRounds: hasMultipleRoundsFlag.value,
-      nowMs: now.value,
+      nowMs: unref(now),
     }),
   )
 

--- a/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
+++ b/src/features/game-timer/composables/useGameTimerPlayerListPresentation.js
@@ -1,0 +1,58 @@
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { hasMultipleRounds } from '../core.js'
+import { createPlayerListViewModel } from '../ui/createPlayerListViewModel.js'
+import { useGameTimerNow } from './useGameTimerNow.js'
+import { useGameTimerStore } from '../../../stores/gameTimer.js'
+
+/**
+ * Wires reactive store snapshot + wall clock into the player list view model.
+ */
+export function useGameTimerPlayerListPresentation() {
+  const store = useGameTimerStore()
+  const now = useGameTimerNow(100)
+  const { hardPassEnabled, round, activePlayerId, turnStartedAt, turnStartedRound, players } =
+    storeToRefs(store)
+
+  const hasMultipleRoundsFlag = computed(() =>
+    hasMultipleRounds({
+      round: round.value,
+      playerOrderByRound: store.playerOrderByRound,
+      players: players.value,
+    }),
+  )
+
+  const playerRowsById = computed(() =>
+    createPlayerListViewModel({
+      players: players.value,
+      session: {
+        activePlayerId: activePlayerId.value,
+        turnStartedAt: turnStartedAt.value,
+        turnStartedRound: turnStartedRound.value,
+      },
+      round: round.value,
+      hardPassEnabled: hardPassEnabled.value,
+      hardPassOrderByRound: store.hardPassOrderByRound,
+      hasMultipleRounds: hasMultipleRoundsFlag.value,
+      nowMs: now.value,
+    }),
+  )
+
+  function isHardPassed(player) {
+    if (!hardPassEnabled.value) return false
+    const arr = store.hardPassOrderByRound[String(round.value)]
+    return Array.isArray(arr) && arr.includes(player.id)
+  }
+
+  function isPausedHeldTurn(player) {
+    if (isHardPassed(player)) return false
+    return activePlayerId.value === player.id && turnStartedAt.value == null
+  }
+
+  return {
+    hasMultipleRounds: hasMultipleRoundsFlag,
+    playerRowsById,
+    isHardPassed,
+    isPausedHeldTurn,
+  }
+}

--- a/src/features/game-timer/core.js
+++ b/src/features/game-timer/core.js
@@ -228,6 +228,65 @@ export function nextDefaultColor(players) {
 }
 
 /**
+ * True when the session has multi-round UI (round > 1 or stored data for round 2+).
+ * Draft `playerOrderByRound` keys for rounds beyond `round` do not count.
+ * @param {{ round: number, playerOrderByRound: Record<string, string[]>, players: GameTimerPlayer[] }} snapshot
+ * @returns {boolean}
+ */
+export function hasMultipleRounds(snapshot) {
+  if (snapshot.round > 1) return true
+  const cur = snapshot.round
+  for (const k of Object.keys(snapshot.playerOrderByRound)) {
+    const nk = Number(k)
+    if (nk > 1 && nk <= cur) return true
+  }
+  for (const p of snapshot.players) {
+    const m = p.bankedMsByRound
+    if (!m || typeof m !== 'object') continue
+    for (const bk of Object.keys(m)) {
+      if (Number(bk) > 1) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Total game elapsed wall-clock ms since first `selectPlayer`; 0 before start.
+ * @param {{ totalGameStartedAt?: number | null }} snapshot
+ * @param {number} nowMs
+ * @returns {number}
+ */
+export function totalGameElapsedMs(snapshot, nowMs) {
+  if (typeof snapshot.totalGameStartedAt !== 'number') return 0
+  return Math.max(0, nowMs - snapshot.totalGameStartedAt)
+}
+
+/**
+ * Session non-player ms: total game minus sum of all player displayed totals.
+ * @param {{
+ *   totalGameStartedAt?: number | null,
+ *   players: GameTimerPlayer[],
+ *   activePlayerId: string | null,
+ *   turnStartedAt: number | null,
+ * }} snapshot
+ * @param {number} nowMs
+ * @returns {number}
+ */
+export function nonPlayerElapsedMs(snapshot, nowMs) {
+  const total = totalGameElapsedMs(snapshot, nowMs)
+  if (total <= 0 || !Array.isArray(snapshot.players) || snapshot.players.length === 0) return total
+  const session = {
+    activePlayerId: snapshot.activePlayerId,
+    turnStartedAt: snapshot.turnStartedAt,
+  }
+  let playerSum = 0
+  for (const p of snapshot.players) {
+    playerSum += displayedMsForPlayer(p, session, nowMs)
+  }
+  return Math.max(0, total - playerSum)
+}
+
+/**
  * `m:ss` or `h:mm:ss` for display in the list UI.
  * @param {number} ms
  * @returns {string}

--- a/src/features/game-timer/core.test.js
+++ b/src/features/game-timer/core.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { withFakeNow } from './test/withFakeNow.js'
+import { createTestSession, testPlayer } from './test/fixtures.js'
+import {
+  hasMultipleRounds,
+  nonPlayerElapsedMs,
+  totalGameElapsedMs,
+} from './core.js'
+import { selectPlayerSnapshot } from './timerRules.js'
+
+test('hasMultipleRounds is false for single-round session', () => {
+  assert.equal(
+    hasMultipleRounds(
+      createTestSession({
+        round: 1,
+        players: [testPlayer('a')],
+        playerOrderByRound: { '1': ['a'] },
+      }),
+    ),
+    false,
+  )
+})
+
+test('hasMultipleRounds is true when round index exceeds one', () => {
+  assert.equal(
+    hasMultipleRounds(
+      createTestSession({
+        round: 2,
+        players: [testPlayer('a')],
+        playerOrderByRound: { '1': ['a'], '2': ['a'] },
+      }),
+    ),
+    true,
+  )
+})
+
+test('hasMultipleRounds is true when player has banked time in round 2', () => {
+  assert.equal(
+    hasMultipleRounds(
+      createTestSession({
+        round: 1,
+        players: [testPlayer('a', { bankedMsByRound: { '2': 1000 } })],
+      }),
+    ),
+    true,
+  )
+})
+
+test('totalGameElapsedMs is zero before first selectPlayer', () => {
+  const snapshot = createTestSession({ totalGameStartedAt: null })
+  assert.equal(totalGameElapsedMs(snapshot, 5000), 0)
+})
+
+test('totalGameElapsedMs tracks wall clock after session start', () => {
+  const snapshot = createTestSession({ totalGameStartedAt: 10_000 })
+  assert.equal(totalGameElapsedMs(snapshot, 15_000), 5_000)
+})
+
+test('nonPlayerElapsedMs is total minus player displayed totals', () => {
+  withFakeNow(10_000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a')],
+      playerOrderByRound: { '1': ['a'] },
+    })
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    advance(5_000)
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+
+    const snapshot = {
+      totalGameStartedAt: session.totalGameStartedAt,
+      players: session.players,
+      activePlayerId: session.activePlayerId,
+      turnStartedAt: session.turnStartedAt,
+    }
+    assert.equal(totalGameElapsedMs(snapshot, 15_000), 5_000)
+    assert.equal(nonPlayerElapsedMs(snapshot, 15_000), 0)
+
+    snapshot.players[0].bankedMs = 12_000
+    assert.equal(nonPlayerElapsedMs(snapshot, 15_000), 0)
+  })
+})

--- a/src/features/game-timer/p2p/gameTimerPiniaBridge.js
+++ b/src/features/game-timer/p2p/gameTimerPiniaBridge.js
@@ -5,6 +5,7 @@
  */
 
 import { nextDefaultColor } from '../core.js'
+import { syncOrderForActiveRoundOnStore } from '../timerRules.js'
 import { useGameTimerStore } from '../../../stores/gameTimer.js'
 import { SCOPED_GUEST_INTENT_KIND_SET } from './protocol.js'
 import {
@@ -109,7 +110,7 @@ function normalizeAfterRemotePatch(store) {
   if (!store.hardPassOrderByRound || typeof store.hardPassOrderByRound !== 'object') {
     store.hardPassOrderByRound = {}
   }
-  store._applyOrderForActiveRound()
+  syncOrderForActiveRoundOnStore(store)
 }
 
 let handlersBound = false

--- a/src/features/game-timer/p2p/session.js
+++ b/src/features/game-timer/p2p/session.js
@@ -79,6 +79,9 @@ let nextSeq = 0
 
 let lastSeenSeq = 0
 
+/** While true, replayed guest inbox updates must not merge into host state during reclaim. */
+let suppressGuestInboxMergeOnHostReclaim = false
+
 /** Reactive session UI state for multiplayer (Vue ref; safe to use outside components). */
 export const sessionPhase = ref(/** @type {GameTimerSessionPhase} */ ('idle'))
 
@@ -240,6 +243,10 @@ function handleHostInboxMessage(stableId, raw) {
     return
   }
 
+  if (suppressGuestInboxMergeOnHostReclaim) {
+    return
+  }
+
   const msg = parseGuestMessage(raw)
   if (!msg) {
     if (
@@ -297,25 +304,26 @@ async function hydrateHostFromRtdb(suffix) {
   const parsed = parseHostMessage(stateSnap.val())
   if (!parsed) return
   nextSeq = parsed.seq
-  try {
-    handlers.applySnapshot(parsed.snapshot)
-  } catch {
-    void 0
-  }
+  // Returning host keeps locally persisted gameplay state; reclaim rebroadcasts it.
 }
 
 /**
  * @param {string} suffix
  */
 async function finishHostSession(suffix) {
-  resetHostGuestWireState()
-  await core.finishHostSession(suffix)
+  suppressGuestInboxMergeOnHostReclaim = true
   try {
-    useGameTimerRoomSessionStore().setHost(suffix)
-  } catch {
-    void 0
+    resetHostGuestWireState()
+    await core.finishHostSession(suffix)
+    try {
+      useGameTimerRoomSessionStore().setHost(suffix)
+    } catch {
+      void 0
+    }
+    hostPublishSnapshot(handlers.getSnapshot())
+  } finally {
+    suppressGuestInboxMergeOnHostReclaim = false
   }
-  hostPublishSnapshot(handlers.getSnapshot())
 }
 
 /**

--- a/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
+++ b/src/features/game-timer/p2p/sessionFacadeReconnect.test.js
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 import { afterEach, mock, test } from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
 import { useGameTimerRoomSessionStore } from '../../../stores/gameTimerRoomSession.js'
-import { encodeHostSnapshot } from './protocol.js'
+import { encodeHostSnapshot, parseHostMessage } from './protocol.js'
 import {
   createRtdbLifecycleAfterEach,
   importGameTimerSession,
@@ -123,11 +123,12 @@ async function installHostReconnectShellHook() {
 
 /**
  * @param {Awaited<ReturnType<typeof importGameTimerSession>>} sessionMod
+ * @param {import('../types.js').GameTimerSyncPayload} [initialSnapshot]
  * @returns {{ getSnapshot: () => import('../types.js').GameTimerSyncPayload, applied: import('../types.js').GameTimerSyncPayload[] }}
  */
-function bindFakeHandlers(sessionMod) {
+function bindFakeHandlers(sessionMod, initialSnapshot) {
   /** @type {import('../types.js').GameTimerSyncPayload} */
-  const snapshot = {
+  const snapshot = initialSnapshot ?? {
     players: [{ id: 'p1', name: 'Host', color: '#111111' }],
     activePlayerId: 'p1',
     turnStartedAt: null,
@@ -294,7 +295,7 @@ test(
 )
 
 test(
-  'host reclaim applies preserved snapshot and continues broadcast seq from RTDB',
+  'host reclaim keeps local snapshot and continues broadcast seq from RTDB',
   facadeReconnectTests,
   async () => {
     mock.reset()
@@ -302,7 +303,7 @@ test(
     const hostStableId = 'GTRECLAIM01'
     const suffix = 'RECLM1'
     /** @type {import('../types.js').GameTimerSyncPayload} */
-    const preservedSnapshot = {
+    const rtdbSnapshot = {
       players: [
         { id: 'p1', name: 'Host', color: '#111111' },
         { id: 'p2', name: 'Guest', color: '#222222' },
@@ -313,7 +314,16 @@ test(
       round: 2,
       playerOrderByRound: { 1: ['p1', 'p2'], 2: ['p2', 'p1'] },
     }
-    const preservedState = encodeHostSnapshot(preservedSnapshot, 5)
+    /** @type {import('../types.js').GameTimerSyncPayload} */
+    const localSnapshot = {
+      ...rtdbSnapshot,
+      activePlayerId: 'p1',
+      turnStartedAt: null,
+      turnStartedRound: null,
+      round: 1,
+      playerOrderByRound: { 1: ['p1', 'p2'] },
+    }
+    const preservedState = encodeHostSnapshot(rtdbSnapshot, 5)
 
     mock.module('../../p2p/identity.js', {
       namedExports: {
@@ -348,7 +358,7 @@ test(
     await withFirebaseEnv(async () => {
       const sessionMod = await importGameTimerSession(`reclaim-seq-${Date.now()}`)
       const { resumeAsHost, sessionPhase, broadcastGameTimerSnapshot } = sessionMod
-      const { getSnapshot, applied } = bindFakeHandlers(sessionMod)
+      const { getSnapshot, applied } = bindFakeHandlers(sessionMod, localSnapshot)
 
       setActivePinia(createPinia())
       useGameTimerRoomSessionStore().setHost(suffix)
@@ -356,13 +366,15 @@ test(
       const result = await resumeAsHost(suffix, 1)
       assert.equal(result.suffix, suffix)
       assert.equal(sessionPhase.value, 'hosting')
-      assert.equal(applied.length, 1)
-      assert.equal(applied[0].activePlayerId, preservedSnapshot.activePlayerId)
-      assert.equal(applied[0].round, preservedSnapshot.round)
-      assert.deepEqual(applied[0].players, preservedSnapshot.players)
+      assert.equal(applied.length, 0, 'host reclaim must not overwrite local state from RTDB')
 
       const resumePublish = broadcastSets.find((s) => s.path.endsWith('/state'))
-      assert.ok(resumePublish, 'host reclaim should publish hydrated authoritative state')
+      assert.ok(resumePublish, 'host reclaim should publish local authoritative state')
+      const resumeParsed = parseHostMessage(resumePublish.value)
+      assert.ok(resumeParsed)
+      assert.equal(resumeParsed.snapshot.activePlayerId, localSnapshot.activePlayerId)
+      assert.equal(resumeParsed.snapshot.round, localSnapshot.round)
+      assert.notEqual(resumeParsed.snapshot.activePlayerId, rtdbSnapshot.activePlayerId)
       assert.equal(
         resumePublish.value.seq,
         6,

--- a/src/features/game-timer/sessionTiming.test.js
+++ b/src/features/game-timer/sessionTiming.test.js
@@ -1,19 +1,16 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
+import { nonPlayerElapsedMs, totalGameElapsedMs } from './core.js'
+import { withFakeNow } from './test/withFakeNow.js'
 import { useGameTimerStore } from '../../stores/gameTimer.js'
 
-function withFakeNow(startMs, run) {
-  const originalNow = Date.now
-  let now = startMs
-  Date.now = () => now
-  const advance = (ms) => {
-    now += ms
-  }
-  try {
-    run(advance)
-  } finally {
-    Date.now = originalNow
+function timingSnapshot(store) {
+  return {
+    totalGameStartedAt: store.totalGameStartedAt,
+    players: store.players,
+    activePlayerId: store.activePlayerId,
+    turnStartedAt: store.turnStartedAt,
   }
 }
 
@@ -24,13 +21,13 @@ test('game timer session timing starts on first selectPlayer only', () => {
     const p1 = store.addPlayer({ name: 'A' })
 
     assert.equal(store.totalGameStartedAt, null)
-    assert.equal(store.totalGameElapsedMs, 0)
-    assert.equal(store.nonPlayerElapsedMs, 0)
+    assert.equal(totalGameElapsedMs(timingSnapshot(store), Date.now()), 0)
+    assert.equal(nonPlayerElapsedMs(timingSnapshot(store), Date.now()), 0)
 
     advance(3_000)
     store.selectPlayer(p1)
     assert.equal(store.totalGameStartedAt, 4_000)
-    assert.equal(store.totalGameElapsedMs, 0)
+    assert.equal(totalGameElapsedMs(timingSnapshot(store), Date.now()), 0)
   })
 })
 
@@ -44,11 +41,12 @@ test('non-player time is total minus players and clamps at zero', () => {
     advance(5_000)
     store.selectPlayer(p1)
 
-    assert.equal(store.totalGameElapsedMs, 5_000)
-    assert.equal(store.nonPlayerElapsedMs, 0)
+    const snapshot = timingSnapshot(store)
+    assert.equal(totalGameElapsedMs(snapshot, Date.now()), 5_000)
+    assert.equal(nonPlayerElapsedMs(snapshot, Date.now()), 0)
 
     store.players[0].bankedMs = 12_000
-    assert.equal(store.nonPlayerElapsedMs, 0)
+    assert.equal(nonPlayerElapsedMs(timingSnapshot(store), Date.now()), 0)
   })
 })
 
@@ -62,7 +60,7 @@ test('clear all players resets session timing baseline', () => {
 
     store.clearAllPlayers()
     assert.equal(store.totalGameStartedAt, null)
-    assert.equal(store.totalGameElapsedMs, 0)
-    assert.equal(store.nonPlayerElapsedMs, 0)
+    assert.equal(totalGameElapsedMs(timingSnapshot(store), Date.now()), 0)
+    assert.equal(nonPlayerElapsedMs(timingSnapshot(store), Date.now()), 0)
   })
 })

--- a/src/features/game-timer/startNewGameSamePlayers.test.js
+++ b/src/features/game-timer/startNewGameSamePlayers.test.js
@@ -1,21 +1,9 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { createPinia, setActivePinia } from 'pinia'
+import { totalGameElapsedMs } from './core.js'
+import { withFakeNow } from './test/withFakeNow.js'
 import { useGameTimerStore } from '../../stores/gameTimer.js'
-
-function withFakeNow(startMs, run) {
-  const originalNow = Date.now
-  let now = startMs
-  Date.now = () => now
-  const advance = (ms) => {
-    now += ms
-  }
-  try {
-    run(advance)
-  } finally {
-    Date.now = originalNow
-  }
-}
 
 test('startNewGameSamePlayers keeps roster and clears clocks and rounds', () => {
   withFakeNow(1000, (advance) => {
@@ -52,7 +40,18 @@ test('startNewGameSamePlayers keeps roster and clears clocks and rounds', () => 
     assert.equal(store.turnStartedAt, null)
     assert.equal(store.turnStartedRound, null)
     assert.equal(store.totalGameStartedAt, null)
-    assert.equal(store.totalGameElapsedMs, 0)
+    assert.equal(
+      totalGameElapsedMs(
+        {
+          totalGameStartedAt: store.totalGameStartedAt,
+          players: store.players,
+          activePlayerId: store.activePlayerId,
+          turnStartedAt: store.turnStartedAt,
+        },
+        Date.now(),
+      ),
+      0,
+    )
     for (const p of store.players) {
       assert.equal(p.bankedMs, 0)
       assert.deepEqual(p.bankedMsByRound, {})

--- a/src/features/game-timer/test/fixtures.js
+++ b/src/features/game-timer/test/fixtures.js
@@ -1,0 +1,54 @@
+/**
+ * @import '../types.js'
+ */
+
+/**
+ * @typedef {import('../timerRules.js').GameTimerRuleSession} GameTimerRuleSession
+ */
+
+/**
+ * @param {Partial<GameTimerRuleSession>} [overrides]
+ * @returns {GameTimerRuleSession}
+ */
+export function createTestSession(overrides = {}) {
+  const base = {
+    players: [],
+    activePlayerId: null,
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: {},
+    hardPassEnabled: false,
+    hardPassOrderNextRound: false,
+    hardPassOrderByRound: {},
+    totalGameStartedAt: null,
+  }
+
+  const merged = { ...base, ...overrides }
+
+  return {
+    ...merged,
+    players: (merged.players ?? []).map((p) => ({
+      bankedMs: 0,
+      bankedMsByRound: {},
+      ...p,
+    })),
+    playerOrderByRound: { ...(merged.playerOrderByRound ?? {}) },
+    hardPassOrderByRound: { ...(merged.hardPassOrderByRound ?? {}) },
+  }
+}
+
+/**
+ * @param {string} id
+ * @param {{ name?: string, color?: string, bankedMs?: number, bankedMsByRound?: Record<string, number> }} [opts]
+ * @returns {GameTimerPlayer}
+ */
+export function testPlayer(id, opts = {}) {
+  return {
+    id,
+    name: opts.name ?? id,
+    color: opts.color ?? '#5c6bc0',
+    bankedMs: opts.bankedMs ?? 0,
+    bankedMsByRound: opts.bankedMsByRound ?? {},
+  }
+}

--- a/src/features/game-timer/test/withFakeNow.js
+++ b/src/features/game-timer/test/withFakeNow.js
@@ -1,0 +1,20 @@
+/**
+ * Stub `Date.now` for deterministic timer tests.
+ * @template T
+ * @param {number} startMs
+ * @param {(advance: (ms: number) => void) => T} run
+ * @returns {T}
+ */
+export function withFakeNow(startMs, run) {
+  const originalNow = Date.now
+  let now = startMs
+  Date.now = () => now
+  const advance = (ms) => {
+    now += ms
+  }
+  try {
+    return run(advance)
+  } finally {
+    Date.now = originalNow
+  }
+}

--- a/src/features/game-timer/timerRules.js
+++ b/src/features/game-timer/timerRules.js
@@ -144,7 +144,7 @@ function saveOrderForRound(session) {
 /**
  * @param {GameTimerRuleSession} session
  */
-function applyOrderForActiveRound(session) {
+export function applyOrderForActiveRound(session) {
   const k = String(session.round)
   let ids = session.playerOrderByRound[k]
   if (!Array.isArray(ids) || ids.length === 0) {
@@ -165,7 +165,7 @@ function applyOrderForActiveRound(session) {
  * @param {GameTimerRuleSession} session
  * @param {number} n
  */
-function recomputeNextRoundOrderFromHardPasses(session, n) {
+export function recomputeNextRoundOrderFromHardPasses(session, n) {
   if (!session.hardPassEnabled || !session.hardPassOrderNextRound) return
   if (session.players.length === 0) return
   const nk = String(Math.max(1, Math.floor(n)))
@@ -455,20 +455,13 @@ export function ruleSessionFromStoreState(state) {
 }
 
 /**
- * @param {GameTimerRuleSession} session
- * @returns {Partial<GameTimerRuleSession>}
+ * Reorder `store.players` for the active round via the rule session adapter.
+ * @param {object} store Pinia game timer store instance
  */
-export function ruleSessionPatch(session) {
-  return {
-    players: session.players,
-    activePlayerId: session.activePlayerId,
-    turnStartedAt: session.turnStartedAt,
-    turnStartedRound: session.turnStartedRound,
-    round: session.round,
-    playerOrderByRound: session.playerOrderByRound,
-    hardPassOrderByRound: session.hardPassOrderByRound,
-    totalGameStartedAt: session.totalGameStartedAt,
-  }
+export function syncOrderForActiveRoundOnStore(store) {
+  const session = ruleSessionFromStoreState(store)
+  applyOrderForActiveRound(session)
+  store.players = session.players
 }
 
 /**

--- a/src/features/game-timer/timerRules.js
+++ b/src/features/game-timer/timerRules.js
@@ -1,0 +1,488 @@
+/**
+ * @import './types.js'
+ */
+
+/**
+ * Authoritative Game Timer snapshot slice for pure rule functions.
+ *
+ * @typedef {object} GameTimerRuleSession
+ * @property {GameTimerPlayer[]} players
+ * @property {string | null} activePlayerId
+ * @property {number | null} turnStartedAt
+ * @property {number | null} turnStartedRound
+ * @property {number} round
+ * @property {Record<string, string[]>} playerOrderByRound
+ * @property {boolean} hardPassEnabled
+ * @property {boolean} hardPassOrderNextRound
+ * @property {Record<string, string[]>} hardPassOrderByRound
+ * @property {number | null} totalGameStartedAt
+ */
+
+/**
+ * @param {GameTimerPlayer} player
+ * @returns {GameTimerPlayer}
+ */
+function clonePlayer(player) {
+  return {
+    ...player,
+    bankedMsByRound:
+      player.bankedMsByRound && typeof player.bankedMsByRound === 'object'
+        ? { ...player.bankedMsByRound }
+        : {},
+  }
+}
+
+/**
+ * @param {Record<string, string[]>} map
+ * @returns {Record<string, string[]>}
+ */
+function cloneStringListMap(map) {
+  const out = {}
+  for (const k of Object.keys(map)) {
+    const arr = map[k]
+    out[k] = Array.isArray(arr) ? [...arr] : []
+  }
+  return out
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @returns {GameTimerRuleSession}
+ */
+export function cloneRuleSession(session) {
+  return {
+    ...session,
+    players: session.players.map(clonePlayer),
+    playerOrderByRound: cloneStringListMap(session.playerOrderByRound),
+    hardPassOrderByRound: cloneStringListMap(session.hardPassOrderByRound),
+  }
+}
+
+/**
+ * Rebuild `players` to match `idOrder`, appending any players missing from that list.
+ * @param {GameTimerPlayer[]} players
+ * @param {string[]} idOrder
+ * @returns {GameTimerPlayer[]}
+ */
+export function applyPlayerOrder(players, idOrder) {
+  const map = new Map(players.map((p) => [p.id, p]))
+  const out = []
+  const seen = new Set()
+  for (const id of idOrder) {
+    const p = map.get(id)
+    if (p) {
+      out.push(p)
+      seen.add(id)
+    }
+  }
+  for (const p of players) {
+    if (!seen.has(p.id)) out.push(p)
+  }
+  return out
+}
+
+/**
+ * @param {Record<string, string[]>} hardPassOrderByRound
+ * @param {string} playerId
+ */
+export function stripPlayerFromHardPassMaps(hardPassOrderByRound, playerId) {
+  for (const k of Object.keys(hardPassOrderByRound)) {
+    const arr = hardPassOrderByRound[k]
+    if (Array.isArray(arr)) {
+      hardPassOrderByRound[k] = arr.filter((id) => id !== playerId)
+    }
+  }
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ */
+function bankActiveSegment(session, nowMs) {
+  if (session.activePlayerId == null || session.turnStartedAt == null) return
+  const seg = Math.max(0, nowMs - session.turnStartedAt)
+  const p = session.players.find((player) => player.id === session.activePlayerId)
+  if (!p) return
+
+  p.bankedMs += seg
+
+  const r = session.turnStartedRound
+  if (r != null) {
+    if (!p.bankedMsByRound || typeof p.bankedMsByRound !== 'object') {
+      p.bankedMsByRound = {}
+    }
+    const key = String(r)
+    p.bankedMsByRound[key] = (p.bankedMsByRound[key] ?? 0) + seg
+  }
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ */
+function clearLiveTurn(session) {
+  session.activePlayerId = null
+  session.turnStartedAt = null
+  session.turnStartedRound = null
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ */
+function pauseLiveTurn(session, nowMs) {
+  bankActiveSegment(session, nowMs)
+  clearLiveTurn(session)
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ */
+function saveOrderForRound(session) {
+  session.playerOrderByRound[String(session.round)] = session.players.map((p) => p.id)
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ */
+function applyOrderForActiveRound(session) {
+  const k = String(session.round)
+  let ids = session.playerOrderByRound[k]
+  if (!Array.isArray(ids) || ids.length === 0) {
+    ids = session.players.map((p) => p.id)
+    session.playerOrderByRound[k] = [...ids]
+  } else {
+    const set = new Set(session.players.map((p) => p.id))
+    ids = ids.filter((id) => set.has(id))
+    for (const p of session.players) {
+      if (!ids.includes(p.id)) ids.push(p.id)
+    }
+    session.playerOrderByRound[k] = ids
+  }
+  session.players = applyPlayerOrder(session.players, ids)
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} n
+ */
+function recomputeNextRoundOrderFromHardPasses(session, n) {
+  if (!session.hardPassEnabled || !session.hardPassOrderNextRound) return
+  if (session.players.length === 0) return
+  const nk = String(Math.max(1, Math.floor(n)))
+  const nextK = String(Math.max(1, Math.floor(n)) + 1)
+  const raw = session.hardPassOrderByRound[nk]
+  const passers = Array.isArray(raw)
+    ? raw.filter((id) => session.players.some((p) => p.id === id))
+    : []
+  if (passers.length === 0) {
+    session.playerOrderByRound[nextK] = session.players.map((p) => p.id)
+    return
+  }
+  const passerSet = new Set(passers)
+  const remaining = session.players.map((p) => p.id).filter((id) => !passerSet.has(id))
+  session.playerOrderByRound[nextK] = [...passers, ...remaining]
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} fromIdx
+ * @param {Set<string>} passed
+ * @returns {number | null}
+ */
+function nextNonPassedPlayerIndex(session, fromIdx, passed) {
+  const n = session.players.length
+  if (n === 0) return null
+  let nextIdx = (fromIdx + 1) % n
+  for (let steps = 0; steps < n; steps++) {
+    if (!passed.has(session.players[nextIdx].id)) return nextIdx
+    nextIdx = (nextIdx + 1) % n
+  }
+  return null
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession}
+ */
+export function pauseLiveTurnSnapshot(session, nowMs) {
+  const next = cloneRuleSession(session)
+  pauseLiveTurn(next, nowMs)
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {string} playerId
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function selectPlayerSnapshot(session, playerId, nowMs) {
+  if (!session.players.some((p) => p.id === playerId)) return null
+  const next = cloneRuleSession(session)
+  if (next.totalGameStartedAt == null) next.totalGameStartedAt = nowMs
+
+  if (next.activePlayerId === playerId) {
+    if (next.turnStartedAt != null) {
+      bankActiveSegment(next, nowMs)
+      next.turnStartedAt = null
+      next.turnStartedRound = null
+      return next
+    }
+    next.turnStartedAt = nowMs
+    next.turnStartedRound = next.round
+    return next
+  }
+
+  if (next.activePlayerId != null) {
+    bankActiveSegment(next, nowMs)
+  }
+  next.activePlayerId = playerId
+  next.turnStartedAt = nowMs
+  next.turnStartedRound = next.round
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function endTurnNextSnapshot(session, nowMs) {
+  if (session.players.length === 0 || session.activePlayerId == null) return null
+  const next = cloneRuleSession(session)
+
+  if (next.turnStartedAt != null) {
+    bankActiveSegment(next, nowMs)
+  }
+
+  const idx = next.players.findIndex((p) => p.id === next.activePlayerId)
+  if (idx === -1) {
+    clearLiveTurn(next)
+    return next
+  }
+
+  const passed = next.hardPassEnabled
+    ? new Set(next.hardPassOrderByRound[String(next.round)] ?? [])
+    : new Set()
+
+  const nextIdx = nextNonPassedPlayerIndex(next, idx, passed)
+  if (nextIdx == null) {
+    clearLiveTurn(next)
+    return next
+  }
+  const successor = next.players[nextIdx]
+  next.activePlayerId = successor.id
+  next.turnStartedAt = nowMs
+  next.turnStartedRound = next.round
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {string} playerId
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function registerHardPassSnapshot(session, playerId, nowMs) {
+  if (!session.hardPassEnabled || !session.players.some((p) => p.id === playerId)) return null
+  const next = cloneRuleSession(session)
+
+  const rk = String(next.round)
+  if (!next.hardPassOrderByRound[rk] || !Array.isArray(next.hardPassOrderByRound[rk])) {
+    next.hardPassOrderByRound[rk] = []
+  }
+  if (next.hardPassOrderByRound[rk].includes(playerId)) return null
+
+  const clockRunning = next.activePlayerId === playerId && next.turnStartedAt != null
+  const turnHeldHere = next.activePlayerId === playerId
+
+  if (clockRunning) {
+    bankActiveSegment(next, nowMs)
+  }
+
+  next.hardPassOrderByRound[rk].push(playerId)
+  recomputeNextRoundOrderFromHardPasses(next, next.round)
+
+  if (turnHeldHere) {
+    const passed = new Set(next.hardPassOrderByRound[rk] ?? [])
+    const idx = next.players.findIndex((p) => p.id === playerId)
+    const nextIdx = idx === -1 ? null : nextNonPassedPlayerIndex(next, idx, passed)
+    if (nextIdx == null) {
+      clearLiveTurn(next)
+    } else {
+      const successor = next.players[nextIdx]
+      next.activePlayerId = successor.id
+      next.turnStartedAt = nowMs
+      next.turnStartedRound = next.round
+    }
+  }
+
+  const list = next.hardPassOrderByRound[rk] ?? []
+  const passedSet = new Set(list)
+  const allHardPassed =
+    next.players.length > 0 && next.players.every((p) => passedSet.has(p.id))
+  if (allHardPassed) {
+    return goToNextRoundSnapshot(next, nowMs)
+  }
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {string} playerId
+ * @returns {GameTimerRuleSession | null}
+ */
+export function undoHardPassSnapshot(session, playerId) {
+  if (!session.hardPassEnabled || !session.players.some((p) => p.id === playerId)) return null
+  const rk = String(session.round)
+  const arr = session.hardPassOrderByRound[rk]
+  if (!Array.isArray(arr) || !arr.includes(playerId)) return null
+  const next = cloneRuleSession(session)
+  next.hardPassOrderByRound[rk] = arr.filter((id) => id !== playerId)
+  recomputeNextRoundOrderFromHardPasses(next, next.round)
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function goToNextRoundSnapshot(session, nowMs) {
+  if (session.players.length === 0) return null
+  const next = cloneRuleSession(session)
+  saveOrderForRound(next)
+  pauseLiveTurn(next, nowMs)
+  next.round += 1
+  applyOrderForActiveRound(next)
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function goToPreviousRoundSnapshot(session, nowMs) {
+  if (session.players.length === 0 || session.round <= 1) return null
+  const next = cloneRuleSession(session)
+  saveOrderForRound(next)
+  pauseLiveTurn(next, nowMs)
+  next.round -= 1
+  applyOrderForActiveRound(next)
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function startNewGameSamePlayersSnapshot(session, nowMs) {
+  if (session.players.length === 0) return null
+  const next = cloneRuleSession(session)
+  pauseLiveTurn(next, nowMs)
+  for (const p of next.players) {
+    p.bankedMs = 0
+    p.bankedMsByRound = {}
+  }
+  next.round = 1
+  const order = next.players.map((p) => p.id)
+  next.playerOrderByRound = { '1': [...order] }
+  next.hardPassOrderByRound = {}
+  next.totalGameStartedAt = null
+  if (next.hardPassEnabled && next.hardPassOrderNextRound) {
+    recomputeNextRoundOrderFromHardPasses(next, 1)
+  }
+  applyOrderForActiveRound(next)
+  return next
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @param {string} playerId
+ * @param {number} nowMs
+ * @returns {GameTimerRuleSession | null}
+ */
+export function removePlayerSnapshot(session, playerId, nowMs) {
+  const idx = session.players.findIndex((p) => p.id === playerId)
+  if (idx === -1) return null
+  const next = cloneRuleSession(session)
+
+  const wasActive = next.activePlayerId === playerId
+  if (wasActive) {
+    bankActiveSegment(next, nowMs)
+  }
+
+  next.players.splice(idx, 1)
+
+  if (wasActive) {
+    clearLiveTurn(next)
+  }
+
+  for (const k of Object.keys(next.playerOrderByRound)) {
+    const arr = next.playerOrderByRound[k]
+    if (Array.isArray(arr)) {
+      next.playerOrderByRound[k] = arr.filter((id) => id !== playerId)
+    }
+  }
+  stripPlayerFromHardPassMaps(next.hardPassOrderByRound, playerId)
+  if (next.hardPassEnabled && next.hardPassOrderNextRound && next.players.length > 0) {
+    recomputeNextRoundOrderFromHardPasses(next, next.round)
+  }
+  return next
+}
+
+/**
+ * Pick rule-relevant fields from Pinia store state for delegation.
+ * @param {object} state
+ * @returns {GameTimerRuleSession}
+ */
+export function ruleSessionFromStoreState(state) {
+  return {
+    players: state.players,
+    activePlayerId: state.activePlayerId,
+    turnStartedAt: state.turnStartedAt,
+    turnStartedRound: state.turnStartedRound,
+    round: state.round,
+    playerOrderByRound: state.playerOrderByRound,
+    hardPassEnabled: state.hardPassEnabled,
+    hardPassOrderNextRound: state.hardPassOrderNextRound,
+    hardPassOrderByRound: state.hardPassOrderByRound,
+    totalGameStartedAt: state.totalGameStartedAt,
+  }
+}
+
+/**
+ * @param {GameTimerRuleSession} session
+ * @returns {Partial<GameTimerRuleSession>}
+ */
+export function ruleSessionPatch(session) {
+  return {
+    players: session.players,
+    activePlayerId: session.activePlayerId,
+    turnStartedAt: session.turnStartedAt,
+    turnStartedRound: session.turnStartedRound,
+    round: session.round,
+    playerOrderByRound: session.playerOrderByRound,
+    hardPassOrderByRound: session.hardPassOrderByRound,
+    totalGameStartedAt: session.totalGameStartedAt,
+  }
+}
+
+/**
+ * Apply authoritative rule output to Pinia store (full replace for map fields).
+ * @param {object} store
+ * @param {GameTimerRuleSession} session
+ */
+export function applyRuleSessionToStore(store, session) {
+  store.players = session.players
+  store.activePlayerId = session.activePlayerId
+  store.turnStartedAt = session.turnStartedAt
+  store.turnStartedRound = session.turnStartedRound
+  store.round = session.round
+  store.playerOrderByRound = session.playerOrderByRound
+  store.hardPassOrderByRound = session.hardPassOrderByRound
+  store.totalGameStartedAt = session.totalGameStartedAt
+}

--- a/src/features/game-timer/timerRules.test.js
+++ b/src/features/game-timer/timerRules.test.js
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { withFakeNow } from './test/withFakeNow.js'
+import { createTestSession, testPlayer } from './test/fixtures.js'
+import {
+  applyPlayerOrder,
+  endTurnNextSnapshot,
+  goToNextRoundSnapshot,
+  goToPreviousRoundSnapshot,
+  registerHardPassSnapshot,
+  removePlayerSnapshot,
+  selectPlayerSnapshot,
+  startNewGameSamePlayersSnapshot,
+  undoHardPassSnapshot,
+} from './timerRules.js'
+
+test('startNewGameSamePlayersSnapshot keeps roster and clears clocks and rounds', () => {
+  withFakeNow(1000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a', { name: 'Ada', color: '#ff0000' }), testPlayer('b', { name: 'Bob', color: '#00ff00' })],
+      playerOrderByRound: { '1': ['a', 'b'] },
+      hardPassEnabled: true,
+      hardPassOrderNextRound: true,
+    })
+
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    advance(2000)
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    session = goToNextRoundSnapshot(session, Date.now())
+    assert.ok(session)
+    session = selectPlayerSnapshot(session, 'b', Date.now())
+    assert.ok(session)
+    advance(1000)
+    session = registerHardPassSnapshot(session, 'b', Date.now())
+    assert.ok(session)
+
+    const rosterSnapshot = session.players.map((p) => ({ id: p.id, name: p.name, color: p.color }))
+    const orderAtReset = session.players.map((p) => p.id)
+    assert.equal(session.round, 2)
+    assert.ok(session.players[0].bankedMs > 0 || session.players[1].bankedMs > 0)
+    assert.ok(Object.keys(session.hardPassOrderByRound).length > 0)
+
+    const reset = startNewGameSamePlayersSnapshot(session, Date.now())
+    assert.ok(reset)
+
+    assert.deepEqual(
+      reset.players.map((p) => ({ id: p.id, name: p.name, color: p.color })),
+      rosterSnapshot,
+    )
+    assert.equal(reset.round, 1)
+    assert.equal(reset.activePlayerId, null)
+    assert.equal(reset.turnStartedAt, null)
+    assert.equal(reset.turnStartedRound, null)
+    assert.equal(reset.totalGameStartedAt, null)
+    for (const p of reset.players) {
+      assert.equal(p.bankedMs, 0)
+      assert.deepEqual(p.bankedMsByRound, {})
+    }
+    assert.deepEqual(reset.hardPassOrderByRound, {})
+    assert.equal(reset.hardPassEnabled, true)
+    assert.equal(reset.hardPassOrderNextRound, true)
+    assert.deepEqual(reset.playerOrderByRound['1'], orderAtReset)
+  })
+})
+
+test('startNewGameSamePlayersSnapshot uses current list order as round 1 order', () => {
+  const session = createTestSession({
+    players: [testPlayer('a'), testPlayer('b')],
+    playerOrderByRound: { '1': ['a', 'b'], '2': ['b', 'a'] },
+    round: 2,
+  })
+
+  const reset = startNewGameSamePlayersSnapshot(session, Date.now())
+  assert.ok(reset)
+  assert.equal(reset.round, 1)
+  assert.deepEqual(
+    reset.players.map((p) => p.id),
+    ['a', 'b'],
+  )
+  assert.deepEqual(reset.playerOrderByRound['1'], ['a', 'b'])
+  assert.equal(Object.keys(reset.playerOrderByRound).length, 1)
+})
+
+test('startNewGameSamePlayersSnapshot is a no-op with no players', () => {
+  assert.equal(startNewGameSamePlayersSnapshot(createTestSession(), Date.now()), null)
+})
+
+test('selectPlayerSnapshot sets totalGameStartedAt on first select', () => {
+  const session = createTestSession({
+    players: [testPlayer('a')],
+    playerOrderByRound: { '1': ['a'] },
+  })
+  const next = selectPlayerSnapshot(session, 'a', 4000)
+  assert.ok(next)
+  assert.equal(next.totalGameStartedAt, 4000)
+  assert.equal(next.activePlayerId, 'a')
+  assert.equal(next.turnStartedAt, 4000)
+})
+
+test('selectPlayerSnapshot pauses and resumes same player', () => {
+  withFakeNow(1000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a')],
+      playerOrderByRound: { '1': ['a'] },
+    })
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    advance(3000)
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    assert.equal(session.turnStartedAt, null)
+    assert.equal(session.activePlayerId, 'a')
+    assert.equal(session.players[0].bankedMs, 3000)
+
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    assert.equal(session.turnStartedAt, 4000)
+    assert.equal(session.turnStartedRound, 1)
+  })
+})
+
+test('selectPlayerSnapshot banks previous player when switching', () => {
+  withFakeNow(1000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'] },
+    })
+    session = selectPlayerSnapshot(session, 'a', Date.now())
+    advance(2000)
+    session = selectPlayerSnapshot(session, 'b', Date.now())
+    assert.ok(session)
+    assert.equal(session.players[0].bankedMs, 2000)
+    assert.equal(session.activePlayerId, 'b')
+    assert.equal(session.turnStartedAt, 3000)
+  })
+})
+
+test('endTurnNextSnapshot wraps and skips hard-passed players', () => {
+  withFakeNow(5000, () => {
+    const session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b'), testPlayer('c')],
+      playerOrderByRound: { '1': ['a', 'b', 'c'] },
+      hardPassEnabled: true,
+      hardPassOrderByRound: { '1': ['b'] },
+      activePlayerId: 'a',
+      turnStartedAt: 5000,
+      turnStartedRound: 1,
+    })
+    const next = endTurnNextSnapshot(session, 6000)
+    assert.ok(next)
+    assert.equal(next.activePlayerId, 'c')
+    assert.equal(next.turnStartedAt, 6000)
+    assert.equal(next.players[0].bankedMs, 1000)
+  })
+})
+
+test('endTurnNextSnapshot clears turn when every player is hard-passed', () => {
+  const session = createTestSession({
+    players: [testPlayer('a'), testPlayer('b')],
+    playerOrderByRound: { '1': ['a', 'b'] },
+    hardPassEnabled: true,
+    hardPassOrderByRound: { '1': ['a', 'b'] },
+    activePlayerId: 'a',
+    turnStartedAt: 1000,
+    turnStartedRound: 1,
+  })
+  const next = endTurnNextSnapshot(session, 2000)
+  assert.ok(next)
+  assert.equal(next.activePlayerId, null)
+  assert.equal(next.turnStartedAt, null)
+})
+
+test('registerHardPassSnapshot banks running clock and auto-advances', () => {
+  withFakeNow(1000, () => {
+    const session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'] },
+      hardPassEnabled: true,
+      activePlayerId: 'a',
+      turnStartedAt: 1000,
+      turnStartedRound: 1,
+    })
+    const next = registerHardPassSnapshot(session, 'a', 4000)
+    assert.ok(next)
+    assert.deepEqual(next.hardPassOrderByRound['1'], ['a'])
+    assert.equal(next.players[0].bankedMs, 3000)
+    assert.equal(next.activePlayerId, 'b')
+    assert.equal(next.turnStartedAt, 4000)
+  })
+})
+
+test('registerHardPassSnapshot advances round when all players hard-passed', () => {
+  withFakeNow(1000, () => {
+    let session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'] },
+      hardPassEnabled: true,
+    })
+    session = registerHardPassSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    assert.equal(session.round, 1)
+    session = registerHardPassSnapshot(session, 'b', Date.now())
+    assert.ok(session)
+    assert.equal(session.round, 2)
+    assert.equal(session.activePlayerId, null)
+  })
+})
+
+test('registerHardPassSnapshot drafts next-round order from pass sequence', () => {
+  const session = createTestSession({
+    players: [testPlayer('a'), testPlayer('b'), testPlayer('c')],
+    playerOrderByRound: { '1': ['a', 'b', 'c'] },
+    hardPassEnabled: true,
+    hardPassOrderNextRound: true,
+  })
+  let next = registerHardPassSnapshot(session, 'b', 1000)
+  assert.ok(next)
+  next = registerHardPassSnapshot(next, 'a', 2000)
+  assert.ok(next)
+  assert.deepEqual(next.playerOrderByRound['2'], ['b', 'a', 'c'])
+})
+
+test('undoHardPassSnapshot removes pass without restoring banked time', () => {
+  withFakeNow(1000, () => {
+    let session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'] },
+      hardPassEnabled: true,
+      hardPassOrderNextRound: true,
+      activePlayerId: 'a',
+      turnStartedAt: 1000,
+      turnStartedRound: 1,
+    })
+    session = registerHardPassSnapshot(session, 'a', 5000)
+    assert.ok(session)
+    const bankedBeforeUndo = session.players[0].bankedMs
+    assert.ok(bankedBeforeUndo > 0)
+
+    session = undoHardPassSnapshot(session, 'a')
+    assert.ok(session)
+    assert.equal(session.hardPassOrderByRound['1']?.includes('a'), false)
+    assert.equal(session.players[0].bankedMs, bankedBeforeUndo)
+  })
+})
+
+test('goToNextRoundSnapshot pauses live turn and preserves lifetime banked time', () => {
+  withFakeNow(1000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a', { bankedMs: 5000, bankedMsByRound: { '1': 5000 } }), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'], '2': ['b', 'a'] },
+      activePlayerId: 'a',
+      turnStartedAt: 1000,
+      turnStartedRound: 1,
+    })
+    advance(2000)
+    session = goToNextRoundSnapshot(session, Date.now())
+    assert.ok(session)
+    assert.equal(session.round, 2)
+    assert.equal(session.activePlayerId, null)
+    const playerA = session.players.find((p) => p.id === 'a')
+    assert.ok(playerA)
+    assert.equal(playerA.bankedMs, 7000)
+    assert.equal(session.players.map((p) => p.id).join(','), 'b,a')
+  })
+})
+
+test('goToPreviousRoundSnapshot applies saved order for prior round', () => {
+  const session = createTestSession({
+    players: [testPlayer('a'), testPlayer('b')],
+    playerOrderByRound: { '1': ['a', 'b'], '2': ['b', 'a'] },
+    round: 2,
+  })
+  const prev = goToPreviousRoundSnapshot(session, Date.now())
+  assert.ok(prev)
+  assert.equal(prev.round, 1)
+  assert.deepEqual(prev.players.map((p) => p.id), ['a', 'b'])
+})
+
+test('removePlayerSnapshot banks active segment and clears live turn', () => {
+  withFakeNow(1000, (advance) => {
+    let session = createTestSession({
+      players: [testPlayer('a'), testPlayer('b')],
+      playerOrderByRound: { '1': ['a', 'b'] },
+      hardPassEnabled: true,
+      hardPassOrderNextRound: true,
+      hardPassOrderByRound: { '1': ['b'] },
+      activePlayerId: 'a',
+      turnStartedAt: 1000,
+      turnStartedRound: 1,
+    })
+    advance(2500)
+    session = removePlayerSnapshot(session, 'a', Date.now())
+    assert.ok(session)
+    assert.equal(session.players.length, 1)
+    assert.equal(session.players[0].id, 'b')
+    assert.equal(session.activePlayerId, null)
+    assert.equal(session.hardPassOrderByRound['1']?.includes('b'), true)
+  })
+})
+
+test('applyPlayerOrder appends players missing from id order', () => {
+  const players = [testPlayer('a'), testPlayer('b'), testPlayer('c')]
+  const ordered = applyPlayerOrder(players, ['c', 'a'])
+  assert.deepEqual(ordered.map((p) => p.id), ['c', 'a', 'b'])
+})

--- a/src/features/game-timer/timerRules.test.js
+++ b/src/features/game-timer/timerRules.test.js
@@ -11,6 +11,7 @@ import {
   removePlayerSnapshot,
   selectPlayerSnapshot,
   startNewGameSamePlayersSnapshot,
+  syncOrderForActiveRoundOnStore,
   undoHardPassSnapshot,
 } from './timerRules.js'
 
@@ -304,4 +305,25 @@ test('applyPlayerOrder appends players missing from id order', () => {
   const players = [testPlayer('a'), testPlayer('b'), testPlayer('c')]
   const ordered = applyPlayerOrder(players, ['c', 'a'])
   assert.deepEqual(ordered.map((p) => p.id), ['c', 'a', 'b'])
+})
+
+test('syncOrderForActiveRoundOnStore reorders store players for active round', () => {
+  const store = {
+    players: [testPlayer('b'), testPlayer('a')],
+    activePlayerId: 'a',
+    turnStartedAt: null,
+    turnStartedRound: null,
+    round: 1,
+    playerOrderByRound: { '1': ['a', 'b'] },
+    hardPassEnabled: false,
+    hardPassOrderNextRound: false,
+    hardPassOrderByRound: {},
+    totalGameStartedAt: null,
+  }
+  syncOrderForActiveRoundOnStore(store)
+  assert.deepEqual(
+    store.players.map((p) => p.id),
+    ['a', 'b'],
+  )
+  assert.equal(store.activePlayerId, 'a')
 })

--- a/src/features/game-timer/ui/createPlayerListViewModel.js
+++ b/src/features/game-timer/ui/createPlayerListViewModel.js
@@ -1,0 +1,69 @@
+/**
+ * @import '../types.js'
+ */
+
+import {
+  displayedMsForPlayer,
+  displayedMsForPlayerInRound,
+  maxDisplayedMs,
+  maxDisplayedMsInRound,
+  progressRatio,
+} from '../core.js'
+
+/**
+ * @param {object} input
+ * @param {GameTimerPlayer[]} input.players
+ * @param {{ activePlayerId: string | null, turnStartedAt: number | null, turnStartedRound: number | null }} input.session
+ * @param {number} input.round
+ * @param {boolean} input.hardPassEnabled
+ * @param {Record<string, string[]>} input.hardPassOrderByRound
+ * @param {boolean} input.hasMultipleRounds
+ * @param {number} input.nowMs
+ * @returns {Map<string, GameTimerPlayerRowViewModel>}
+ */
+export function createPlayerListViewModel({
+  players,
+  session,
+  round,
+  hardPassEnabled,
+  hardPassOrderByRound,
+  hasMultipleRounds,
+  nowMs,
+}) {
+  const hardPassIdsThisRound = new Set(
+    Array.isArray(hardPassOrderByRound[String(round)]) ? hardPassOrderByRound[String(round)] : [],
+  )
+
+  const maxMs = maxDisplayedMs(players, session, nowMs)
+  const maxRoundMs = hasMultipleRounds ? maxDisplayedMsInRound(players, session, nowMs, round) : 0
+  const map = new Map()
+
+  for (const p of players) {
+    const displayedMs = displayedMsForPlayer(p, session, nowMs)
+    const displayedMsRound = hasMultipleRounds
+      ? displayedMsForPlayerInRound(p, session, nowMs, round)
+      : 0
+    const isHardPassed = hardPassEnabled && hardPassIdsThisRound.has(p.id)
+    const isPausedHeldTurn =
+      !isHardPassed && session.activePlayerId === p.id && session.turnStartedAt == null
+
+    map.set(p.id, {
+      id: p.id,
+      name: p.name,
+      color: p.color,
+      displayedMs,
+      progress: progressRatio(displayedMs, maxMs),
+      displayedMsRound,
+      progressRound: hasMultipleRounds ? progressRatio(displayedMsRound, maxRoundMs) : 0,
+      isActive: session.activePlayerId === p.id,
+      isHardPassed,
+      isPausedHeldTurn,
+    })
+  }
+
+  return map
+}
+
+/**
+ * @typedef {GameTimerPlayerRow & { isHardPassed: boolean, isPausedHeldTurn: boolean }} GameTimerPlayerRowViewModel
+ */

--- a/src/features/game-timer/ui/createPlayerListViewModel.test.js
+++ b/src/features/game-timer/ui/createPlayerListViewModel.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createPlayerListViewModel } from './createPlayerListViewModel.js'
+import { testPlayer } from '../test/fixtures.js'
+
+test('player list view model exposes row ms totals and flags', () => {
+  const players = [testPlayer('a', { bankedMs: 3000 }), testPlayer('b', { bankedMs: 1000 })]
+  const session = {
+    activePlayerId: 'a',
+    turnStartedAt: 5000,
+    turnStartedRound: 1,
+  }
+  const rows = createPlayerListViewModel({
+    players,
+    session,
+    round: 1,
+    hardPassEnabled: true,
+    hardPassOrderByRound: { '1': ['b'] },
+    hasMultipleRounds: false,
+    nowMs: 8000,
+  })
+
+  const rowA = rows.get('a')
+  const rowB = rows.get('b')
+  assert.ok(rowA)
+  assert.ok(rowB)
+  assert.equal(rowA.displayedMs, 6000)
+  assert.equal(rowB.displayedMs, 1000)
+  assert.equal(rowA.isActive, true)
+  assert.equal(rowB.isHardPassed, true)
+  assert.equal(rowA.isHardPassed, false)
+  assert.equal(rowA.progress, 1)
+  assert.equal(rowB.progress, 1000 / 6000)
+})
+
+test('player list view model marks paused held turn', () => {
+  const players = [testPlayer('a')]
+  const rows = createPlayerListViewModel({
+    players,
+    session: { activePlayerId: 'a', turnStartedAt: null, turnStartedRound: null },
+    round: 1,
+    hardPassEnabled: false,
+    hardPassOrderByRound: {},
+    hasMultipleRounds: false,
+    nowMs: 1000,
+  })
+  const row = rows.get('a')
+  assert.ok(row)
+  assert.equal(row.isPausedHeldTurn, true)
+  assert.equal(row.isHardPassed, false)
+})
+
+test('player list view model includes round-scoped totals when multi-round', () => {
+  const players = [
+    testPlayer('a', { bankedMs: 5000, bankedMsByRound: { '1': 2000, '2': 3000 } }),
+    testPlayer('b', { bankedMs: 1000, bankedMsByRound: { '2': 1000 } }),
+  ]
+  const rows = createPlayerListViewModel({
+    players,
+    session: { activePlayerId: null, turnStartedAt: null, turnStartedRound: null },
+    round: 2,
+    hardPassEnabled: false,
+    hardPassOrderByRound: {},
+    hasMultipleRounds: true,
+    nowMs: 10_000,
+  })
+  const rowA = rows.get('a')
+  assert.ok(rowA)
+  assert.equal(rowA.displayedMsRound, 3000)
+  assert.equal(rowA.progressRound, 1)
+})

--- a/src/pages/projects/GameTimerPage.vue
+++ b/src/pages/projects/GameTimerPage.vue
@@ -42,7 +42,7 @@
         icon="add"
         aria-label="Add player"
         class="gt-actions-bar__fixed-btn"
-        :disable="hasMultipleRounds"
+        :disable="hasMultipleRoundsFlag"
         @click="openAddDialog"
       />
     </div>
@@ -104,7 +104,7 @@ import GameTimerTurnControls from '../../features/game-timer/components/GameTime
 import { useGameTimerP2P } from '../../features/game-timer/composables/useGameTimerP2P.js'
 import { useProjectShellBrowserFullscreen } from '../../layouts/projects/composables/useProjectShellBrowserFullscreen.js'
 import { useNoSleep } from '../../features/game-timer/composables/useNoSleep.js'
-import { nextDefaultColor } from '../../features/game-timer/core.js'
+import { nextDefaultColor, hasMultipleRounds } from '../../features/game-timer/core.js'
 import {
   GAME_TIMER_ROOM_QUERY_KEY,
   isValidRoomSuffix,
@@ -118,7 +118,15 @@ const route = useRoute()
 const router = useRouter()
 const { isGuest } = useGameTimerP2P()
 const store = useGameTimerStore()
-const { players, activePlayerId, hasMultipleRounds, fullscreenEnabled } = storeToRefs(store)
+const { players, activePlayerId, fullscreenEnabled } = storeToRefs(store)
+
+const hasMultipleRoundsFlag = computed(() =>
+  hasMultipleRounds({
+    round: store.round,
+    playerOrderByRound: store.playerOrderByRound,
+    players: players.value,
+  }),
+)
 
 /** True when a turn is held (clock running or paused); `activePlayerId` is set. */
 const hasHeldTurn = computed(() => activePlayerId.value != null)

--- a/src/pages/projects/GameTimerPage.vue
+++ b/src/pages/projects/GameTimerPage.vue
@@ -208,6 +208,7 @@ function confirmResetAll() {
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y pinch-zoom;
 }
 
 .gt-actions-bar {

--- a/src/stores/gameTimer.js
+++ b/src/stores/gameTimer.js
@@ -3,43 +3,21 @@
  */
 
 import { defineStore, acceptHMRUpdate } from 'pinia'
-import { createPlayerId, displayedMsForPlayer, nextDefaultColor } from '../features/game-timer/core.js'
-
-/**
- * Rebuild `players` to match `idOrder`, appending any players missing from that list.
- * @param {GameTimerPlayer[]} players
- * @param {string[]} idOrder
- * @returns {GameTimerPlayer[]}
- */
-function applyPlayerOrder(players, idOrder) {
-  const map = new Map(players.map((p) => [p.id, p]))
-  const out = []
-  const seen = new Set()
-  for (const id of idOrder) {
-    const p = map.get(id)
-    if (p) {
-      out.push(p)
-      seen.add(id)
-    }
-  }
-  for (const p of players) {
-    if (!seen.has(p.id)) out.push(p)
-  }
-  return out
-}
-
-/**
- * @param {Record<string, string[]>} hardPassOrderByRound
- * @param {string} playerId
- */
-function stripPlayerFromHardPassMaps(hardPassOrderByRound, playerId) {
-  for (const k of Object.keys(hardPassOrderByRound)) {
-    const arr = hardPassOrderByRound[k]
-    if (Array.isArray(arr)) {
-      hardPassOrderByRound[k] = arr.filter((id) => id !== playerId)
-    }
-  }
-}
+import { createPlayerId, nextDefaultColor } from '../features/game-timer/core.js'
+import {
+  applyPlayerOrder,
+  applyRuleSessionToStore,
+  endTurnNextSnapshot,
+  goToNextRoundSnapshot,
+  goToPreviousRoundSnapshot,
+  pauseLiveTurnSnapshot,
+  registerHardPassSnapshot,
+  removePlayerSnapshot,
+  ruleSessionFromStoreState,
+  selectPlayerSnapshot,
+  startNewGameSamePlayersSnapshot,
+  undoHardPassSnapshot,
+} from '../features/game-timer/timerRules.js'
 
 /** Pinia store: Game Timer session (players, turns, rounds, persisted). */
 export const useGameTimerStore = defineStore('gameTimer', {
@@ -57,56 +35,6 @@ export const useGameTimerStore = defineStore('gameTimer', {
     totalGameStartedAt: null,
     timingStripMode: 'total',
   }),
-
-  getters: {
-    /**
-     * True when the session has multi-round UI (round > 1 or stored data for round 2+).
-     * Draft `playerOrderByRound` keys for rounds beyond `round` (e.g. next-round prep) do not count.
-     * @returns {boolean}
-     */
-    hasMultipleRounds(state) {
-      if (state.round > 1) return true
-      const cur = state.round
-      for (const k of Object.keys(state.playerOrderByRound)) {
-        const nk = Number(k)
-        if (nk > 1 && nk <= cur) return true
-      }
-      for (const p of state.players) {
-        const m = p.bankedMsByRound
-        if (!m || typeof m !== 'object') continue
-        for (const bk of Object.keys(m)) {
-          if (Number(bk) > 1) return true
-        }
-      }
-      return false
-    },
-    /**
-     * Total game elapsed wall-clock ms since first `selectPlayer`; 0 before start.
-     * @returns {number}
-     */
-    totalGameElapsedMs(state) {
-      if (typeof state.totalGameStartedAt !== 'number') return 0
-      return Math.max(0, Date.now() - state.totalGameStartedAt)
-    },
-    /**
-     * Session non-player ms: total game minus sum of all player displayed totals.
-     * @returns {number}
-     */
-    nonPlayerElapsedMs(state) {
-      const total = this.totalGameElapsedMs
-      if (total <= 0 || !Array.isArray(state.players) || state.players.length === 0) return total
-      const now = Date.now()
-      const session = {
-        activePlayerId: state.activePlayerId,
-        turnStartedAt: state.turnStartedAt,
-      }
-      let playerSum = 0
-      for (const p of state.players) {
-        playerSum += displayedMsForPlayer(p, session, now)
-      }
-      return Math.max(0, total - playerSum)
-    },
-  },
 
   /**
    * pinia-plugin-persistedstate: `pick` lists fields; `afterHydrate` normalizes players and order maps.
@@ -181,7 +109,6 @@ export const useGameTimerStore = defineStore('gameTimer', {
 
     /**
      * When hard pass affects next round, set `playerOrderByRound[n+1]` from pass order + remaining ids.
-     * With an empty pass list, draft next-round order matches current display order.
      * @param {number} n
      */
     _recomputeNextRoundOrderFromHardPasses(n) {
@@ -305,173 +232,43 @@ export const useGameTimerStore = defineStore('gameTimer', {
      * @param {string} playerId
      */
     registerHardPass(playerId) {
-      if (!this.hardPassEnabled || !this.players.some((p) => p.id === playerId)) return
-
-      const rk = String(this.round)
-      if (!this.hardPassOrderByRound[rk] || !Array.isArray(this.hardPassOrderByRound[rk])) {
-        this.hardPassOrderByRound[rk] = []
-      }
-      if (this.hardPassOrderByRound[rk].includes(playerId)) return
-
-      const now = Date.now()
-      const clockRunning = this.activePlayerId === playerId && this.turnStartedAt != null
-      const turnHeldHere = this.activePlayerId === playerId
-
-      if (clockRunning) {
-        this._bankActiveSegment(now)
-      }
-
-      this.hardPassOrderByRound[rk].push(playerId)
-      this._recomputeNextRoundOrderFromHardPasses(this.round)
-
-      if (turnHeldHere) {
-        const passed = new Set(this.hardPassOrderByRound[rk] ?? [])
-        const idx = this.players.findIndex((p) => p.id === playerId)
-        const nextIdx = idx === -1 ? null : this._nextNonPassedPlayerIndex(idx, passed)
-        if (nextIdx == null) {
-          this._clearLiveTurn()
-        } else {
-          const next = this.players[nextIdx]
-          this.activePlayerId = next.id
-          this.turnStartedAt = now
-          this.turnStartedRound = this.round
-        }
-      }
-
-      const list = this.hardPassOrderByRound[rk] ?? []
-      const passedSet = new Set(list)
-      const allHardPassed =
-        this.players.length > 0 && this.players.every((p) => passedSet.has(p.id))
-      if (allHardPassed) {
-        this.goToNextRound()
-      }
+      const next = registerHardPassSnapshot(ruleSessionFromStoreState(this), playerId, Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /**
-     * Remove a hard pass for this round (mistake). Recomputes draft next-round order when enabled.
-     * Does not restore banked time if they had passed while the clock was running.
      * @param {string} playerId
      */
     undoHardPass(playerId) {
-      if (!this.hardPassEnabled || !this.players.some((p) => p.id === playerId)) return
-      const rk = String(this.round)
-      const arr = this.hardPassOrderByRound[rk]
-      if (!Array.isArray(arr) || !arr.includes(playerId)) return
-      this.hardPassOrderByRound[rk] = arr.filter((id) => id !== playerId)
-      this._recomputeNextRoundOrderFromHardPasses(this.round)
-    },
-
-    /**
-     * Add elapsed time since `turnStartedAt` to `bankedMs` and `bankedMsByRound`.
-     * @param {number} [now]
-     */
-    _bankActiveSegment(now = Date.now()) {
-      if (this.activePlayerId == null || this.turnStartedAt == null) return
-      const seg = Math.max(0, now - this.turnStartedAt)
-      const p = this.players.find((player) => player.id === this.activePlayerId)
-      if (!p) return
-
-      p.bankedMs += seg
-
-      const r = this.turnStartedRound
-      if (r != null) {
-        if (!p.bankedMsByRound || typeof p.bankedMsByRound !== 'object') {
-          p.bankedMsByRound = {}
-        }
-        const key = String(r)
-        p.bankedMsByRound[key] = (p.bankedMsByRound[key] ?? 0) + seg
-      }
-    },
-
-    /** Clear active turn fields without banking (caller must bank first if needed). */
-    _clearLiveTurn() {
-      this.activePlayerId = null
-      this.turnStartedAt = null
-      this.turnStartedRound = null
-    },
-
-    /** Bank the live segment (if any) and clear active turn state. */
-    _pauseLiveTurn(now = Date.now()) {
-      this._bankActiveSegment(now)
-      this._clearLiveTurn()
+      const next = undoHardPassSnapshot(ruleSessionFromStoreState(this), playerId)
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /** Increment round, pausing any live turn and applying saved order for the new round. */
     goToNextRound() {
-      if (this.players.length === 0) return
-      const now = Date.now()
-      this._saveOrderForRound()
-      this._pauseLiveTurn(now)
-      this.round += 1
-      this._applyOrderForActiveRound()
+      const next = goToNextRoundSnapshot(ruleSessionFromStoreState(this), Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /** Decrement round (no-op on round 1); pauses any live turn. */
     goToPreviousRound() {
-      if (this.players.length === 0 || this.round <= 1) return
-      const now = Date.now()
-      this._saveOrderForRound()
-      this._pauseLiveTurn(now)
-      this.round -= 1
-      this._applyOrderForActiveRound()
+      const next = goToPreviousRoundSnapshot(ruleSessionFromStoreState(this), Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /**
-     * Start this player’s turn; tap same player again to pause (clock stops, turn stays); tap again to resume.
+     * Start this player’s turn; tap same player again to pause; tap again to resume.
      * @param {string} playerId
      */
     selectPlayer(playerId) {
-      const now = Date.now()
-      if (!this.players.some((p) => p.id === playerId)) return
-      if (this.totalGameStartedAt == null) this.totalGameStartedAt = now
-
-      if (this.activePlayerId === playerId) {
-        if (this.turnStartedAt != null) {
-          this._bankActiveSegment(now)
-          this.turnStartedAt = null
-          this.turnStartedRound = null
-          return
-        }
-        this.turnStartedAt = now
-        this.turnStartedRound = this.round
-        return
-      }
-
-      if (this.activePlayerId != null) {
-        this._bankActiveSegment(now)
-      }
-      this.activePlayerId = playerId
-      this.turnStartedAt = now
-      this.turnStartedRound = this.round
+      const next = selectPlayerSnapshot(ruleSessionFromStoreState(this), playerId, Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /** Remove a player from the list and from every round’s stored order. */
     removePlayer(playerId) {
-      const now = Date.now()
-      const idx = this.players.findIndex((p) => p.id === playerId)
-      if (idx === -1) return
-
-      const wasActive = this.activePlayerId === playerId
-      if (wasActive) {
-        this._bankActiveSegment(now)
-      }
-
-      this.players.splice(idx, 1)
-
-      if (wasActive) {
-        this._clearLiveTurn()
-      }
-
-      for (const k of Object.keys(this.playerOrderByRound)) {
-        const arr = this.playerOrderByRound[k]
-        if (Array.isArray(arr)) {
-          this.playerOrderByRound[k] = arr.filter((id) => id !== playerId)
-        }
-      }
-      stripPlayerFromHardPassMaps(this.hardPassOrderByRound, playerId)
-      if (this.hardPassEnabled && this.hardPassOrderNextRound && this.players.length > 0) {
-        this._recomputeNextRoundOrderFromHardPasses(this.round)
-      }
+      const next = removePlayerSnapshot(ruleSessionFromStoreState(this), playerId, Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /**
@@ -497,30 +294,16 @@ export const useGameTimerStore = defineStore('gameTimer', {
 
     /**
      * Bank live turn, clear clocks and round progression, keep roster and session rule toggles.
-     * Idempotent for empty roster (no-op).
      */
     startNewGameSamePlayers() {
-      if (this.players.length === 0) return
-      const now = Date.now()
-      this._pauseLiveTurn(now)
-      for (const p of this.players) {
-        p.bankedMs = 0
-        p.bankedMsByRound = {}
-      }
-      this.round = 1
-      const order = this.players.map((p) => p.id)
-      this.playerOrderByRound = { '1': [...order] }
-      this.hardPassOrderByRound = {}
-      this.totalGameStartedAt = null
-      if (this.hardPassEnabled && this.hardPassOrderNextRound) {
-        this._recomputeNextRoundOrderFromHardPasses(1)
-      }
-      this._applyOrderForActiveRound()
+      const next = startNewGameSamePlayersSnapshot(ruleSessionFromStoreState(this), Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
 
     /** Bank any live turn, then clear all players and order; round becomes 1. */
     clearAllPlayers() {
-      this._pauseLiveTurn()
+      const paused = pauseLiveTurnSnapshot(ruleSessionFromStoreState(this), Date.now())
+      applyRuleSessionToStore(this, paused)
       this.players = []
       this.playerOrderByRound = {}
       this.round = 1
@@ -533,34 +316,8 @@ export const useGameTimerStore = defineStore('gameTimer', {
 
     /** Bank active segment and advance to the next player in list order (wraps); skips hard-passed when enabled. */
     endTurnNext() {
-      const now = Date.now()
-      if (this.players.length === 0 || this.activePlayerId == null) {
-        return
-      }
-
-      if (this.turnStartedAt != null) {
-        this._bankActiveSegment(now)
-      }
-
-      const idx = this.players.findIndex((p) => p.id === this.activePlayerId)
-      if (idx === -1) {
-        this._clearLiveTurn()
-        return
-      }
-
-      const passed = this.hardPassEnabled
-        ? new Set(this.hardPassOrderByRound[String(this.round)] ?? [])
-        : new Set()
-
-      const nextIdx = this._nextNonPassedPlayerIndex(idx, passed)
-      if (nextIdx == null) {
-        this._clearLiveTurn()
-        return
-      }
-      const next = this.players[nextIdx]
-      this.activePlayerId = next.id
-      this.turnStartedAt = now
-      this.turnStartedRound = this.round
+      const next = endTurnNextSnapshot(ruleSessionFromStoreState(this), Date.now())
+      if (next) applyRuleSessionToStore(this, next)
     },
   },
 })

--- a/src/stores/gameTimer.js
+++ b/src/stores/gameTimer.js
@@ -5,17 +5,18 @@
 import { defineStore, acceptHMRUpdate } from 'pinia'
 import { createPlayerId, nextDefaultColor } from '../features/game-timer/core.js'
 import {
-  applyPlayerOrder,
   applyRuleSessionToStore,
   endTurnNextSnapshot,
   goToNextRoundSnapshot,
   goToPreviousRoundSnapshot,
   pauseLiveTurnSnapshot,
+  recomputeNextRoundOrderFromHardPasses,
   registerHardPassSnapshot,
   removePlayerSnapshot,
   ruleSessionFromStoreState,
   selectPlayerSnapshot,
   startNewGameSamePlayersSnapshot,
+  syncOrderForActiveRoundOnStore,
   undoHardPassSnapshot,
 } from '../features/game-timer/timerRules.js'
 
@@ -79,72 +80,11 @@ export const useGameTimerStore = defineStore('gameTimer', {
         store.timingStripMode = 'total'
       }
       store.fullscreenEnabled = store.fullscreenEnabled === true
-      store._applyOrderForActiveRound()
+      syncOrderForActiveRoundOnStore(store)
     },
   },
 
   actions: {
-    /** Persist the current `players` order under the active `round`. */
-    _saveOrderForRound() {
-      this.playerOrderByRound[String(this.round)] = this.players.map((p) => p.id)
-    },
-
-    /** Reorder `players` from `playerOrderByRound[round]`, merging in any new ids. */
-    _applyOrderForActiveRound() {
-      const k = String(this.round)
-      let ids = this.playerOrderByRound[k]
-      if (!Array.isArray(ids) || ids.length === 0) {
-        ids = this.players.map((p) => p.id)
-        this.playerOrderByRound[k] = [...ids]
-      } else {
-        const set = new Set(this.players.map((p) => p.id))
-        ids = ids.filter((id) => set.has(id))
-        for (const p of this.players) {
-          if (!ids.includes(p.id)) ids.push(p.id)
-        }
-        this.playerOrderByRound[k] = ids
-      }
-      this.players = applyPlayerOrder(this.players, ids)
-    },
-
-    /**
-     * When hard pass affects next round, set `playerOrderByRound[n+1]` from pass order + remaining ids.
-     * @param {number} n
-     */
-    _recomputeNextRoundOrderFromHardPasses(n) {
-      if (!this.hardPassEnabled || !this.hardPassOrderNextRound) return
-      if (this.players.length === 0) return
-      const nk = String(Math.max(1, Math.floor(n)))
-      const nextK = String(Math.max(1, Math.floor(n)) + 1)
-      const raw = this.hardPassOrderByRound[nk]
-      const passers = Array.isArray(raw)
-        ? raw.filter((id) => this.players.some((p) => p.id === id))
-        : []
-      if (passers.length === 0) {
-        this.playerOrderByRound[nextK] = this.players.map((p) => p.id)
-        return
-      }
-      const passerSet = new Set(passers)
-      const remaining = this.players.map((p) => p.id).filter((id) => !passerSet.has(id))
-      this.playerOrderByRound[nextK] = [...passers, ...remaining]
-    },
-
-    /**
-     * @param {number} fromIdx Index in `this.players` to start after (exclusive step pattern like end turn).
-     * @param {Set<string>} passed
-     * @returns {number | null} Next player index or null if none eligible.
-     */
-    _nextNonPassedPlayerIndex(fromIdx, passed) {
-      const n = this.players.length
-      if (n === 0) return null
-      let nextIdx = (fromIdx + 1) % n
-      for (let steps = 0; steps < n; steps++) {
-        if (!passed.has(this.players[nextIdx].id)) return nextIdx
-        nextIdx = (nextIdx + 1) % n
-      }
-      return null
-    },
-
     /**
      * Append a player and register them in the current round’s order.
      * @param {{ name?: string, color?: string }} [payload]
@@ -205,7 +145,7 @@ export const useGameTimerStore = defineStore('gameTimer', {
       if (this.hardPassOrderNextRound) {
         const arr = this.hardPassOrderByRound[String(this.round)]
         if (Array.isArray(arr) && arr.length > 0) {
-          this._recomputeNextRoundOrderFromHardPasses(this.round)
+          recomputeNextRoundOrderFromHardPasses(ruleSessionFromStoreState(this), this.round)
         }
       }
     },


### PR DESCRIPTION
## Summary

- Extract authoritative Game Timer snapshot mutations into unit-tested pure functions in `timerRules.js`, and move display derivations (`hasMultipleRounds`, timing-strip elapsed math) into `core.js`.
- Introduce `createPlayerListViewModel` plus `useGameTimerPlayerListPresentation` so the player list shell keeps drag/swipe/formatting while row ms, ratios, and flags come from a tested view model.
- Thin the Pinia store to persistence, sync orchestration, and delegation; fix host swipe-to-edit/delete by limiting drag-reorder to the turn column handle.

Closes #218. Part of #211.

## Test plan

- [x] `npm test -- src/features/game-timer/timerRules.test.js src/features/game-timer/core.test.js src/features/game-timer/ui/createPlayerListViewModel.test.js`
- [x] `npm test -- src/features/game-timer/startNewGameSamePlayers.test.js src/features/game-timer/sessionTiming.test.js`
- [x] `npm test -- src/features/game-timer/p2p/*.test.js`
- [x] ESLint on touched files
- [x] Manual: host swipe right on player name → edit dialog; swipe left → delete confirm; long-press left turn column → reorder
- [x] Manual: turn select/pause, hard pass, round nav, timing strip totals unchanged from pre-refactor behavior