### PR TITLE
World Builder: Increment 1 — Single-colony survival (#392)

### DIFF
--- a/src/composables/useWorldBuilderColonization.js
+++ b/src/composables/useWorldBuilderColonization.js
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { applyEpochStep } from '../../world-builder/core/colonization/applyEpochStep.js'
 import { beginColonizationCommit } from '../../world-builder/core/colonization/beginColonizationCommit.js'
 import { computeHaulShedReachPreview } from '../../world-builder/core/colonization/computeHaulShedReachPreview.js'
 import {
@@ -61,7 +62,9 @@ export function useWorldBuilderColonization(options) {
   const showResetColonization = computed(
     () => slice.value.colonizationPhase === COLONIZATION_PHASE_RUNNING,
   )
-  const timeControlsActive = computed(() => false)
+  const timeControlsActive = computed(
+    () => slice.value.colonizationPhase === COLONIZATION_PHASE_RUNNING,
+  )
   const isColonistSettingsReadOnlyExceptEpochBatch = computed(
     () => slice.value.colonizationPhase === COLONIZATION_PHASE_RUNNING,
   )
@@ -126,12 +129,14 @@ export function useWorldBuilderColonization(options) {
     }
     const phase = slice.value.colonizationPhase
     const placementEnabled = phase === COLONIZATION_PHASE_SETUP
-    const showMarker =
-      phase === COLONIZATION_PHASE_SETUP || phase === COLONIZATION_PHASE_RUNNING
+    // Pin + haul-shed preview are setup-only; in running they sit on top of the
+    // population overlay and hide the claimed-cell density.
     viewport.setLandingPlacementMode?.(placementEnabled)
-    viewport.setFoundingLandingMarker?.(showMarker ? slice.value.foundingLanding : null)
+    viewport.setFoundingLandingMarker?.(
+      placementEnabled ? slice.value.foundingLanding : null,
+    )
     viewport.setHaulShedPreviewCells?.(
-      showMarker ? haulShedPreviewCells(getGeographyDocument?.() ?? null) : [],
+      placementEnabled ? haulShedPreviewCells(getGeographyDocument?.() ?? null) : [],
     )
     if (placementEnabled) {
       viewport.onCellPick?.((cell) => {
@@ -215,6 +220,20 @@ export function useWorldBuilderColonization(options) {
     persistSlice()
     syncLandingVisuals()
     return slice.value.colonizationPhase === COLONIZATION_PHASE_RUNNING
+  }
+
+  function epochStep() {
+    if (!timeControlsActive.value) {
+      return false
+    }
+    const doc = getGeographyDocument?.()
+    if (!doc) {
+      return false
+    }
+    slice.value = applyEpochStep(slice.value, doc)
+    persistSlice()
+    syncLandingVisuals()
+    return true
   }
 
   /**
@@ -302,7 +321,10 @@ export function useWorldBuilderColonization(options) {
     enterColonizationSetup,
     backToTerrain,
     beginColonization,
+    epochStep,
     resetColonization,
+    epoch: computed(() => slice.value.epoch),
+    settlements: computed(() => slice.value.settlements),
     applyToWorldDocument,
     setFoundingLanding,
     pickFoundingLanding,

--- a/src/composables/useWorldBuilderColonization.js
+++ b/src/composables/useWorldBuilderColonization.js
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import { applyEpochStep } from '../../world-builder/core/colonization/applyEpochStep.js'
+import { applyPopulationCollapse } from '../../world-builder/core/colonization/applyPopulationCollapse.js'
 import { beginColonizationCommit } from '../../world-builder/core/colonization/beginColonizationCommit.js'
 import { computeHaulShedReachPreview } from '../../world-builder/core/colonization/computeHaulShedReachPreview.js'
 import {
@@ -165,7 +166,30 @@ export function useWorldBuilderColonization(options) {
    * @returns {import('../../world-builder/core/types.js').WorldDocument}
    */
   function applyToWorldDocument(doc) {
-    return applyColonizationSliceToWorldDocument(doc, slice.value)
+    const resolvedSlice = recomputePopulationCollapseRaster(slice.value, doc)
+    if (resolvedSlice !== slice.value) {
+      slice.value = resolvedSlice
+    }
+    return applyColonizationSliceToWorldDocument(doc, resolvedSlice)
+  }
+
+  /**
+   * Derive collapse raster from settlements, claims, epoch, and geography (never loaded from storage).
+   *
+   * @param {import('../../world-builder/core/colonization/createDefaultColonizationSlice.js').ColonizationSlice} current
+   * @param {import('../../world-builder/core/types.js').WorldDocument} doc
+   * @returns {import('../../world-builder/core/colonization/createDefaultColonizationSlice.js').ColonizationSlice}
+   */
+  function recomputePopulationCollapseRaster(current, doc) {
+    if (current.colonizationPhase !== COLONIZATION_PHASE_RUNNING) {
+      return current
+    }
+    const raster = current.populationCollapseRaster
+    const expectedLength = doc.gridWidth * doc.gridHeight
+    if (raster instanceof Float32Array && raster.length === expectedLength) {
+      return current
+    }
+    return applyPopulationCollapse(current, doc).slice
   }
 
   /**

--- a/src/composables/useWorldBuilderGeneration.js
+++ b/src/composables/useWorldBuilderGeneration.js
@@ -107,15 +107,18 @@ export function useWorldBuilderGeneration(options) {
   /**
    * Apply a previously generated landmass without running the worker (terrain cache restore).
    * @param {import('../../world-builder/core/types.js').WorldDocument} doc
+   * @param {{ skipPersist?: boolean }} [options]
    * @returns {Promise<void>}
    */
-  async function applyCachedWorldDocument(doc) {
+  async function applyCachedWorldDocument(doc, applyOptions = {}) {
     generationRunController.value?.cancelActive()
     worldDocument.value = doc
     runPhase.value = 'success'
     generationProgress.value = createInitialGenerationProgress()
     await Promise.resolve(options.applyWorldDocument(doc))
-    options.onRunCompleteSuccess?.()
+    if (!applyOptions.skipPersist) {
+      options.onRunCompleteSuccess?.()
+    }
   }
 
   function dispose() {

--- a/src/composables/useWorldBuilderPageController.js
+++ b/src/composables/useWorldBuilderPageController.js
@@ -101,6 +101,12 @@ export function useWorldBuilderPageController(options) {
   /** @type {ReturnType<typeof useWorldBuilderColonization>} */
   let colonization
 
+  function syncColonizationRunningOverlays() {
+    if (colonization.colonizationPhase.value === COLONIZATION_PHASE_RUNNING) {
+      overlay.toggleVisibility('population', true)
+    }
+  }
+
   function syncColonizationDocumentToMap() {
     const doc = generation?.worldDocument.value
     if (!doc || !mapLifecycle) {
@@ -108,6 +114,7 @@ export function useWorldBuilderPageController(options) {
     }
     void mapLifecycle.applyWorldDocument(colonization.applyToWorldDocument(doc))
     colonization.syncLandingVisuals()
+    syncColonizationRunningOverlays()
   }
 
   colonization = useWorldBuilderColonization({
@@ -271,14 +278,6 @@ export function useWorldBuilderPageController(options) {
     return result
   }
 
-  function beginColonization() {
-    const started = colonization.beginColonization()
-    if (started) {
-      overlay.toggleVisibility('population', true)
-    }
-    return started
-  }
-
   /**
    * @param {string} key
    * @returns {number | boolean | undefined}
@@ -391,9 +390,7 @@ export function useWorldBuilderPageController(options) {
         const cached = await loadLockedTerrain(currentTerrainFingerprint())
         if (cached) {
           await generation.applyCachedWorldDocument(cached)
-          if (phase === COLONIZATION_PHASE_RUNNING) {
-            overlay.toggleVisibility('population', true)
-          }
+          syncColonizationRunningOverlays()
           return
         }
       } catch {
@@ -402,9 +399,7 @@ export function useWorldBuilderPageController(options) {
     }
 
     regenerate({ force: true })
-    if (colonization.colonizationPhase.value === COLONIZATION_PHASE_RUNNING) {
-      overlay.toggleVisibility('population', true)
-    }
+    syncColonizationRunningOverlays()
   }
 
   function destroy() {
@@ -442,7 +437,7 @@ export function useWorldBuilderPageController(options) {
     hasLandmass,
     enterColonizationSetup,
     backToTerrain,
-    beginColonization,
+    beginColonization: colonization.beginColonization,
     epochStep: colonization.epochStep,
     resetColonization,
     canBeginColonization: colonization.canBeginColonization,

--- a/src/composables/useWorldBuilderPageController.js
+++ b/src/composables/useWorldBuilderPageController.js
@@ -429,10 +429,13 @@ export function useWorldBuilderPageController(options) {
     enterColonizationSetup,
     backToTerrain,
     beginColonization: colonization.beginColonization,
+    epochStep: colonization.epochStep,
     resetColonization,
     canBeginColonization: colonization.canBeginColonization,
     showResetColonization: colonization.showResetColonization,
     timeControlsActive: colonization.timeControlsActive,
+    colonizationEpoch: colonization.epoch,
+    colonizationSettlements: colonization.settlements,
     isColonistSettingsReadOnlyExceptEpochBatch:
       colonization.isColonistSettingsReadOnlyExceptEpochBatch,
     pickFoundingLanding: colonization.pickFoundingLanding,

--- a/src/composables/useWorldBuilderPageController.js
+++ b/src/composables/useWorldBuilderPageController.js
@@ -20,6 +20,7 @@ import {
 import {
   COLONIZATION_PHASE_RUNNING,
   COLONIZATION_PHASE_SETUP,
+  mergeColonizationSessions,
 } from '../../world-builder/core/colonization/createDefaultColonizationSlice.js'
 import {
   colonizationAdvisoryRequiresConfirm,
@@ -32,6 +33,11 @@ import {
   loadLockedTerrain as defaultLoadLockedTerrain,
   saveLockedTerrain as defaultSaveLockedTerrain,
 } from '../utils/worldBuilderTerrainCache.js'
+import {
+  clearColonizationSession as defaultClearColonizationSession,
+  loadColonizationSession as defaultLoadColonizationSession,
+  saveColonizationSession as defaultSaveColonizationSession,
+} from '../utils/worldBuilderColonizationCache.js'
 import { useWorldBuilderColonization } from './useWorldBuilderColonization.js'
 import { useWorldBuilderGeneration } from './useWorldBuilderGeneration.js'
 import { useWorldBuilderOverlayState } from './useWorldBuilderOverlayState.js'
@@ -69,6 +75,9 @@ async function loadWorldBuilderViewportFactory() {
  *   loadLockedTerrain?: typeof defaultLoadLockedTerrain,
  *   saveLockedTerrain?: typeof defaultSaveLockedTerrain,
  *   clearLockedTerrain?: typeof defaultClearLockedTerrain,
+ *   loadColonizationSession?: typeof defaultLoadColonizationSession,
+ *   saveColonizationSession?: typeof defaultSaveColonizationSession,
+ *   clearColonizationSession?: typeof defaultClearColonizationSession,
  * }} options
  */
 export function useWorldBuilderPageController(options) {
@@ -83,6 +92,9 @@ export function useWorldBuilderPageController(options) {
     loadLockedTerrain = defaultLoadLockedTerrain,
     saveLockedTerrain = defaultSaveLockedTerrain,
     clearLockedTerrain = defaultClearLockedTerrain,
+    loadColonizationSession = defaultLoadColonizationSession,
+    saveColonizationSession = defaultSaveColonizationSession,
+    clearColonizationSession = defaultClearColonizationSession,
   } = options
 
   const seedInput = ref(String(DEFAULT_GEOGRAPHY_SEED))
@@ -115,6 +127,7 @@ export function useWorldBuilderPageController(options) {
     void mapLifecycle.applyWorldDocument(colonization.applyToWorldDocument(doc))
     colonization.syncLandingVisuals()
     syncColonizationRunningOverlays()
+    void persistColonizationSessionIfNeeded()
   }
 
   colonization = useWorldBuilderColonization({
@@ -153,6 +166,17 @@ export function useWorldBuilderPageController(options) {
     })
   }
 
+  async function persistColonizationSessionIfNeeded() {
+    if (!colonization.isTerrainLocked.value) {
+      return
+    }
+    try {
+      await saveColonizationSession(currentTerrainFingerprint(), colonization.slice.value)
+    } catch {
+      // Cache is best-effort; regen remains the fallback.
+    }
+  }
+
   async function persistLockedTerrainIfNeeded() {
     if (!colonization.isTerrainLocked.value) {
       return
@@ -169,14 +193,30 @@ export function useWorldBuilderPageController(options) {
     } catch {
       // Cache is best-effort; regen remains the fallback.
     }
+    await persistColonizationSessionIfNeeded()
   }
 
   async function discardLockedTerrain() {
     try {
       await clearLockedTerrain()
+      await clearColonizationSession()
     } catch {
       // ignore
     }
+  }
+
+  async function restoreColonizationSessionFromCaches(fingerprint) {
+    const fromStore = settingsStore.colonizationSession
+    let fromColonizationCache = null
+    try {
+      fromColonizationCache = await loadColonizationSession(fingerprint)
+    } catch {
+      // Fall through with store-only session.
+    }
+    const merged = mergeColonizationSessions(fromStore, fromColonizationCache)
+    settingsStore.setColonizationSession?.(merged)
+    colonization.hydrateFromPersistedSettings()
+    return merged
   }
 
   generation = useWorldBuilderGeneration({
@@ -368,8 +408,25 @@ export function useWorldBuilderPageController(options) {
     overlay.resetVisibility()
   }
 
+  async function beginColonization() {
+    const started = colonization.beginColonization()
+    if (started) {
+      await persistColonizationSessionIfNeeded()
+    }
+    return started
+  }
+
+  async function epochStep() {
+    const stepped = colonization.epochStep()
+    if (stepped) {
+      await persistColonizationSessionIfNeeded()
+    }
+    return stepped
+  }
+
   async function start() {
     settingsStore.ensureInitialized()
+    settingsStore.$hydrate?.()
     seedInput.value = String(settingsStore.geographySeed)
     overlay.hydrateFromPersistedSettings()
     colonization.hydrateFromPersistedSettings()
@@ -384,12 +441,15 @@ export function useWorldBuilderPageController(options) {
       },
     })
 
+    const fingerprint = currentTerrainFingerprint()
+    await restoreColonizationSessionFromCaches(fingerprint)
+
     const phase = colonization.colonizationPhase.value
     if (phase === COLONIZATION_PHASE_SETUP || phase === COLONIZATION_PHASE_RUNNING) {
       try {
-        const cached = await loadLockedTerrain(currentTerrainFingerprint())
+        const cached = await loadLockedTerrain(fingerprint)
         if (cached) {
-          await generation.applyCachedWorldDocument(cached)
+          await generation.applyCachedWorldDocument(cached.worldDocument, { skipPersist: true })
           syncColonizationRunningOverlays()
           return
         }
@@ -437,8 +497,8 @@ export function useWorldBuilderPageController(options) {
     hasLandmass,
     enterColonizationSetup,
     backToTerrain,
-    beginColonization: colonization.beginColonization,
-    epochStep: colonization.epochStep,
+    beginColonization,
+    epochStep: epochStep,
     resetColonization,
     canBeginColonization: colonization.canBeginColonization,
     showResetColonization: colonization.showResetColonization,

--- a/src/composables/useWorldBuilderPageController.js
+++ b/src/composables/useWorldBuilderPageController.js
@@ -271,6 +271,14 @@ export function useWorldBuilderPageController(options) {
     return result
   }
 
+  function beginColonization() {
+    const started = colonization.beginColonization()
+    if (started) {
+      overlay.toggleVisibility('population', true)
+    }
+    return started
+  }
+
   /**
    * @param {string} key
    * @returns {number | boolean | undefined}
@@ -383,6 +391,9 @@ export function useWorldBuilderPageController(options) {
         const cached = await loadLockedTerrain(currentTerrainFingerprint())
         if (cached) {
           await generation.applyCachedWorldDocument(cached)
+          if (phase === COLONIZATION_PHASE_RUNNING) {
+            overlay.toggleVisibility('population', true)
+          }
           return
         }
       } catch {
@@ -391,6 +402,9 @@ export function useWorldBuilderPageController(options) {
     }
 
     regenerate({ force: true })
+    if (colonization.colonizationPhase.value === COLONIZATION_PHASE_RUNNING) {
+      overlay.toggleVisibility('population', true)
+    }
   }
 
   function destroy() {
@@ -428,7 +442,7 @@ export function useWorldBuilderPageController(options) {
     hasLandmass,
     enterColonizationSetup,
     backToTerrain,
-    beginColonization: colonization.beginColonization,
+    beginColonization,
     epochStep: colonization.epochStep,
     resetColonization,
     canBeginColonization: colonization.canBeginColonization,

--- a/src/composables/useWorldBuilderPageController.test.js
+++ b/src/composables/useWorldBuilderPageController.test.js
@@ -1256,6 +1256,7 @@ test('beginColonization commits founding settlement tip and locks terrain', asyn
     await nextTick()
 
     assert.strictEqual(ctx.colonizationPhase.value, COLONIZATION_PHASE_RUNNING)
+    assert.strictEqual(ctx.resourceOverlayVisibility.value.population, true)
     assert.strictEqual(ctx.worldDocument.value?.settlements?.length, 1)
     assert.strictEqual(ctx.worldDocument.value?.committedTips?.length, 1)
     assert.strictEqual(ctx.worldDocument.value?.historyLog?.[0]?.kind, 'founding')

--- a/src/composables/useWorldBuilderPageController.test.js
+++ b/src/composables/useWorldBuilderPageController.test.js
@@ -23,6 +23,7 @@ const SIDE_EFFECT_METHOD_COVERAGE = {
   start: [
     'start runs initial generation and applies the world document to the map',
     'start syncs overlay state when the viewport becomes ready',
+    'start restores running colonization from colonization cache after beginColonization refresh',
   ],
   destroy: ['destroy cancels the active run and tears down the map lifecycle'],
   regenerate: [
@@ -55,6 +56,7 @@ const SIDE_EFFECT_METHOD_COVERAGE = {
     'enterColonizationSetup is a no-op without a landmass',
     'enterColonizationSetup requires confirm when advisory has fail rows',
     'enterColonizationSetup skips confirm when advisory is warn-only',
+    'enterColonizationSetup persists locked terrain and colonization session',
   ],
   backToTerrain: [
     'backToTerrain returns to terrain and discards setup progress',
@@ -73,6 +75,7 @@ const SIDE_EFFECT_METHOD_COVERAGE = {
   beginColonization: [
     'beginColonization commits founding settlement tip and locks terrain',
     'beginColonization is disabled without a founding landing',
+    'start restores running colonization from colonization cache after beginColonization refresh',
   ],
   epochStep: [
     'epochStep advances epoch by epochBatch and updates settlements',
@@ -231,9 +234,33 @@ function createMemoryTerrainCache() {
       if (!record || record.fingerprint !== fingerprint) {
         return null
       }
-      return record.worldDocument
+      return {
+        worldDocument: record.worldDocument,
+      }
     },
     async clearLockedTerrain() {
+      record = null
+    },
+    getRecord() {
+      return record
+    },
+  }
+}
+
+function createMemoryColonizationCache() {
+  /** @type {{ fingerprint: string, session: import('../../world-builder/core/colonization/createDefaultColonizationSlice.js').ColonizationSlice } | null} */
+  let record = null
+  return {
+    async saveColonizationSession(fingerprint, session) {
+      record = { fingerprint, session }
+    },
+    async loadColonizationSession(fingerprint) {
+      if (!record || record.fingerprint !== fingerprint) {
+        return null
+      }
+      return record.session
+    },
+    async clearColonizationSession() {
       record = null
     },
     getRecord() {
@@ -251,6 +278,7 @@ function mountController(scope, overrides = {}) {
   const confirmCalls = []
   const viewport = overrides.viewport ?? createFakeViewport()
   const terrainCache = overrides.terrainCache ?? createMemoryTerrainCache()
+  const colonizationCache = overrides.colonizationCache ?? createMemoryColonizationCache()
   let lifecycleDestroyed = false
   let workerRunCount = 0
 
@@ -281,6 +309,9 @@ function mountController(scope, overrides = {}) {
       loadLockedTerrain: terrainCache.loadLockedTerrain,
       saveLockedTerrain: terrainCache.saveLockedTerrain,
       clearLockedTerrain: terrainCache.clearLockedTerrain,
+      loadColonizationSession: colonizationCache.loadColonizationSession,
+      saveColonizationSession: colonizationCache.saveColonizationSession,
+      clearColonizationSession: colonizationCache.clearColonizationSession,
       runDerivedGeographyInWorker:
         overrides.runDerivedGeographyInWorker ??
         ((_params, callbacks) => {
@@ -306,6 +337,7 @@ function mountController(scope, overrides = {}) {
     errors,
     confirmCalls,
     terrainCache,
+    colonizationCache,
     workerRunCount: () => workerRunCount,
     isLifecycleDestroyed: () => lifecycleDestroyed,
   }
@@ -1252,7 +1284,7 @@ test('beginColonization commits founding settlement tip and locks terrain', asyn
     ctx.pickFoundingLanding(3, 3)
     assert.strictEqual(ctx.canBeginColonization.value, true)
 
-    assert.strictEqual(ctx.beginColonization(), true)
+    assert.strictEqual(await ctx.beginColonization(), true)
     await nextTick()
 
     assert.strictEqual(ctx.colonizationPhase.value, COLONIZATION_PHASE_RUNNING)
@@ -1299,10 +1331,10 @@ test('epochStep advances epoch by epochBatch and updates settlements', async () 
     await ctx.enterColonizationSetup()
     ctx.pickFoundingLanding(3, 3)
     ctx.setColonistSetting('epochBatch', 2)
-    ctx.beginColonization()
+    await ctx.beginColonization()
     const populationBefore = ctx.worldDocument.value?.settlements?.[0]?.population ?? 0
 
-    assert.strictEqual(ctx.epochStep(), true)
+    assert.strictEqual(await ctx.epochStep(), true)
     await nextTick()
 
     assert.strictEqual(ctx.colonizationEpoch.value, 2)
@@ -1321,7 +1353,7 @@ test('epochStep is inactive outside running phase', async () => {
     const { ctx } = mountController(scope)
     await ctx.start()
     await nextTick()
-    assert.strictEqual(ctx.epochStep(), false)
+    assert.strictEqual(await ctx.epochStep(), false)
     assert.strictEqual(ctx.timeControlsActive.value, false)
   } finally {
     scope.stop()
@@ -1337,7 +1369,7 @@ test('beginColonization is disabled without a founding landing', async () => {
     await nextTick()
     await ctx.enterColonizationSetup()
 
-    assert.strictEqual(ctx.beginColonization(), false)
+    assert.strictEqual(await ctx.beginColonization(), false)
     assert.strictEqual(ctx.colonizationPhase.value, COLONIZATION_PHASE_SETUP)
   } finally {
     scope.stop()
@@ -1371,7 +1403,7 @@ test('resetColonization clears tips and returns to terrain when confirmed', asyn
     await nextTick()
     await ctx.enterColonizationSetup()
     ctx.pickFoundingLanding(3, 3)
-    ctx.beginColonization()
+    await ctx.beginColonization()
 
     assert.strictEqual(await ctx.resetColonization(), true)
     await nextTick()
@@ -1408,7 +1440,7 @@ test('resetColonization stays in running when confirm is declined', async () => 
     await nextTick()
     await ctx.enterColonizationSetup()
     ctx.pickFoundingLanding(3, 3)
-    ctx.beginColonization()
+    await ctx.beginColonization()
 
     assert.strictEqual(await ctx.resetColonization(), false)
     await nextTick()
@@ -1497,13 +1529,15 @@ test('start restores locked terrain from cache without running the worker', asyn
   }
 })
 
-test('enterColonizationSetup persists locked terrain and backToTerrain clears it', async () => {
+test('enterColonizationSetup persists locked terrain and colonization session', async () => {
   const scope = effectScope(true)
   try {
     const landmass = coastalLandmassDocument()
     const terrainCache = createMemoryTerrainCache()
+    const colonizationCache = createMemoryColonizationCache()
     const { ctx } = mountController(scope, {
       terrainCache,
+      colonizationCache,
       runDerivedGeographyInWorker: (_params, callbacks) => {
         callbacks.onStepComplete?.({
           stepId: 'validation',
@@ -1524,10 +1558,15 @@ test('enterColonizationSetup persists locked terrain and backToTerrain clears it
 
     assert.ok(terrainCache.getRecord())
     assert.strictEqual(terrainCache.getRecord()?.worldDocument.gridWidth, landmass.gridWidth)
+    assert.strictEqual(
+      colonizationCache.getRecord()?.session.colonizationPhase,
+      COLONIZATION_PHASE_SETUP,
+    )
 
     await ctx.backToTerrain()
     await nextTick()
     assert.strictEqual(terrainCache.getRecord(), null)
+    assert.strictEqual(colonizationCache.getRecord(), null)
   } finally {
     scope.stop()
   }
@@ -1555,6 +1594,77 @@ test('start restores running colonization tips from session after landmass regen
     assert.strictEqual(ctx.worldDocument.value?.settlements?.length, 1)
     assert.strictEqual(ctx.worldDocument.value?.realmId, 'realm-test')
     assert.strictEqual(ctx.isTerrainLocked.value, true)
+  } finally {
+    scope.stop()
+  }
+})
+
+test('start restores running colonization from colonization cache after beginColonization refresh', async () => {
+  const scope = effectScope(true)
+  try {
+    const landmass = coastalLandmassDocument()
+    const terrainCache = createMemoryTerrainCache()
+    const colonizationCache = createMemoryColonizationCache()
+    const settingsStore = createFakeSettingsStore()
+    let workerRuns = 0
+    const { ctx } = mountController(scope, {
+      settingsStore,
+      terrainCache,
+      colonizationCache,
+      runDerivedGeographyInWorker: (_params, callbacks) => {
+        workerRuns += 1
+        callbacks.onStepComplete?.({
+          stepId: 'validation',
+          stepIndex: 5,
+          stepCount: 6,
+          label: 'Validation',
+          worldDocument: landmass,
+        })
+        callbacks.onComplete?.()
+        return { cancel() {} }
+      },
+    })
+
+    await ctx.start()
+    await nextTick()
+    await ctx.enterColonizationSetup()
+    ctx.pickFoundingLanding(3, 3)
+    await ctx.beginColonization()
+    await nextTick()
+
+    assert.strictEqual(
+      colonizationCache.getRecord()?.session.colonizationPhase,
+      COLONIZATION_PHASE_RUNNING,
+    )
+
+    // Simulate stale localStorage that never received the running commit.
+    settingsStore.colonizationSession = createDefaultColonizationSlice()
+    settingsStore.colonizationSession.colonizationPhase = COLONIZATION_PHASE_SETUP
+    settingsStore.colonizationSession.foundingLanding = { x: 3, y: 3 }
+
+    ctx.destroy()
+    await nextTick()
+
+    const { ctx: refreshed } = mountController(scope, {
+      settingsStore,
+      terrainCache,
+      colonizationCache,
+      runDerivedGeographyInWorker: () => {
+        workerRuns += 1
+        return { cancel() {} }
+      },
+    })
+
+    await refreshed.start()
+    await nextTick()
+
+    assert.strictEqual(workerRuns, 1)
+    assert.strictEqual(refreshed.colonizationPhase.value, COLONIZATION_PHASE_RUNNING)
+    assert.strictEqual(refreshed.colonizationEpoch.value, 0)
+    assert.strictEqual(refreshed.worldDocument.value?.settlements?.length, 1)
+    assert.strictEqual(refreshed.worldDocument.value?.committedTips?.length, 1)
+    assert.strictEqual(refreshed.timeControlsActive.value, true)
+    assert.ok(refreshed.worldDocument.value?.populationCollapseRaster instanceof Float32Array)
   } finally {
     scope.stop()
   }

--- a/src/composables/useWorldBuilderPageController.test.js
+++ b/src/composables/useWorldBuilderPageController.test.js
@@ -74,6 +74,10 @@ const SIDE_EFFECT_METHOD_COVERAGE = {
     'beginColonization commits founding settlement tip and locks terrain',
     'beginColonization is disabled without a founding landing',
   ],
+  epochStep: [
+    'epochStep advances epoch by epochBatch and updates settlements',
+    'epochStep is inactive outside running phase',
+  ],
   resetColonization: [
     'resetColonization clears tips and returns to terrain when confirmed',
     'resetColonization stays in running when confirm is declined',
@@ -83,15 +87,28 @@ const SIDE_EFFECT_METHOD_COVERAGE = {
 function coastalLandmassDocument() {
   const width = 8
   const height = 8
-  const elevation = new Float32Array(width * height).fill(SEA_LEVEL + 0.2)
+  const cellCount = width * height
+  const elevation = new Float32Array(cellCount).fill(SEA_LEVEL + 0.2)
   for (let y = 2; y < 6; y += 1) {
     elevation[y * width + 2] = SEA_LEVEL - 0.2
   }
+  const riverCorridorMask = new Uint8Array(cellCount)
+  riverCorridorMask[3 * width + 3] = 1
   return fakeWorldDocument({
     gridWidth: width,
     gridHeight: height,
-    fields: { elevation },
-    lakeMask: new Uint8Array(width * height),
+    fields: {
+      elevation,
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(2),
+    arableRaster: new Float32Array(cellCount).fill(1),
+    timberRaster: new Float32Array(cellCount).fill(1),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask,
     generationReport: {
       validationRows: [],
       validationSignals: { movement: { largestSailComponentCellCount: 8 } },
@@ -1214,7 +1231,7 @@ test('beginColonization commits founding settlement tip and locks terrain', asyn
   const scope = effectScope(true)
   try {
     const landmass = coastalLandmassDocument()
-    const { ctx, settingsStore, appliedDocs } = mountController(scope, {
+    const { ctx, settingsStore, appliedDocs, viewport } = mountController(scope, {
       runDerivedGeographyInWorker: (_params, callbacks) => {
         callbacks.onStepComplete?.({
           stepId: 'validation',
@@ -1244,11 +1261,67 @@ test('beginColonization commits founding settlement tip and locks terrain', asyn
     assert.strictEqual(ctx.worldDocument.value?.historyLog?.[0]?.kind, 'founding')
     assert.ok(ctx.worldDocument.value?.realmId)
     assert.strictEqual(ctx.isTerrainLocked.value, true)
-    assert.strictEqual(ctx.timeControlsActive.value, false)
+    assert.strictEqual(ctx.timeControlsActive.value, true)
     assert.strictEqual(ctx.showResetColonization.value, true)
     assert.strictEqual(settingsStore.colonizationSession.colonizationPhase, COLONIZATION_PHASE_RUNNING)
     assert.strictEqual(appliedDocs.at(-1)?.colonizationPhase, COLONIZATION_PHASE_RUNNING)
     assert.strictEqual(appliedDocs.at(-1)?.settlements?.length, 1)
+    assert.ok(appliedDocs.at(-1)?.populationCollapseRaster instanceof Float32Array)
+    assert.ok(appliedDocs.at(-1)?.populationCollapseRaster.some((value) => value > 0))
+    assert.strictEqual(viewport.landingMarkers.at(-1), null)
+    assert.deepStrictEqual(viewport.haulShedPreviews.at(-1), [])
+  } finally {
+    scope.stop()
+  }
+})
+
+test('epochStep advances epoch by epochBatch and updates settlements', async () => {
+  const scope = effectScope(true)
+  try {
+    const landmass = coastalLandmassDocument()
+    const { ctx, settingsStore } = mountController(scope, {
+      runDerivedGeographyInWorker: (_params, callbacks) => {
+        callbacks.onStepComplete?.({
+          stepId: 'validation',
+          stepIndex: 5,
+          stepCount: 6,
+          label: 'Validation',
+          worldDocument: landmass,
+        })
+        callbacks.onComplete?.()
+        return { cancel() {} }
+      },
+    })
+
+    await ctx.start()
+    await nextTick()
+    await ctx.enterColonizationSetup()
+    ctx.pickFoundingLanding(3, 3)
+    ctx.setColonistSetting('epochBatch', 2)
+    ctx.beginColonization()
+    const populationBefore = ctx.worldDocument.value?.settlements?.[0]?.population ?? 0
+
+    assert.strictEqual(ctx.epochStep(), true)
+    await nextTick()
+
+    assert.strictEqual(ctx.colonizationEpoch.value, 2)
+    assert.strictEqual(settingsStore.colonizationSession.epoch, 2)
+    assert.ok(ctx.worldDocument.value?.settlements?.[0]?.population >= populationBefore)
+    assert.strictEqual(ctx.worldDocument.value?.committedTips?.at(-1)?.epoch, 2)
+    assert.strictEqual(ctx.timeControlsActive.value, true)
+  } finally {
+    scope.stop()
+  }
+})
+
+test('epochStep is inactive outside running phase', async () => {
+  const scope = effectScope(true)
+  try {
+    const { ctx } = mountController(scope)
+    await ctx.start()
+    await nextTick()
+    assert.strictEqual(ctx.epochStep(), false)
+    assert.strictEqual(ctx.timeControlsActive.value, false)
   } finally {
     scope.stop()
   }

--- a/src/pages/projects/WorldBuilderPage.vue
+++ b/src/pages/projects/WorldBuilderPage.vue
@@ -306,6 +306,15 @@
             :disable="!canBeginColonization"
             @click="beginColonization"
           />
+          <q-btn
+            v-else-if="timeControlsActive"
+            unelevated
+            color="primary"
+            class="full-width q-mb-md"
+            data-testid="world-builder-epoch-step"
+            label="Epoch step"
+            @click="epochStep"
+          />
           <q-banner
             v-if="showValidationFailureIndicator"
             :data-testid="WORLD_BUILDER_VALIDATION_EXHAUSTED_INDICATOR_TEST_ID"
@@ -482,10 +491,12 @@ const {
   hasLandmass,
   canBeginColonization,
   showResetColonization,
+  timeControlsActive,
   isColonistSettingsReadOnlyExceptEpochBatch,
   enterColonizationSetup,
   backToTerrain,
   beginColonization,
+  epochStep,
   resetColonization,
   setColonistSetting,
   resetColonistSettings,

--- a/src/stores/worldBuilderSettings.js
+++ b/src/stores/worldBuilderSettings.js
@@ -57,6 +57,7 @@ export const useWorldBuilderSettingsStore = defineStore('worldBuilderSettings', 
       'overlayDisplaySettings',
       'colonizationSession',
     ],
+    omit: ['colonizationSession.populationCollapseRaster'],
     afterHydrate: ({ store }) => {
       store.geographySeed = parseStoredGeographySeed(store.geographySeed)
       store.prevailingWindDegrees = normalizeWindDegrees(store.prevailingWindDegrees)

--- a/src/utils/worldBuilderColonizationCache.js
+++ b/src/utils/worldBuilderColonizationCache.js
@@ -1,0 +1,99 @@
+import {
+  resolveColonizationSlice,
+  serializeColonizationSessionForStorage,
+} from '../../world-builder/core/colonization/createDefaultColonizationSlice.js'
+
+const DB_NAME = 'portfolio-world-builder'
+const DB_VERSION = 1
+const STORE_NAME = 'terrainCache'
+const RECORD_KEY = 'colonizationSession'
+
+/**
+ * @returns {Promise<IDBDatabase>}
+ */
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onerror = () => reject(request.error ?? new Error('Failed to open colonization cache'))
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+/**
+ * @param {IDBDatabase} db
+ * @param {'readonly' | 'readwrite'} mode
+ * @returns {IDBObjectStore}
+ */
+function objectStore(db, mode) {
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/**
+ * @param {string} fingerprint
+ * @param {import('../../world-builder/core/colonization/createDefaultColonizationSlice.js').ColonizationSlice} session
+ * @returns {Promise<void>}
+ */
+export async function saveColonizationSession(fingerprint, session) {
+  const db = await openDb()
+  try {
+    const payload = serializeColonizationSessionForStorage(session)
+    await new Promise((resolve, reject) => {
+      const request = objectStore(db, 'readwrite').put(
+        {
+          fingerprint,
+          session: payload,
+          savedAt: Date.now(),
+        },
+        RECORD_KEY,
+      )
+      request.onsuccess = () => resolve()
+      request.onerror = () => reject(request.error ?? new Error('Failed to save colonization session'))
+    })
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * @param {string} fingerprint
+ * @returns {Promise<import('../../world-builder/core/colonization/createDefaultColonizationSlice.js').ColonizationSlice | null>}
+ */
+export async function loadColonizationSession(fingerprint) {
+  const db = await openDb()
+  try {
+    /** @type {{ fingerprint: string, session: unknown, savedAt?: number } | undefined} */
+    const record = await new Promise((resolve, reject) => {
+      const request = objectStore(db, 'readonly').get(RECORD_KEY)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error ?? new Error('Failed to load colonization session'))
+    })
+    if (!record || record.fingerprint !== fingerprint) {
+      return null
+    }
+    return resolveColonizationSlice(record.session)
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function clearColonizationSession() {
+  const db = await openDb()
+  try {
+    await new Promise((resolve, reject) => {
+      const request = objectStore(db, 'readwrite').delete(RECORD_KEY)
+      request.onsuccess = () => resolve()
+      request.onerror = () => reject(request.error ?? new Error('Failed to clear colonization session'))
+    })
+  } finally {
+    db.close()
+  }
+}

--- a/src/utils/worldBuilderTerrainCache.js
+++ b/src/utils/worldBuilderTerrainCache.js
@@ -7,6 +7,17 @@ const STORE_NAME = 'terrainCache'
 const RECORD_KEY = 'lockedTerrain'
 
 /**
+ * @typedef {Object} LockedTerrainCachePayload
+ * @property {string} fingerprint
+ * @property {import('../../world-builder/core/types.js').WorldDocument} worldDocument
+ */
+
+/**
+ * @typedef {Object} LockedTerrainCacheRecord
+ * @property {import('../../world-builder/core/types.js').WorldDocument} worldDocument
+ */
+
+/**
  * @returns {Promise<IDBDatabase>}
  */
 function openTerrainCacheDb() {
@@ -33,7 +44,7 @@ function store(db, mode) {
 }
 
 /**
- * @param {{ fingerprint: string, worldDocument: import('../../world-builder/core/types.js').WorldDocument }} payload
+ * @param {LockedTerrainCachePayload} payload
  * @returns {Promise<void>}
  */
 export async function saveLockedTerrain(payload) {
@@ -56,12 +67,12 @@ export async function saveLockedTerrain(payload) {
 
 /**
  * @param {string} fingerprint
- * @returns {Promise<import('../../world-builder/core/types.js').WorldDocument | null>}
+ * @returns {Promise<LockedTerrainCacheRecord | null>}
  */
 export async function loadLockedTerrain(fingerprint) {
   const db = await openTerrainCacheDb()
   try {
-    /** @type {{ fingerprint: string, worldDocument: import('../../world-builder/core/types.js').WorldDocument } | undefined} */
+    /** @type {{ fingerprint: string, worldDocument: import('../../world-builder/core/types.js').WorldDocument, savedAt?: number } | undefined} */
     const record = await new Promise((resolve, reject) => {
       const request = store(db, 'readonly').get(RECORD_KEY)
       request.onsuccess = () => resolve(request.result)
@@ -70,7 +81,9 @@ export async function loadLockedTerrain(fingerprint) {
     if (!record || record.fingerprint !== fingerprint || !record.worldDocument) {
       return null
     }
-    return cloneWorldDocument(stripColonizationFromWorldDocument(record.worldDocument))
+    return {
+      worldDocument: cloneWorldDocument(stripColonizationFromWorldDocument(record.worldDocument)),
+    }
   } finally {
     db.close()
   }

--- a/world-builder/CONTEXT.md
+++ b/world-builder/CONTEXT.md
@@ -539,7 +539,7 @@ _Avoid_: “NPCs”; census lists for every farmer; agent simulation of every pe
 
 ### Population collapse
 
-Once per **epoch**, resolve bulk population parameters into a concrete spatial distribution for the **population overlay** and **settlement** totals—inspired by wavefunction-collapse-style constraint satisfaction (exact algorithm TBD). In increment 1, uses **core + hinterland** weighting inside the founding **haul-shed**. Deterministic from **geography seed** + **colonist settings** + **founding landing** + sim state. The canonical “where people are this year” observation.
+Once per **epoch**, resolve bulk population parameters into a concrete spatial distribution for the **population overlay** and **settlement** totals—inspired by wavefunction-collapse-style constraint satisfaction: seeded weighted placement of integer people onto legal claimed land (urban cluster at the pin plus arable hinterland sample), not a reachability tint. In increment 1, uses **core + hinterland** weighting inside the founding **haul-shed**. Deterministic from **geography seed** + **colonist settings** + **founding landing** + sim state. The canonical “where people are this year” observation.
 
 _Avoid_: “Render pass” alone when simulation state is meant; collapsing mid-epoch for gameplay sub-ticks unless explicitly modeled; spatial output that disagrees with **settlement** pin population total.
 
@@ -770,7 +770,7 @@ _Avoid_: Rejecting or accepting worlds based on `riverGraph` edge counts when **
 - **Extinct polity**: resolved (epic cross-cut) — **faction** with no living members goes extinct (**history log**); **realm** with only **ruins** stays as colonial memory in `running` (scrub/export/**reset colonization** only—no auto-reset, no further exploration/politics progress).
 - **Faction territory overlay**: resolved — pins + **haul-shed** fill; **vassals** under liege; contested overlaps; not visit-status claims.
 - **Mid-run control**: observe-only for outcomes in v1; **epoch batch** editable mid-run; no rewriting **faction** borders or **history log** events by hand.
-- **Population model**: **bulk population** parameters + per-**epoch** **population collapse** for **population overlay**; **notable figure** dynasties tracked outside the bulk model—WFC-style constraint satisfaction is inspiration, not a committed algorithm name in product copy.
+- **Population model**: **bulk population** parameters + per-**epoch** **population collapse** for **population overlay**; **notable figure** dynasties tracked outside the bulk model—WFC-style constraint satisfaction (seeded integer placement on legal land) is the collapse mechanism; “wavefunction collapse” is not product UI copy.
 - **Increment 2 exploration**: **exploration fog** overlay + auto-dispatched **expeditions**; new **settlements** founded automatically at logistics nodes—one **realm** as sole polity until increment 3.
 - **Realm after latch**: resolved (epic cross-cut) — **realm** stays the colonial-origin umbrella (shared founding wave); **factions** are political bodies inside it. Not retired; not 1:1 with the origin **faction**.
 - **Expedition dispatch gate**: resolved — eligible from first **epoch step**; per-**settlement** stochastic timing each **epoch**; optional surplus/population bias only, no hard tier or survival-streak prerequisite.

--- a/world-builder/core/colonization/applyColonizationEpoch.js
+++ b/world-builder/core/colonization/applyColonizationEpoch.js
@@ -1,0 +1,119 @@
+import { applyPopulationCollapse } from './applyPopulationCollapse.js'
+import { applyRuinTransitions } from './applyRuin.js'
+import { recomputePrimaryClaims, serializeClaimMap } from './computePrimaryClaimMap.js'
+import { applySurvivalResolveToSettlement } from './resolveSurvivalTriad.js'
+import { saltSpoilageMultiplierForSettlement as defaultSaltSpoilage } from './saltSpoilageMultiplier.js'
+import { settlementTierFromPopulation } from './settlementTierFromPopulation.js'
+
+/**
+ * Annual colonization tick order:
+ * network (no-op in increment 1) → claims → survival → politics (no-op until #394).
+ *
+ * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
+ * @param {import('../types.js').WorldDocument} worldDocument
+ * @param {{ saltSpoilageMultiplierForSettlement?: (settlement: object, claimedCells: Array<{x:number,y:number}>, worldDocument: import('../types.js').WorldDocument) => number }} [options]
+ * @returns {{
+ *   slice: import('./createDefaultColonizationSlice.js').ColonizationSlice,
+ *   events: object[],
+ * }}
+ */
+export function applyColonizationEpoch(slice, worldDocument, options = {}) {
+  if (slice.colonizationPhase !== 'running') {
+    return { slice, events: [] }
+  }
+
+  applyNetworkPhaseNoop()
+
+  const claimMap = recomputePrimaryClaims({
+    settlements: slice.settlements,
+    colonistSettings: slice.colonistSettings,
+    gridWidth: worldDocument.gridWidth,
+    gridHeight: worldDocument.gridHeight,
+    movementCost: worldDocument.movementCost,
+  })
+  const primaryClaim = serializeClaimMap(claimMap)
+
+  /** @type {object[]} */
+  const nextSettlements = []
+
+  for (const settlement of slice.settlements) {
+    if (settlement.status === 'ruin') {
+      nextSettlements.push({ ...settlement })
+      continue
+    }
+
+    const claimedCells = primaryClaim[settlement.id] ?? []
+    const saltResolver = options.saltSpoilageMultiplierForSettlement ?? defaultSaltSpoilage
+    const saltSpoilageMultiplier = saltResolver(settlement, claimedCells, worldDocument)
+
+    const { settlement: resolved, survival } = applySurvivalResolveToSettlement({
+      settlement,
+      claimedCells,
+      colonistSettings: slice.colonistSettings,
+      worldDocument,
+      saltSpoilageMultiplier,
+    })
+
+    let population = resolved.population
+    if (survival.hasFreshwater) {
+      population = applySurplusPopulationDelta(
+        population,
+        survival.foodSurplus,
+        survival.populationCeiling,
+      )
+    } else {
+      population = 0
+    }
+
+    nextSettlements.push({
+      ...resolved,
+      population,
+      tier: settlementTierFromPopulation(population),
+    })
+  }
+
+  const nextEpoch = slice.epoch + 1
+  const ruined = applyRuinTransitions({
+    settlements: nextSettlements,
+    primaryClaim,
+    historyLog: slice.historyLog,
+    epoch: nextEpoch,
+  })
+
+  applyPoliticsPhaseNoop()
+
+  const withClaims = {
+    ...slice,
+    epoch: nextEpoch,
+    settlements: ruined.settlements,
+    primaryClaim: ruined.primaryClaim,
+    historyLog: ruined.historyLog,
+  }
+
+  return {
+    slice: applyPopulationCollapse(withClaims, worldDocument),
+    events: ruined.events,
+  }
+}
+
+/**
+ * Surplus-driven population change in people-units, clamped by ceiling.
+ *
+ * @param {number} population
+ * @param {number} foodSurplus
+ * @param {number} populationCeiling
+ * @returns {number}
+ */
+export function applySurplusPopulationDelta(population, foodSurplus, populationCeiling) {
+  let next = population
+  if (foodSurplus > 0) {
+    next = population + Math.max(1, Math.floor(foodSurplus * 0.1))
+  } else if (foodSurplus < 0) {
+    next = population - Math.max(1, Math.floor(Math.abs(foodSurplus) * 0.1))
+  }
+  return Math.max(0, Math.min(Math.floor(next), populationCeiling))
+}
+
+function applyNetworkPhaseNoop() {}
+
+function applyPoliticsPhaseNoop() {}

--- a/world-builder/core/colonization/applyColonizationEpoch.js
+++ b/world-builder/core/colonization/applyColonizationEpoch.js
@@ -90,8 +90,10 @@ export function applyColonizationEpoch(slice, worldDocument, options = {}) {
     historyLog: ruined.historyLog,
   }
 
+  const { slice: collapsed } = applyPopulationCollapse(withClaims, worldDocument)
+
   return {
-    slice: applyPopulationCollapse(withClaims, worldDocument),
+    slice: collapsed,
     events: ruined.events,
   }
 }

--- a/world-builder/core/colonization/applyColonizationEpoch.test.js
+++ b/world-builder/core/colonization/applyColonizationEpoch.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { applyColonizationEpoch, applySurplusPopulationDelta } from './applyColonizationEpoch.js'
+import { beginColonizationCommit } from './beginColonizationCommit.js'
+import {
+  COLONIZATION_PHASE_SETUP,
+  createDefaultColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+import { SETTLEMENT_TIER_THRESHOLDS } from './settlementTierFromPopulation.js'
+
+function richGeographyDoc() {
+  const cellCount = 16
+  return {
+    geographySeed: 7,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(2),
+    timberRaster: new Float32Array(cellCount).fill(2),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: Uint8Array.from({ length: cellCount }, (_, i) => (i === 5 ? 1 : 0)),
+  }
+}
+
+function commitRunningSlice(startingPopulation = 20) {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 1 }
+  slice.colonistSettings.startingPopulation = startingPopulation
+  slice.colonistSettings.threeDayHaulDistance = 2
+  slice.colonistSettings.epochBatch = 1
+  return beginColonizationCommit(slice, richGeographyDoc())
+}
+
+test('applySurplusPopulationDelta grows, stalls, and declines by surplus sign', () => {
+  assert.ok(applySurplusPopulationDelta(10, 20, 100) > 10)
+  assert.strictEqual(applySurplusPopulationDelta(10, 0, 100), 10)
+  assert.ok(applySurplusPopulationDelta(10, -20, 100) < 10)
+  assert.strictEqual(applySurplusPopulationDelta(10, 1000, 12), 12)
+})
+
+test('applyColonizationEpoch advances epoch and updates population from surplus', () => {
+  const running = commitRunningSlice(20)
+  const doc = richGeographyDoc()
+  const { slice: next } = applyColonizationEpoch(running, doc)
+
+  assert.strictEqual(next.epoch, 1)
+  assert.ok(next.settlements[0].population >= running.settlements[0].population)
+  assert.ok(Object.keys(next.primaryClaim).length > 0)
+})
+
+test('applyColonizationEpoch clamps population to ceiling across many epochs', () => {
+  let current = commitRunningSlice(20)
+  const doc = richGeographyDoc()
+  for (let i = 0; i < 40; i += 1) {
+    current = applyColonizationEpoch(current, doc).slice
+  }
+  const settlement = current.settlements[0]
+  assert.ok(settlement.population > 20)
+  const tier = settlement.tier
+  assert.ok(SETTLEMENT_TIER_THRESHOLDS.some((band) => band.tier === tier))
+})
+
+test('applyColonizationEpoch declines without freshwater and does not auto-stop', () => {
+  let current = commitRunningSlice(20)
+  const doc = richGeographyDoc()
+  doc.riverCorridorMask.fill(0)
+  doc.fields.rainfall.fill(0)
+  doc.biomes.fill(BIOMES.DESERT)
+
+  const first = applyColonizationEpoch(current, doc).slice
+  assert.strictEqual(first.settlements[0].population, 0)
+  const second = applyColonizationEpoch(first, doc).slice
+  assert.strictEqual(second.epoch, first.epoch + 1)
+  assert.strictEqual(second.settlements[0].population, 0)
+})

--- a/world-builder/core/colonization/applyEpochStep.js
+++ b/world-builder/core/colonization/applyEpochStep.js
@@ -1,0 +1,69 @@
+import { applyColonizationEpoch } from './applyColonizationEpoch.js'
+
+/**
+ * Advance epochBatch annual ticks. Retains committed tips at post-step present day
+ * and history-log event years (abandonment). Quiet intra-batch years are omitted.
+ *
+ * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
+ * @param {import('../types.js').WorldDocument} worldDocument
+ * @param {{ saltSpoilageMultiplierForSettlement?: Function }} [options]
+ * @returns {import('./createDefaultColonizationSlice.js').ColonizationSlice}
+ */
+export function applyEpochStep(slice, worldDocument, options = {}) {
+  if (slice.colonizationPhase !== 'running') {
+    return slice
+  }
+
+  const batch = Math.max(1, Math.floor(slice.colonistSettings.epochBatch || 1))
+  let current = slice
+  /** @type {object[]} */
+  const eventTips = []
+
+  for (let i = 0; i < batch; i += 1) {
+    const { slice: next, events } = applyColonizationEpoch(current, worldDocument, options)
+    current = next
+    for (const event of events) {
+      if (event?.retainTip) {
+        eventTips.push(createCommittedTip(current, event))
+      }
+    }
+  }
+
+  const presentDayTip = createCommittedTip(current)
+  const committedTips = [...current.committedTips, ...eventTips, presentDayTip]
+
+  return {
+    ...current,
+    committedTips,
+  }
+}
+
+/**
+ * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
+ * @param {object} [event]
+ */
+function createCommittedTip(slice, event) {
+  const claimMap = event?.claimMap
+    ? Object.fromEntries(
+        Object.entries(event.claimMap).map(([settlementId, cells]) => [
+          settlementId,
+          cells.map((cell) => ({ x: cell.x, y: cell.y })),
+        ]),
+      )
+    : Object.fromEntries(
+        Object.entries(slice.primaryClaim).map(([settlementId, cells]) => [
+          settlementId,
+          cells.map((cell) => ({ x: cell.x, y: cell.y })),
+        ]),
+      )
+
+  return {
+    epoch: slice.epoch,
+    settlements: slice.settlements.map((row) => ({ ...row })),
+    foundingLanding: slice.foundingLanding ? { ...slice.foundingLanding } : null,
+    colonistSettings: { ...slice.colonistSettings },
+    historyLog: slice.historyLog.map((row) => ({ ...row })),
+    claimMap,
+    ...(event?.kind ? { eventKind: event.kind } : {}),
+  }
+}

--- a/world-builder/core/colonization/applyEpochStep.js
+++ b/world-builder/core/colonization/applyEpochStep.js
@@ -1,4 +1,5 @@
 import { applyColonizationEpoch } from './applyColonizationEpoch.js'
+import { createCommittedTip } from './createCommittedTip.js'
 
 /**
  * Advance epochBatch annual ticks. Retains committed tips at post-step present day
@@ -35,35 +36,5 @@ export function applyEpochStep(slice, worldDocument, options = {}) {
   return {
     ...current,
     committedTips,
-  }
-}
-
-/**
- * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
- * @param {object} [event]
- */
-function createCommittedTip(slice, event) {
-  const claimMap = event?.claimMap
-    ? Object.fromEntries(
-        Object.entries(event.claimMap).map(([settlementId, cells]) => [
-          settlementId,
-          cells.map((cell) => ({ x: cell.x, y: cell.y })),
-        ]),
-      )
-    : Object.fromEntries(
-        Object.entries(slice.primaryClaim).map(([settlementId, cells]) => [
-          settlementId,
-          cells.map((cell) => ({ x: cell.x, y: cell.y })),
-        ]),
-      )
-
-  return {
-    epoch: slice.epoch,
-    settlements: slice.settlements.map((row) => ({ ...row })),
-    foundingLanding: slice.foundingLanding ? { ...slice.foundingLanding } : null,
-    colonistSettings: { ...slice.colonistSettings },
-    historyLog: slice.historyLog.map((row) => ({ ...row })),
-    claimMap,
-    ...(event?.kind ? { eventKind: event.kind } : {}),
   }
 }

--- a/world-builder/core/colonization/applyEpochStep.test.js
+++ b/world-builder/core/colonization/applyEpochStep.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { applyEpochStep } from './applyEpochStep.js'
+import { beginColonizationCommit } from './beginColonizationCommit.js'
+import {
+  COLONIZATION_PHASE_SETUP,
+  createDefaultColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+
+function richGeographyDoc() {
+  const cellCount = 16
+  return {
+    geographySeed: 7,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(2),
+    timberRaster: new Float32Array(cellCount).fill(2),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: Uint8Array.from({ length: cellCount }, (_, i) => (i === 5 ? 1 : 0)),
+  }
+}
+
+function commitRunningSlice(epochBatch = 1) {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 1 }
+  slice.colonistSettings.startingPopulation = 20
+  slice.colonistSettings.threeDayHaulDistance = 2
+  slice.colonistSettings.epochBatch = epochBatch
+  return beginColonizationCommit(slice, richGeographyDoc())
+}
+
+test('applyEpochStep advances epoch by epochBatch and retains present-day tip', () => {
+  const running = commitRunningSlice(3)
+  const next = applyEpochStep(running, richGeographyDoc())
+
+  assert.strictEqual(next.epoch, 3)
+  assert.strictEqual(next.committedTips.at(-1)?.epoch, 3)
+  assert.ok(next.committedTips.at(-1)?.claimMap)
+  // Quiet intra-batch years (1, 2) are not tipped — only epoch 0 and present day.
+  const tipEpochs = next.committedTips.map((tip) => tip.epoch)
+  assert.deepStrictEqual(tipEpochs, [0, 3])
+})
+
+test('applyEpochStep remains available indefinitely with no auto-stop', () => {
+  let current = commitRunningSlice(1)
+  const doc = richGeographyDoc()
+  for (let i = 0; i < 5; i += 1) {
+    current = applyEpochStep(current, doc)
+  }
+  assert.strictEqual(current.epoch, 5)
+  assert.strictEqual(current.colonizationPhase, 'running')
+})

--- a/world-builder/core/colonization/applyPopulationCollapse.js
+++ b/world-builder/core/colonization/applyPopulationCollapse.js
@@ -1,9 +1,15 @@
 import { collapsePopulation } from './collapsePopulation.js'
 
 /**
+ * Spatial population collapse seam: maps post-tick colonization slice + geography
+ * into an updated slice and the population overlay raster.
+ *
  * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
  * @param {import('../types.js').WorldDocument} worldDocument
- * @returns {import('./createDefaultColonizationSlice.js').ColonizationSlice}
+ * @returns {{
+ *   slice: import('./createDefaultColonizationSlice.js').ColonizationSlice,
+ *   populationCollapseRaster: Float32Array,
+ * }}
  */
 export function applyPopulationCollapse(slice, worldDocument) {
   const populationCollapseRaster = collapsePopulation({
@@ -22,7 +28,10 @@ export function applyPopulationCollapse(slice, worldDocument) {
   })
 
   return {
-    ...slice,
+    slice: {
+      ...slice,
+      populationCollapseRaster,
+    },
     populationCollapseRaster,
   }
 }

--- a/world-builder/core/colonization/applyPopulationCollapse.js
+++ b/world-builder/core/colonization/applyPopulationCollapse.js
@@ -12,9 +12,13 @@ export function applyPopulationCollapse(slice, worldDocument) {
     arableRaster: worldDocument.arableRaster,
     elevation: worldDocument.fields?.elevation,
     lakeMask: worldDocument.lakeMask,
+    riverCorridorMask: worldDocument.riverCorridorMask,
+    simulationRiverMask: worldDocument.simulationRiverMask,
     biomes: worldDocument.biomes,
     gridWidth: worldDocument.gridWidth,
     gridHeight: worldDocument.gridHeight,
+    geographySeed: worldDocument.geographySeed ?? 0,
+    epoch: slice.epoch,
   })
 
   return {

--- a/world-builder/core/colonization/applyPopulationCollapse.js
+++ b/world-builder/core/colonization/applyPopulationCollapse.js
@@ -1,0 +1,24 @@
+import { collapsePopulation } from './collapsePopulation.js'
+
+/**
+ * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
+ * @param {import('../types.js').WorldDocument} worldDocument
+ * @returns {import('./createDefaultColonizationSlice.js').ColonizationSlice}
+ */
+export function applyPopulationCollapse(slice, worldDocument) {
+  const populationCollapseRaster = collapsePopulation({
+    settlements: slice.settlements,
+    primaryClaim: slice.primaryClaim,
+    arableRaster: worldDocument.arableRaster,
+    elevation: worldDocument.fields?.elevation,
+    lakeMask: worldDocument.lakeMask,
+    biomes: worldDocument.biomes,
+    gridWidth: worldDocument.gridWidth,
+    gridHeight: worldDocument.gridHeight,
+  })
+
+  return {
+    ...slice,
+    populationCollapseRaster,
+  }
+}

--- a/world-builder/core/colonization/applyPopulationCollapse.test.js
+++ b/world-builder/core/colonization/applyPopulationCollapse.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { applyPopulationCollapse } from './applyPopulationCollapse.js'
+import {
+  COLONIZATION_PHASE_RUNNING,
+  createDefaultColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+
+function geographyDoc() {
+  const cellCount = 16
+  const riverCorridorMask = new Uint8Array(cellCount)
+  riverCorridorMask[2 * 4 + 1] = 1
+
+  return {
+    geographySeed: 42,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(1),
+    timberRaster: new Float32Array(cellCount).fill(1),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask,
+  }
+}
+
+test('applyPopulationCollapse returns slice and raster with shared reference', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_RUNNING
+  slice.epoch = 0
+  slice.settlements = [
+    {
+      id: 's1',
+      x: 1,
+      y: 2,
+      population: 50,
+      status: 'living',
+      tier: 'outpost',
+    },
+  ]
+  slice.primaryClaim = {
+    s1: [{ x: 1, y: 2 }, { x: 2, y: 2 }],
+  }
+
+  const doc = geographyDoc()
+  const result = applyPopulationCollapse(slice, doc)
+
+  assert.ok(result.slice)
+  assert.ok(result.populationCollapseRaster instanceof Float32Array)
+  assert.strictEqual(result.slice.populationCollapseRaster, result.populationCollapseRaster)
+  assert.strictEqual(result.populationCollapseRaster.length, 16)
+  assert.ok(result.populationCollapseRaster.some((value) => value > 0))
+})

--- a/world-builder/core/colonization/applyRuin.js
+++ b/world-builder/core/colonization/applyRuin.js
@@ -1,0 +1,67 @@
+/**
+ * Convert zero-population living settlements to ruins and release their claims.
+ *
+ * @param {{
+ *   settlements: object[],
+ *   primaryClaim: Record<string, Array<{ x: number, y: number }>>,
+ *   historyLog: object[],
+ *   epoch: number,
+ * }} state
+ * @returns {{
+ *   settlements: object[],
+ *   primaryClaim: Record<string, Array<{ x: number, y: number }>>,
+ *   historyLog: object[],
+ *   events: object[],
+ * }}
+ */
+export function applyRuinTransitions(state) {
+  const primaryClaim = { ...state.primaryClaim }
+  /** @type {object[]} */
+  const events = []
+  /** @type {object[]} */
+  const historyLog = [...state.historyLog]
+  /** @type {object[]} */
+  const settlements = []
+
+  for (const settlement of state.settlements) {
+    if (settlement.status === 'ruin') {
+      settlements.push({ ...settlement })
+      continue
+    }
+
+    if (settlement.population > 0) {
+      settlements.push({ ...settlement })
+      continue
+    }
+
+    const claimSnapshot = (primaryClaim[settlement.id] ?? []).map((cell) => ({
+      x: cell.x,
+      y: cell.y,
+    }))
+    delete primaryClaim[settlement.id]
+
+    const abandoned = {
+      ...settlement,
+      population: 0,
+      tier: null,
+      status: 'ruin',
+    }
+    settlements.push(abandoned)
+
+    const historyEntry = {
+      kind: 'settlement_abandoned',
+      epoch: state.epoch,
+      settlementId: settlement.id,
+    }
+    historyLog.push(historyEntry)
+    events.push({
+      kind: 'settlement_abandoned',
+      retainTip: true,
+      settlementId: settlement.id,
+      claimMap: { [settlement.id]: claimSnapshot },
+      historyEntry,
+    })
+  }
+
+  return { settlements, primaryClaim, historyLog, events }
+}

--- a/world-builder/core/colonization/applyRuin.test.js
+++ b/world-builder/core/colonization/applyRuin.test.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { applyColonizationEpoch } from './applyColonizationEpoch.js'
+import { applyEpochStep } from './applyEpochStep.js'
+import { applyRuinTransitions } from './applyRuin.js'
+import { beginColonizationCommit } from './beginColonizationCommit.js'
+import {
+  COLONIZATION_PHASE_SETUP,
+  createDefaultColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+
+test('applyRuinTransitions converts population 0 to ruin and releases claims', () => {
+  const result = applyRuinTransitions({
+    settlements: [{ id: 's1', x: 1, y: 1, population: 0, status: 'living', tier: null }],
+    primaryClaim: { s1: [{ x: 1, y: 1 }, { x: 2, y: 1 }] },
+    historyLog: [{ kind: 'founding', epoch: 0 }],
+    epoch: 3,
+  })
+
+  assert.strictEqual(result.settlements[0].status, 'ruin')
+  assert.deepStrictEqual(result.primaryClaim, {})
+  assert.strictEqual(result.historyLog.at(-1)?.kind, 'settlement_abandoned')
+  assert.strictEqual(result.historyLog.at(-1)?.epoch, 3)
+  assert.strictEqual(result.events[0].retainTip, true)
+  assert.ok(result.events[0].claimMap.s1.length > 0)
+})
+
+function dryGeographyDoc() {
+  const cellCount = 16
+  return {
+    geographySeed: 1,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(1),
+    timberRaster: new Float32Array(cellCount).fill(1),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.DESERT),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: new Uint8Array(cellCount),
+  }
+}
+
+test('applyColonizationEpoch ruins waterless settlements and keeps epoch step available', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 1 }
+  slice.colonistSettings.startingPopulation = 50
+  slice.colonistSettings.threeDayHaulDistance = 1
+
+  // Commit with water so we start living, then dry the map for the tick.
+  const wet = dryGeographyDoc()
+  wet.riverCorridorMask[1 * 4 + 1] = 1
+  wet.biomes.fill(BIOMES.GRASSLAND)
+  wet.fields.rainfall.fill(0.6)
+  let running = beginColonizationCommit(slice, wet)
+  assert.strictEqual(running.settlements[0].status, 'living')
+
+  const dry = dryGeographyDoc()
+  const { slice: next, events } = applyColonizationEpoch(running, dry)
+  assert.strictEqual(next.settlements[0].status, 'ruin')
+  assert.strictEqual(next.settlements[0].population, 0)
+  assert.deepStrictEqual(next.primaryClaim, {})
+  assert.ok(events.some((event) => event.kind === 'settlement_abandoned'))
+  assert.ok(next.historyLog.some((entry) => entry.kind === 'settlement_abandoned'))
+
+  const stepped = applyEpochStep(next, dry)
+  assert.strictEqual(stepped.colonizationPhase, 'running')
+  assert.ok(stepped.epoch > next.epoch)
+})
+
+test('applyEpochStep retains abandonment tip with claim map and omits quiet intra-batch years', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 1 }
+  slice.colonistSettings.startingPopulation = 50
+  slice.colonistSettings.threeDayHaulDistance = 1
+  slice.colonistSettings.epochBatch = 3
+
+  const wet = dryGeographyDoc()
+  wet.riverCorridorMask[1 * 4 + 1] = 1
+  wet.biomes.fill(BIOMES.GRASSLAND)
+  wet.fields.rainfall.fill(0.6)
+  const running = beginColonizationCommit(slice, wet)
+
+  const dry = dryGeographyDoc()
+  const next = applyEpochStep(running, dry)
+  const tipEpochs = next.committedTips.map((tip) => tip.epoch)
+  assert.ok(tipEpochs.includes(0))
+  assert.ok(next.committedTips.some((tip) => tip.eventKind === 'settlement_abandoned'))
+  const abandonmentTip = next.committedTips.find((tip) => tip.eventKind === 'settlement_abandoned')
+  assert.ok(abandonmentTip.claimMap[running.settlements[0].id]?.length > 0)
+  // Quiet years inside the batch are not tipped.
+  assert.ok(!tipEpochs.includes(2) || abandonmentTip.epoch === 2 || tipEpochs.at(-1) === 3)
+})

--- a/world-builder/core/colonization/beginColonizationCommit.js
+++ b/world-builder/core/colonization/beginColonizationCommit.js
@@ -5,6 +5,7 @@ import {
 } from './createDefaultColonizationSlice.js'
 import { applyPopulationCollapse } from './applyPopulationCollapse.js'
 import { applyRuinTransitions } from './applyRuin.js'
+import { createCommittedTip } from './createCommittedTip.js'
 import { createFoundingDynasty } from './createFoundingDynasty.js'
 import { recomputePrimaryClaims, serializeClaimMap } from './computePrimaryClaimMap.js'
 import { applySurvivalResolveToSettlement } from './resolveSurvivalTriad.js'
@@ -78,7 +79,7 @@ export function beginColonizationCommit(slice, doc) {
     worldDocument: doc,
   })
 
-  const withCollapse = applyPopulationCollapse(
+  const { slice: withCollapse } = applyPopulationCollapse(
     {
       ...current,
       colonizationPhase: COLONIZATION_PHASE_RUNNING,
@@ -92,29 +93,12 @@ export function beginColonizationCommit(slice, doc) {
     doc,
   )
 
-  /** @type {object[]} */
   const committedTips = [
-    {
-      epoch: 0,
-      settlements: ruined.settlements.map((row) => ({ ...row })),
-      foundingLanding: { ...landing },
-      colonistSettings: { ...current.colonistSettings },
-      historyLog: ruined.historyLog.map((row) => ({ ...row })),
-      claimMap: { ...primaryClaim },
-    },
+    createCommittedTip(withCollapse),
+    ...ruined.events
+      .filter((event) => event.retainTip)
+      .map((event) => createCommittedTip(withCollapse, event)),
   ]
-
-  for (const event of ruined.events) {
-    committedTips.push({
-      epoch: 0,
-      settlements: ruined.settlements.map((row) => ({ ...row })),
-      foundingLanding: { ...landing },
-      colonistSettings: { ...current.colonistSettings },
-      historyLog: ruined.historyLog.map((row) => ({ ...row })),
-      claimMap: event.claimMap,
-      eventKind: event.kind,
-    })
-  }
 
   return {
     ...withCollapse,

--- a/world-builder/core/colonization/beginColonizationCommit.js
+++ b/world-builder/core/colonization/beginColonizationCommit.js
@@ -3,6 +3,12 @@ import {
   COLONIZATION_PHASE_SETUP,
   cloneColonizationSlice,
 } from './createDefaultColonizationSlice.js'
+import { applyPopulationCollapse } from './applyPopulationCollapse.js'
+import { applyRuinTransitions } from './applyRuin.js'
+import { createFoundingDynasty } from './createFoundingDynasty.js'
+import { recomputePrimaryClaims, serializeClaimMap } from './computePrimaryClaimMap.js'
+import { applySurvivalResolveToSettlement } from './resolveSurvivalTriad.js'
+import { saltSpoilageMultiplier } from './saltSpoilageMultiplier.js'
 
 /**
  * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
@@ -20,14 +26,32 @@ export function beginColonizationCommit(slice, doc) {
     return slice
   }
 
-  const settlement = {
+  const seedSettlement = {
     id: `settlement-founding-${landing.x}-${landing.y}`,
     x: landing.x,
     y: landing.y,
-    tier: 'outpost',
+    tier: /** @type {string | null} */ ('outpost'),
     population: current.colonistSettings.startingPopulation,
     status: 'living',
   }
+
+  const claimMap = recomputePrimaryClaims({
+    settlements: [seedSettlement],
+    colonistSettings: current.colonistSettings,
+    gridWidth: doc.gridWidth,
+    gridHeight: doc.gridHeight,
+    movementCost: doc.movementCost,
+  })
+  const primaryClaim = serializeClaimMap(claimMap)
+  const claimedCells = primaryClaim[seedSettlement.id] ?? [{ x: landing.x, y: landing.y }]
+
+  const { settlement } = applySurvivalResolveToSettlement({
+    settlement: seedSettlement,
+    claimedCells,
+    colonistSettings: current.colonistSettings,
+    worldDocument: doc,
+    saltSpoilageMultiplier: saltSpoilageMultiplier(claimedCells, doc.saltNodes),
+  })
 
   const historyEntry = {
     kind: 'founding',
@@ -41,21 +65,59 @@ export function beginColonizationCommit(slice, doc) {
     },
   }
 
-  const committedTip = {
+  const ruined = applyRuinTransitions({
+    settlements: [settlement],
+    primaryClaim,
+    historyLog: [historyEntry],
     epoch: 0,
-    settlements: [{ ...settlement }],
-    foundingLanding: { ...landing },
-    colonistSettings: { ...current.colonistSettings },
-    historyLog: [{ ...historyEntry }],
+  })
+
+  const foundingDynasty = createFoundingDynasty({
+    settlementId: settlement.id,
+    landing,
+    worldDocument: doc,
+  })
+
+  const withCollapse = applyPopulationCollapse(
+    {
+      ...current,
+      colonizationPhase: COLONIZATION_PHASE_RUNNING,
+      epoch: 0,
+      settlements: ruined.settlements,
+      historyLog: ruined.historyLog,
+      primaryClaim: ruined.primaryClaim,
+      notableFigures: [foundingDynasty],
+      realmId: `realm-${doc.geographySeed ?? 0}-${landing.x}-${landing.y}`,
+    },
+    doc,
+  )
+
+  /** @type {object[]} */
+  const committedTips = [
+    {
+      epoch: 0,
+      settlements: ruined.settlements.map((row) => ({ ...row })),
+      foundingLanding: { ...landing },
+      colonistSettings: { ...current.colonistSettings },
+      historyLog: ruined.historyLog.map((row) => ({ ...row })),
+      claimMap: { ...primaryClaim },
+    },
+  ]
+
+  for (const event of ruined.events) {
+    committedTips.push({
+      epoch: 0,
+      settlements: ruined.settlements.map((row) => ({ ...row })),
+      foundingLanding: { ...landing },
+      colonistSettings: { ...current.colonistSettings },
+      historyLog: ruined.historyLog.map((row) => ({ ...row })),
+      claimMap: event.claimMap,
+      eventKind: event.kind,
+    })
   }
 
   return {
-    ...current,
-    colonizationPhase: COLONIZATION_PHASE_RUNNING,
-    epoch: 0,
-    settlements: [settlement],
-    historyLog: [historyEntry],
-    committedTips: [committedTip],
-    realmId: `realm-${doc.geographySeed ?? 0}-${landing.x}-${landing.y}`,
+    ...withCollapse,
+    committedTips,
   }
 }

--- a/world-builder/core/colonization/beginColonizationCommit.test.js
+++ b/world-builder/core/colonization/beginColonizationCommit.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
 import { beginColonizationCommit } from './beginColonizationCommit.js'
 import {
   COLONIZATION_PHASE_RUNNING,
@@ -7,18 +8,41 @@ import {
   createDefaultColonizationSlice,
 } from './createDefaultColonizationSlice.js'
 
-function geographyDoc() {
+/**
+ * @param {Partial<{
+ *   arable: number,
+ *   timber: number,
+ *   riverAtLanding: boolean,
+ *   startingPopulation: number,
+ * }>} [options]
+ */
+function geographyDoc(options = {}) {
+  const cellCount = 16
+  const arableValue = options.arable ?? 1
+  const timberValue = options.timber ?? 1
+  const arableRaster = new Float32Array(cellCount).fill(arableValue)
+  const timberRaster = new Float32Array(cellCount).fill(timberValue)
+  const riverCorridorMask = new Uint8Array(cellCount)
+  if (options.riverAtLanding !== false) {
+    riverCorridorMask[2 * 4 + 1] = 1
+  }
+
   return {
     geographySeed: 42,
     gridWidth: 4,
     gridHeight: 4,
+    arableRaster,
+    timberRaster,
     fields: {
-      elevation: new Float32Array(16),
-      temperature: new Float32Array(16).fill(0.5),
-      rainfall: new Float32Array(16).fill(0.4),
-      drainage: new Float32Array(16),
-      salinity: new Float32Array(16).fill(0.1),
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
     },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask,
   }
 }
 
@@ -27,6 +51,7 @@ test('beginColonizationCommit enters running with founding settlement and tip', 
   slice.colonizationPhase = COLONIZATION_PHASE_SETUP
   slice.foundingLanding = { x: 1, y: 2 }
   slice.colonistSettings.startingPopulation = 120
+  slice.colonistSettings.threeDayHaulDistance = 2
 
   const next = beginColonizationCommit(slice, geographyDoc())
 
@@ -35,12 +60,74 @@ test('beginColonizationCommit enters running with founding settlement and tip', 
   assert.strictEqual(next.settlements.length, 1)
   assert.strictEqual(next.settlements[0].x, 1)
   assert.strictEqual(next.settlements[0].y, 2)
-  assert.strictEqual(next.settlements[0].population, 120)
+  assert.ok(next.settlements[0].population <= 120)
+  assert.ok(next.settlements[0].population > 0)
+  assert.ok(next.settlements[0].tier != null)
   assert.strictEqual(next.historyLog.length, 1)
   assert.strictEqual(next.historyLog[0].kind, 'founding')
+  assert.strictEqual(next.historyLog[0].epoch, 0)
   assert.strictEqual(next.committedTips.length, 1)
   assert.strictEqual(next.committedTips[0].epoch, 0)
   assert.ok(typeof next.realmId === 'string' && next.realmId.length > 0)
+  const settlementId = next.settlements[0].id
+  assert.ok(Array.isArray(next.primaryClaim[settlementId]))
+  assert.ok(next.primaryClaim[settlementId].some((cell) => cell.x === 1 && cell.y === 2))
+  assert.deepStrictEqual(next.committedTips[0].claimMap, next.primaryClaim)
+  assert.ok(next.populationCollapseRaster instanceof Float32Array)
+  assert.strictEqual(next.populationCollapseRaster.length, 16)
+  assert.ok(next.populationCollapseRaster.some((value) => value > 0))
+})
+
+test('beginColonizationCommit clamps starting population and keeps founding history as epoch 0 anchor', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 2 }
+  slice.colonistSettings.startingPopulation = 50_000
+  slice.colonistSettings.threeDayHaulDistance = 1
+
+  const next = beginColonizationCommit(slice, geographyDoc({ arable: 0.1, timber: 0.1 }))
+
+  assert.ok(next.settlements[0].population < 50_000)
+  assert.strictEqual(next.historyLog[0].kind, 'founding')
+  assert.strictEqual(next.historyLog[0].epoch, 0)
+  assert.strictEqual(next.historyLog[0].colonistSettings.startingPopulation, 50_000)
+})
+
+test('beginColonizationCommit non-sustain path when freshwater fails', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 2 }
+  slice.colonistSettings.startingPopulation = 120
+  slice.colonistSettings.threeDayHaulDistance = 1
+
+  const doc = geographyDoc({ riverAtLanding: false })
+  doc.fields.rainfall.fill(0)
+  doc.biomes.fill(BIOMES.DESERT)
+
+  const next = beginColonizationCommit(slice, doc)
+
+  assert.strictEqual(next.settlements[0].population, 0)
+  assert.strictEqual(next.settlements[0].tier, null)
+  assert.strictEqual(next.settlements[0].status, 'ruin')
+  assert.strictEqual(next.historyLog[0].kind, 'founding')
+  assert.ok(next.historyLog.some((entry) => entry.kind === 'settlement_abandoned'))
+})
+
+test('beginColonizationCommit is deterministic for same geography and colonist inputs', () => {
+  const build = () => {
+    const slice = createDefaultColonizationSlice()
+    slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+    slice.foundingLanding = { x: 1, y: 2 }
+    slice.colonistSettings.startingPopulation = 200
+    slice.colonistSettings.threeDayHaulDistance = 2
+    return beginColonizationCommit(slice, geographyDoc())
+  }
+
+  const a = build()
+  const b = build()
+  assert.strictEqual(a.settlements[0].population, b.settlements[0].population)
+  assert.strictEqual(a.settlements[0].tier, b.settlements[0].tier)
+  assert.deepStrictEqual(a.primaryClaim, b.primaryClaim)
 })
 
 test('beginColonizationCommit is a no-op without landing or outside setup', () => {

--- a/world-builder/core/colonization/collapsePopulation.js
+++ b/world-builder/core/colonization/collapsePopulation.js
@@ -1,10 +1,18 @@
 import { BIOMES, SEA_LEVEL } from '../biomeIds.js'
+import { createSeededRandom, deriveFieldSeed } from '../noise/seededRandom.js'
 
-/** Fraction of settlement population placed at the pin (implementation tuning). */
-export const POPULATION_COLLAPSE_CORE_FRACTION = 0.35
+/** Share of settlement population in the urban cluster (implementation tuning). */
+export const POPULATION_COLLAPSE_CORE_FRACTION = 0.8
+
+/** Pin weight vs Moore neighbors when splitting the urban cluster. */
+const URBAN_PIN_WEIGHT = 4
+const URBAN_NEIGHBOR_WEIGHT = 1
+
+/** Distance decay length (cells) for rural sampling. */
+const HINTERLAND_DECAY_CELLS = 8
 
 /**
- * Land cells only — no ocean, lakes, or open water biomes.
+ * Land cells only — fail-closed when elevation is missing.
  *
  * @param {{
  *   x: number,
@@ -12,6 +20,8 @@ export const POPULATION_COLLAPSE_CORE_FRACTION = 0.35
  *   gridWidth: number,
  *   elevation?: Float32Array | null,
  *   lakeMask?: Uint8Array | null,
+ *   riverCorridorMask?: Uint8Array | null,
+ *   simulationRiverMask?: Uint8Array | null,
  *   biomes?: Uint8Array | null,
  *   seaLevel?: number,
  * }} params
@@ -24,26 +34,122 @@ export function isHabitablePopulationCell(params) {
     gridWidth,
     elevation,
     lakeMask,
+    riverCorridorMask,
+    simulationRiverMask,
     biomes,
     seaLevel = SEA_LEVEL,
   } = params
   const index = y * gridWidth + x
+
+  if (!elevation || index < 0 || index >= elevation.length) {
+    return false
+  }
+  if (elevation[index] < seaLevel) {
+    return false
+  }
   if (lakeMask?.[index]) {
+    return false
+  }
+  if (riverCorridorMask?.[index] || simulationRiverMask?.[index]) {
     return false
   }
   const biome = biomes?.[index]
   if (biome === BIOMES.OCEAN || biome === BIOMES.FRESHWATER_LAKE) {
     return false
   }
-  if (elevation && elevation[index] < seaLevel) {
-    return false
-  }
   return true
 }
 
 /**
- * Distribute settlement headcount as core (pin) + hinterland (arable-weighted) on
- * claimed **land** cells only.
+ * @param {{ x: number, y: number }} cell
+ * @param {number} gridWidth
+ * @returns {number}
+ */
+function cellIndex(cell, gridWidth) {
+  return cell.y * gridWidth + cell.x
+}
+
+/**
+ * @param {{ x: number, y: number }} a
+ * @param {{ x: number, y: number }} b
+ * @returns {number}
+ */
+function euclideanDistance(a, b) {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return Math.sqrt(dx * dx + dy * dy)
+}
+
+/**
+ * @param {number} distance
+ * @returns {number}
+ */
+function distanceDecay(distance) {
+  return Math.exp(-distance / HINTERLAND_DECAY_CELLS)
+}
+
+/**
+ * @param {Array<{ cell: { x: number, y: number }, weight: number }>} weighted
+ * @param {() => number} random
+ * @returns {{ x: number, y: number } | null}
+ */
+function sampleWeightedCell(weighted, random) {
+  const total = weighted.reduce((sum, entry) => sum + entry.weight, 0)
+  if (total <= 0) {
+    return null
+  }
+  let roll = random() * total
+  for (const entry of weighted) {
+    roll -= entry.weight
+    if (roll <= 0) {
+      return entry.cell
+    }
+  }
+  return weighted[weighted.length - 1]?.cell ?? null
+}
+
+/**
+ * @param {Float32Array} raster
+ * @param {number} index
+ * @param {number} amount
+ */
+function addPeople(raster, index, amount) {
+  if (amount > 0 && index >= 0 && index < raster.length) {
+    raster[index] += amount
+  }
+}
+
+/**
+ * Split an integer count across weighted cells (deterministic, no RNG).
+ *
+ * @param {number} count
+ * @param {Array<{ cell: { x: number, y: number }, weight: number }>} weighted
+ * @param {Float32Array} raster
+ * @param {number} gridWidth
+ */
+function distributeIntegerByWeight(count, weighted, raster, gridWidth) {
+  if (count <= 0 || weighted.length === 0) {
+    return
+  }
+  const weightSum = weighted.reduce((sum, entry) => sum + entry.weight, 0)
+  if (weightSum <= 0) {
+    addPeople(raster, cellIndex(weighted[0].cell, gridWidth), count)
+    return
+  }
+  let assigned = 0
+  for (let i = 0; i < weighted.length; i += 1) {
+    const { cell, weight } = weighted[i]
+    const share =
+      i === weighted.length - 1
+        ? count - assigned
+        : Math.floor((count * weight) / weightSum)
+    assigned += share
+    addPeople(raster, cellIndex(cell, gridWidth), share)
+  }
+}
+
+/**
+ * Seeded constraint-satisfaction placement: urban cluster + arable hinterland sample.
  *
  * @param {{
  *   settlements: Array<{ id: string, x: number, y: number, population: number, status?: string }>,
@@ -51,10 +157,14 @@ export function isHabitablePopulationCell(params) {
  *   arableRaster?: Float32Array | null,
  *   elevation?: Float32Array | null,
  *   lakeMask?: Uint8Array | null,
+ *   riverCorridorMask?: Uint8Array | null,
+ *   simulationRiverMask?: Uint8Array | null,
  *   biomes?: Uint8Array | null,
  *   gridWidth: number,
  *   gridHeight: number,
  *   seaLevel?: number,
+ *   geographySeed?: number,
+ *   epoch?: number,
  * }} params
  * @returns {Float32Array}
  */
@@ -65,10 +175,14 @@ export function collapsePopulation(params) {
     arableRaster,
     elevation,
     lakeMask,
+    riverCorridorMask,
+    simulationRiverMask,
     biomes,
     gridWidth,
     gridHeight,
     seaLevel = SEA_LEVEL,
+    geographySeed = 0,
+    epoch = 0,
   } = params
   const raster = new Float32Array(gridWidth * gridHeight)
 
@@ -77,85 +191,92 @@ export function collapsePopulation(params) {
       continue
     }
 
-    const landCells = (primaryClaim[settlement.id] ?? []).filter((cell) =>
-      isHabitablePopulationCell({
-        x: cell.x,
-        y: cell.y,
-        gridWidth,
-        elevation,
-        lakeMask,
-        biomes,
-        seaLevel,
-      }),
+    const habitability = {
+      gridWidth,
+      elevation,
+      lakeMask,
+      riverCorridorMask,
+      simulationRiverMask,
+      biomes,
+      seaLevel,
+    }
+
+    const domain = (primaryClaim[settlement.id] ?? []).filter((cell) =>
+      isHabitablePopulationCell({ ...habitability, x: cell.x, y: cell.y }),
     )
-    if (landCells.length === 0) {
+    if (domain.length === 0) {
       continue
     }
 
-    const population = settlement.population
+    const pin = { x: settlement.x, y: settlement.y }
+    const pinInDomain = domain.some((cell) => cell.x === pin.x && cell.y === pin.y)
+    const urbanAnchor = pinInDomain
+      ? pin
+      : domain.reduce((best, cell) => {
+          const bestDist = euclideanDistance(best, pin)
+          const cellDist = euclideanDistance(cell, pin)
+          return cellDist < bestDist ? cell : best
+        }, domain[0])
+
+    const population = Math.floor(settlement.population)
     const corePopulation = Math.min(
       population,
-      Math.max(1, Math.floor(population * POPULATION_COLLAPSE_CORE_FRACTION)),
+      Math.max(population > 0 ? 1 : 0, Math.floor(population * POPULATION_COLLAPSE_CORE_FRACTION)),
     )
     const hinterlandPopulation = population - corePopulation
-    const pinIndex = settlement.y * gridWidth + settlement.x
-    const pinIsLand = landCells.some(
-      (cell) => cell.x === settlement.x && cell.y === settlement.y,
-    )
-    if (pinIsLand && pinIndex >= 0 && pinIndex < raster.length) {
-      raster[pinIndex] += corePopulation
-    } else {
-      // Pin is not habitable (should not happen for founding landings); park core on first land cell.
-      const fallback = landCells[0]
-      raster[fallback.y * gridWidth + fallback.x] += corePopulation
+
+    /** @type {Array<{ cell: { x: number, y: number }, weight: number }>} */
+    const urbanWeighted = []
+    for (const cell of domain) {
+      const dx = Math.abs(cell.x - urbanAnchor.x)
+      const dy = Math.abs(cell.y - urbanAnchor.y)
+      if (dx === 0 && dy === 0) {
+        urbanWeighted.push({ cell, weight: URBAN_PIN_WEIGHT })
+      } else if (dx <= 1 && dy <= 1) {
+        urbanWeighted.push({ cell, weight: URBAN_NEIGHBOR_WEIGHT })
+      }
     }
+    if (urbanWeighted.length === 0) {
+      urbanWeighted.push({ cell: urbanAnchor, weight: URBAN_PIN_WEIGHT })
+    }
+    distributeIntegerByWeight(corePopulation, urbanWeighted, raster, gridWidth)
 
     if (hinterlandPopulation <= 0) {
       continue
     }
 
-    const hinterlandCells = landCells.filter(
-      (cell) => !(cell.x === settlement.x && cell.y === settlement.y),
-    )
-    if (hinterlandCells.length === 0) {
-      const target = pinIsLand
-        ? pinIndex
-        : landCells[0].y * gridWidth + landCells[0].x
-      raster[target] += hinterlandPopulation
-      continue
-    }
-
-    const weighted = hinterlandCells
-      .map((cell) => {
-        const value = arableRaster?.[cell.y * gridWidth + cell.x] ?? 0
-        return {
-          cell,
-          weight: Number.isFinite(value) && value > 0 ? value : 0,
-        }
-      })
-      .filter((entry) => entry.weight > 0)
-
-    if (weighted.length === 0) {
-      // No arable hinterland — keep people at the pin rather than inventing rural density.
-      const target = pinIsLand
-        ? pinIndex
-        : landCells[0].y * gridWidth + landCells[0].x
-      raster[target] += hinterlandPopulation
-      continue
-    }
-
-    const weightSum = weighted.reduce((sum, entry) => sum + entry.weight, 0)
-    let assigned = 0
-    for (let i = 0; i < weighted.length; i += 1) {
-      const { cell, weight } = weighted[i]
-      const share =
-        i === weighted.length - 1
-          ? hinterlandPopulation - assigned
-          : Math.floor((hinterlandPopulation * weight) / weightSum)
-      assigned += share
-      if (share > 0) {
-        raster[cell.y * gridWidth + cell.x] += share
+    const urbanKeys = new Set(urbanWeighted.map((entry) => `${entry.cell.x},${entry.cell.y}`))
+    /** @type {Array<{ cell: { x: number, y: number }, weight: number }>} */
+    const hinterlandWeighted = []
+    for (const cell of domain) {
+      const key = `${cell.x},${cell.y}`
+      if (urbanKeys.has(key)) {
+        continue
       }
+      const arable = arableRaster?.[cellIndex(cell, gridWidth)] ?? 0
+      if (!(arable > 0)) {
+        continue
+      }
+      const weight = arable * distanceDecay(euclideanDistance(cell, urbanAnchor))
+      if (weight > 0) {
+        hinterlandWeighted.push({ cell, weight })
+      }
+    }
+
+    if (hinterlandWeighted.length === 0) {
+      distributeIntegerByWeight(hinterlandPopulation, urbanWeighted, raster, gridWidth)
+      continue
+    }
+
+    const streamSalt = `population-collapse:${epoch}:${settlement.id}`
+    const random = createSeededRandom(deriveFieldSeed(geographySeed, streamSalt))
+    for (let i = 0; i < hinterlandPopulation; i += 1) {
+      const chosen = sampleWeightedCell(hinterlandWeighted, random)
+      if (!chosen) {
+        distributeIntegerByWeight(hinterlandPopulation - i, urbanWeighted, raster, gridWidth)
+        break
+      }
+      addPeople(raster, cellIndex(chosen, gridWidth), 1)
     }
   }
 

--- a/world-builder/core/colonization/collapsePopulation.js
+++ b/world-builder/core/colonization/collapsePopulation.js
@@ -1,0 +1,179 @@
+import { BIOMES, SEA_LEVEL } from '../biomeIds.js'
+
+/** Fraction of settlement population placed at the pin (implementation tuning). */
+export const POPULATION_COLLAPSE_CORE_FRACTION = 0.35
+
+/**
+ * Land cells only — no ocean, lakes, or open water biomes.
+ *
+ * @param {{
+ *   x: number,
+ *   y: number,
+ *   gridWidth: number,
+ *   elevation?: Float32Array | null,
+ *   lakeMask?: Uint8Array | null,
+ *   biomes?: Uint8Array | null,
+ *   seaLevel?: number,
+ * }} params
+ * @returns {boolean}
+ */
+export function isHabitablePopulationCell(params) {
+  const {
+    x,
+    y,
+    gridWidth,
+    elevation,
+    lakeMask,
+    biomes,
+    seaLevel = SEA_LEVEL,
+  } = params
+  const index = y * gridWidth + x
+  if (lakeMask?.[index]) {
+    return false
+  }
+  const biome = biomes?.[index]
+  if (biome === BIOMES.OCEAN || biome === BIOMES.FRESHWATER_LAKE) {
+    return false
+  }
+  if (elevation && elevation[index] < seaLevel) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Distribute settlement headcount as core (pin) + hinterland (arable-weighted) on
+ * claimed **land** cells only.
+ *
+ * @param {{
+ *   settlements: Array<{ id: string, x: number, y: number, population: number, status?: string }>,
+ *   primaryClaim: Record<string, Array<{ x: number, y: number }>>,
+ *   arableRaster?: Float32Array | null,
+ *   elevation?: Float32Array | null,
+ *   lakeMask?: Uint8Array | null,
+ *   biomes?: Uint8Array | null,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   seaLevel?: number,
+ * }} params
+ * @returns {Float32Array}
+ */
+export function collapsePopulation(params) {
+  const {
+    settlements,
+    primaryClaim,
+    arableRaster,
+    elevation,
+    lakeMask,
+    biomes,
+    gridWidth,
+    gridHeight,
+    seaLevel = SEA_LEVEL,
+  } = params
+  const raster = new Float32Array(gridWidth * gridHeight)
+
+  for (const settlement of settlements) {
+    if (settlement.status === 'ruin' || settlement.population <= 0) {
+      continue
+    }
+
+    const landCells = (primaryClaim[settlement.id] ?? []).filter((cell) =>
+      isHabitablePopulationCell({
+        x: cell.x,
+        y: cell.y,
+        gridWidth,
+        elevation,
+        lakeMask,
+        biomes,
+        seaLevel,
+      }),
+    )
+    if (landCells.length === 0) {
+      continue
+    }
+
+    const population = settlement.population
+    const corePopulation = Math.min(
+      population,
+      Math.max(1, Math.floor(population * POPULATION_COLLAPSE_CORE_FRACTION)),
+    )
+    const hinterlandPopulation = population - corePopulation
+    const pinIndex = settlement.y * gridWidth + settlement.x
+    const pinIsLand = landCells.some(
+      (cell) => cell.x === settlement.x && cell.y === settlement.y,
+    )
+    if (pinIsLand && pinIndex >= 0 && pinIndex < raster.length) {
+      raster[pinIndex] += corePopulation
+    } else {
+      // Pin is not habitable (should not happen for founding landings); park core on first land cell.
+      const fallback = landCells[0]
+      raster[fallback.y * gridWidth + fallback.x] += corePopulation
+    }
+
+    if (hinterlandPopulation <= 0) {
+      continue
+    }
+
+    const hinterlandCells = landCells.filter(
+      (cell) => !(cell.x === settlement.x && cell.y === settlement.y),
+    )
+    if (hinterlandCells.length === 0) {
+      const target = pinIsLand
+        ? pinIndex
+        : landCells[0].y * gridWidth + landCells[0].x
+      raster[target] += hinterlandPopulation
+      continue
+    }
+
+    const weighted = hinterlandCells
+      .map((cell) => {
+        const value = arableRaster?.[cell.y * gridWidth + cell.x] ?? 0
+        return {
+          cell,
+          weight: Number.isFinite(value) && value > 0 ? value : 0,
+        }
+      })
+      .filter((entry) => entry.weight > 0)
+
+    if (weighted.length === 0) {
+      // No arable hinterland — keep people at the pin rather than inventing rural density.
+      const target = pinIsLand
+        ? pinIndex
+        : landCells[0].y * gridWidth + landCells[0].x
+      raster[target] += hinterlandPopulation
+      continue
+    }
+
+    const weightSum = weighted.reduce((sum, entry) => sum + entry.weight, 0)
+    let assigned = 0
+    for (let i = 0; i < weighted.length; i += 1) {
+      const { cell, weight } = weighted[i]
+      const share =
+        i === weighted.length - 1
+          ? hinterlandPopulation - assigned
+          : Math.floor((hinterlandPopulation * weight) / weightSum)
+      assigned += share
+      if (share > 0) {
+        raster[cell.y * gridWidth + cell.x] += share
+      }
+    }
+  }
+
+  return raster
+}
+
+/**
+ * Stable hash of collapse raster for determinism checks.
+ *
+ * @param {Float32Array} raster
+ * @returns {string}
+ */
+export function hashPopulationCollapseRaster(raster) {
+  let hash = 2166136261
+  for (let i = 0; i < raster.length; i += 1) {
+    const value = Math.round(raster[i] * 1000)
+    hash ^= value
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16)
+}

--- a/world-builder/core/colonization/collapsePopulation.test.js
+++ b/world-builder/core/colonization/collapsePopulation.test.js
@@ -13,25 +13,44 @@ function landElevation(cellCount) {
   return new Float32Array(cellCount).fill(SEA_LEVEL + 0.2)
 }
 
-test('isHabitablePopulationCell rejects ocean elevation and water biomes', () => {
-  const elevation = Float32Array.from([SEA_LEVEL + 0.2, SEA_LEVEL - 0.1])
+/**
+ * @param {number} width
+ * @param {number} height
+ * @param {{ x: number, y: number }} pin
+ */
+function fullClaim(width, height, pin) {
+  /** @type {Array<{ x: number, y: number }>} */
+  const cells = []
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      cells.push({ x, y })
+    }
+  }
+  return { s1: cells, pin }
+}
+
+test('isHabitablePopulationCell is fail-closed without elevation', () => {
   assert.strictEqual(
     isHabitablePopulationCell({
       x: 0,
       y: 0,
-      gridWidth: 2,
-      elevation,
-      biomes: Uint8Array.from([BIOMES.GRASSLAND, BIOMES.OCEAN]),
+      gridWidth: 1,
+      elevation: null,
     }),
-    true,
+    false,
   )
+})
+
+test('isHabitablePopulationCell rejects ocean, lakes, and river channels', () => {
+  const elevation = landElevation(4)
+  elevation[1] = SEA_LEVEL - 0.1
   assert.strictEqual(
     isHabitablePopulationCell({
       x: 1,
       y: 0,
       gridWidth: 2,
       elevation,
-      biomes: Uint8Array.from([BIOMES.GRASSLAND, BIOMES.OCEAN]),
+      biomes: Uint8Array.from([BIOMES.GRASSLAND, BIOMES.GRASSLAND]),
     }),
     false,
   )
@@ -39,138 +58,222 @@ test('isHabitablePopulationCell rejects ocean elevation and water biomes', () =>
     isHabitablePopulationCell({
       x: 0,
       y: 0,
-      gridWidth: 1,
-      elevation: landElevation(1),
-      lakeMask: Uint8Array.from([1]),
+      gridWidth: 2,
+      elevation: landElevation(2),
+      lakeMask: Uint8Array.from([1, 0]),
     }),
     false,
   )
-})
-
-test('collapsePopulation places core fraction at the pin and spreads hinterland by arable', () => {
-  const raster = collapsePopulation({
-    settlements: [{ id: 's1', x: 1, y: 1, population: 100, status: 'living' }],
-    primaryClaim: {
-      s1: [
-        { x: 1, y: 1 },
-        { x: 0, y: 1 },
-        { x: 2, y: 1 },
-      ],
-    },
-    // (0,1)=1, (2,1)=3 so eastern hinterland gets more density
-    arableRaster: Float32Array.from([0, 0, 0, 1, 0, 3, 0, 0, 0]),
-    elevation: landElevation(9),
-    biomes: new Uint8Array(9).fill(BIOMES.GRASSLAND),
-    gridWidth: 3,
-    gridHeight: 3,
-  })
-
-  const core = Math.floor(100 * POPULATION_COLLAPSE_CORE_FRACTION)
-  assert.strictEqual(raster[1 * 3 + 1], core)
-  assert.ok(raster[1 * 3 + 2] > raster[1 * 3 + 0])
-  const total = raster.reduce((sum, value) => sum + value, 0)
-  assert.strictEqual(total, 100)
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 0,
+      y: 0,
+      gridWidth: 2,
+      elevation: landElevation(2),
+      riverCorridorMask: Uint8Array.from([1, 0]),
+    }),
+    false,
+  )
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 0,
+      y: 0,
+      gridWidth: 2,
+      elevation: landElevation(2),
+      biomes: Uint8Array.from([BIOMES.FRESHWATER_LAKE, BIOMES.GRASSLAND]),
+    }),
+    false,
+  )
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 1,
+      y: 0,
+      gridWidth: 2,
+      elevation: landElevation(2),
+      biomes: Uint8Array.from([BIOMES.FRESHWATER_LAKE, BIOMES.GRASSLAND]),
+    }),
+    true,
+  )
 })
 
 test('collapsePopulation never places people on water cells', () => {
-  const elevation = landElevation(9)
-  elevation[1 * 3 + 2] = SEA_LEVEL - 0.1
-  const biomes = new Uint8Array(9).fill(BIOMES.GRASSLAND)
-  biomes[1 * 3 + 0] = BIOMES.OCEAN
+  const width = 5
+  const height = 5
+  const cellCount = width * height
+  const elevation = landElevation(cellCount)
+  elevation[2 * width + 4] = SEA_LEVEL - 0.1
+  const biomes = new Uint8Array(cellCount).fill(BIOMES.GRASSLAND)
+  biomes[2 * width + 0] = BIOMES.OCEAN
+  const lakeMask = new Uint8Array(cellCount)
+  lakeMask[0 * width + 2] = 1
+  const riverCorridorMask = new Uint8Array(cellCount)
+  riverCorridorMask[4 * width + 2] = 1
+  const arableRaster = new Float32Array(cellCount).fill(1)
 
   const raster = collapsePopulation({
-    settlements: [{ id: 's1', x: 1, y: 1, population: 100, status: 'living' }],
-    primaryClaim: {
-      s1: [
-        { x: 1, y: 1 },
-        { x: 0, y: 1 },
-        { x: 2, y: 1 },
-        { x: 1, y: 0 },
-      ],
-    },
-    arableRaster: Float32Array.from([0, 5, 0, 5, 0, 5, 0, 0, 0]),
+    settlements: [{ id: 's1', x: 2, y: 2, population: 100, status: 'living' }],
+    primaryClaim: fullClaim(width, height, { x: 2, y: 2 }),
+    arableRaster,
     elevation,
     biomes,
-    lakeMask: Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1, 0]),
-    gridWidth: 3,
-    gridHeight: 3,
+    lakeMask,
+    riverCorridorMask,
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 7,
+    epoch: 0,
   })
 
-  assert.strictEqual(raster[1 * 3 + 0], 0)
-  assert.strictEqual(raster[1 * 3 + 2], 0)
-  assert.strictEqual(raster[2 * 3 + 1], 0)
-  assert.ok(raster[1 * 3 + 1] > 0)
+  assert.strictEqual(raster[2 * width + 4], 0)
+  assert.strictEqual(raster[2 * width + 0], 0)
+  assert.strictEqual(raster[0 * width + 2], 0)
+  assert.strictEqual(raster[4 * width + 2], 0)
   assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 100)
 })
 
-test('collapsePopulation keeps hinterland at the pin when no arable land exists', () => {
+test('collapsePopulation places urban majority in the core cluster', () => {
+  const width = 7
+  const height = 7
+  const cellCount = width * height
+  const pin = { x: 3, y: 3 }
   const raster = collapsePopulation({
-    settlements: [{ id: 's1', x: 0, y: 0, population: 20, status: 'living' }],
-    primaryClaim: {
-      s1: [
-        { x: 0, y: 0 },
-        { x: 1, y: 0 },
-      ],
-    },
-    arableRaster: Float32Array.from([0, 0]),
-    elevation: landElevation(2),
-    biomes: new Uint8Array(2).fill(BIOMES.GRASSLAND),
-    gridWidth: 2,
-    gridHeight: 1,
+    settlements: [{ id: 's1', ...pin, population: 100, status: 'living' }],
+    primaryClaim: fullClaim(width, height, pin),
+    arableRaster: new Float32Array(cellCount).fill(1),
+    elevation: landElevation(cellCount),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 11,
+    epoch: 0,
   })
 
-  assert.strictEqual(raster[0], 20)
-  assert.strictEqual(raster[1], 0)
+  let urban = 0
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      urban += raster[(pin.y + dy) * width + (pin.x + dx)]
+    }
+  }
+  assert.ok(urban >= Math.floor(100 * POPULATION_COLLAPSE_CORE_FRACTION))
+  assert.ok(urban / 100 >= 0.75)
+  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 100)
 })
 
-test('collapsePopulation only writes claimed land cells', () => {
+test('collapsePopulation scatters hinterland instead of filling the claim', () => {
+  const width = 25
+  const height = 25
+  const cellCount = width * height
+  const pin = { x: 12, y: 12 }
+  const population = 100
   const raster = collapsePopulation({
-    settlements: [{ id: 's1', x: 0, y: 0, population: 10, status: 'living' }],
-    primaryClaim: {
-      s1: [
-        { x: 0, y: 0 },
-        { x: 1, y: 0 },
-      ],
-    },
-    arableRaster: Float32Array.from([1, 1, 1, 1]),
-    elevation: landElevation(4),
-    biomes: new Uint8Array(4).fill(BIOMES.GRASSLAND),
-    gridWidth: 2,
-    gridHeight: 2,
+    settlements: [{ id: 's1', ...pin, population, status: 'living' }],
+    primaryClaim: fullClaim(width, height, pin),
+    arableRaster: new Float32Array(cellCount).fill(1),
+    elevation: landElevation(cellCount),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 99,
+    epoch: 3,
   })
 
-  assert.strictEqual(raster[1 * 2 + 1], 0)
-  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 10)
+  let occupied = 0
+  let domainArable = 0
+  for (let i = 0; i < cellCount; i += 1) {
+    if (raster[i] >= 1) occupied += 1
+    domainArable += 1
+  }
+  assert.ok(occupied < domainArable / 2)
+  assert.ok(occupied <= population)
+  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), population)
+})
+
+test('collapsePopulation totals match settlement population', () => {
+  const width = 5
+  const height = 5
+  const cellCount = width * height
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 2, y: 2, population: 47, status: 'living' }],
+    primaryClaim: fullClaim(width, height, { x: 2, y: 2 }),
+    arableRaster: new Float32Array(cellCount).fill(0.5),
+    elevation: landElevation(cellCount),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 3,
+    epoch: 1,
+  })
+  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 47)
+  assert.ok([...raster].every((value) => Number.isInteger(value)))
 })
 
 test('collapsePopulation is deterministic for identical inputs', () => {
+  const width = 6
+  const height = 6
+  const cellCount = width * height
   const params = {
-    settlements: [{ id: 's1', x: 0, y: 0, population: 40, status: 'living' }],
-    primaryClaim: {
-      s1: [
-        { x: 0, y: 0 },
-        { x: 1, y: 0 },
-        { x: 0, y: 1 },
-      ],
-    },
-    arableRaster: Float32Array.from([1, 2, 3, 4]),
-    elevation: landElevation(4),
-    biomes: new Uint8Array(4).fill(BIOMES.GRASSLAND),
-    gridWidth: 2,
-    gridHeight: 2,
+    settlements: [{ id: 's1', x: 2, y: 2, population: 80, status: 'living' }],
+    primaryClaim: fullClaim(width, height, { x: 2, y: 2 }),
+    arableRaster: new Float32Array(cellCount).fill(1),
+    elevation: landElevation(cellCount),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 42,
+    epoch: 5,
   }
   const a = collapsePopulation(params)
   const b = collapsePopulation(params)
   assert.strictEqual(hashPopulationCollapseRaster(a), hashPopulationCollapseRaster(b))
 })
 
-test('collapsePopulation skips ruins', () => {
-  const raster = collapsePopulation({
-    settlements: [{ id: 's1', x: 0, y: 0, population: 0, status: 'ruin' }],
+test('collapsePopulation skips ruins and empty domains', () => {
+  const empty = collapsePopulation({
+    settlements: [{ id: 's1', x: 0, y: 0, population: 10, status: 'ruin' }],
     primaryClaim: { s1: [{ x: 0, y: 0 }] },
     elevation: landElevation(1),
     gridWidth: 1,
     gridHeight: 1,
+    geographySeed: 1,
+    epoch: 0,
   })
-  assert.strictEqual(raster[0], 0)
+  assert.strictEqual(empty[0], 0)
+
+  const noLand = collapsePopulation({
+    settlements: [{ id: 's1', x: 0, y: 0, population: 10, status: 'living' }],
+    primaryClaim: { s1: [{ x: 0, y: 0 }] },
+    elevation: null,
+    gridWidth: 1,
+    gridHeight: 1,
+    geographySeed: 1,
+    epoch: 0,
+  })
+  assert.strictEqual(noLand[0], 0)
+})
+
+test('collapsePopulation parks hinterland in urban cluster when no arable hinterland exists', () => {
+  const width = 3
+  const height = 3
+  const cellCount = width * height
+  const arableRaster = new Float32Array(cellCount)
+  // Only pin has arable; neighbors are land but non-arable.
+  arableRaster[1 * width + 1] = 1
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 1, y: 1, population: 50, status: 'living' }],
+    primaryClaim: fullClaim(width, height, { x: 1, y: 1 }),
+    arableRaster,
+    elevation: landElevation(cellCount),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    gridWidth: width,
+    gridHeight: height,
+    geographySeed: 2,
+    epoch: 0,
+  })
+  let urban = 0
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      urban += raster[(1 + dy) * width + (1 + dx)]
+    }
+  }
+  assert.strictEqual(urban, 50)
 })

--- a/world-builder/core/colonization/collapsePopulation.test.js
+++ b/world-builder/core/colonization/collapsePopulation.test.js
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES, SEA_LEVEL } from '../biomeIds.js'
+import {
+  POPULATION_COLLAPSE_CORE_FRACTION,
+  collapsePopulation,
+  hashPopulationCollapseRaster,
+  isHabitablePopulationCell,
+} from './collapsePopulation.js'
+
+/** @param {number} cellCount */
+function landElevation(cellCount) {
+  return new Float32Array(cellCount).fill(SEA_LEVEL + 0.2)
+}
+
+test('isHabitablePopulationCell rejects ocean elevation and water biomes', () => {
+  const elevation = Float32Array.from([SEA_LEVEL + 0.2, SEA_LEVEL - 0.1])
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 0,
+      y: 0,
+      gridWidth: 2,
+      elevation,
+      biomes: Uint8Array.from([BIOMES.GRASSLAND, BIOMES.OCEAN]),
+    }),
+    true,
+  )
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 1,
+      y: 0,
+      gridWidth: 2,
+      elevation,
+      biomes: Uint8Array.from([BIOMES.GRASSLAND, BIOMES.OCEAN]),
+    }),
+    false,
+  )
+  assert.strictEqual(
+    isHabitablePopulationCell({
+      x: 0,
+      y: 0,
+      gridWidth: 1,
+      elevation: landElevation(1),
+      lakeMask: Uint8Array.from([1]),
+    }),
+    false,
+  )
+})
+
+test('collapsePopulation places core fraction at the pin and spreads hinterland by arable', () => {
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 1, y: 1, population: 100, status: 'living' }],
+    primaryClaim: {
+      s1: [
+        { x: 1, y: 1 },
+        { x: 0, y: 1 },
+        { x: 2, y: 1 },
+      ],
+    },
+    // (0,1)=1, (2,1)=3 so eastern hinterland gets more density
+    arableRaster: Float32Array.from([0, 0, 0, 1, 0, 3, 0, 0, 0]),
+    elevation: landElevation(9),
+    biomes: new Uint8Array(9).fill(BIOMES.GRASSLAND),
+    gridWidth: 3,
+    gridHeight: 3,
+  })
+
+  const core = Math.floor(100 * POPULATION_COLLAPSE_CORE_FRACTION)
+  assert.strictEqual(raster[1 * 3 + 1], core)
+  assert.ok(raster[1 * 3 + 2] > raster[1 * 3 + 0])
+  const total = raster.reduce((sum, value) => sum + value, 0)
+  assert.strictEqual(total, 100)
+})
+
+test('collapsePopulation never places people on water cells', () => {
+  const elevation = landElevation(9)
+  elevation[1 * 3 + 2] = SEA_LEVEL - 0.1
+  const biomes = new Uint8Array(9).fill(BIOMES.GRASSLAND)
+  biomes[1 * 3 + 0] = BIOMES.OCEAN
+
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 1, y: 1, population: 100, status: 'living' }],
+    primaryClaim: {
+      s1: [
+        { x: 1, y: 1 },
+        { x: 0, y: 1 },
+        { x: 2, y: 1 },
+        { x: 1, y: 0 },
+      ],
+    },
+    arableRaster: Float32Array.from([0, 5, 0, 5, 0, 5, 0, 0, 0]),
+    elevation,
+    biomes,
+    lakeMask: Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1, 0]),
+    gridWidth: 3,
+    gridHeight: 3,
+  })
+
+  assert.strictEqual(raster[1 * 3 + 0], 0)
+  assert.strictEqual(raster[1 * 3 + 2], 0)
+  assert.strictEqual(raster[2 * 3 + 1], 0)
+  assert.ok(raster[1 * 3 + 1] > 0)
+  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 100)
+})
+
+test('collapsePopulation keeps hinterland at the pin when no arable land exists', () => {
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 0, y: 0, population: 20, status: 'living' }],
+    primaryClaim: {
+      s1: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+    },
+    arableRaster: Float32Array.from([0, 0]),
+    elevation: landElevation(2),
+    biomes: new Uint8Array(2).fill(BIOMES.GRASSLAND),
+    gridWidth: 2,
+    gridHeight: 1,
+  })
+
+  assert.strictEqual(raster[0], 20)
+  assert.strictEqual(raster[1], 0)
+})
+
+test('collapsePopulation only writes claimed land cells', () => {
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 0, y: 0, population: 10, status: 'living' }],
+    primaryClaim: {
+      s1: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+      ],
+    },
+    arableRaster: Float32Array.from([1, 1, 1, 1]),
+    elevation: landElevation(4),
+    biomes: new Uint8Array(4).fill(BIOMES.GRASSLAND),
+    gridWidth: 2,
+    gridHeight: 2,
+  })
+
+  assert.strictEqual(raster[1 * 2 + 1], 0)
+  assert.strictEqual(raster.reduce((sum, value) => sum + value, 0), 10)
+})
+
+test('collapsePopulation is deterministic for identical inputs', () => {
+  const params = {
+    settlements: [{ id: 's1', x: 0, y: 0, population: 40, status: 'living' }],
+    primaryClaim: {
+      s1: [
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 0, y: 1 },
+      ],
+    },
+    arableRaster: Float32Array.from([1, 2, 3, 4]),
+    elevation: landElevation(4),
+    biomes: new Uint8Array(4).fill(BIOMES.GRASSLAND),
+    gridWidth: 2,
+    gridHeight: 2,
+  }
+  const a = collapsePopulation(params)
+  const b = collapsePopulation(params)
+  assert.strictEqual(hashPopulationCollapseRaster(a), hashPopulationCollapseRaster(b))
+})
+
+test('collapsePopulation skips ruins', () => {
+  const raster = collapsePopulation({
+    settlements: [{ id: 's1', x: 0, y: 0, population: 0, status: 'ruin' }],
+    primaryClaim: { s1: [{ x: 0, y: 0 }] },
+    elevation: landElevation(1),
+    gridWidth: 1,
+    gridHeight: 1,
+  })
+  assert.strictEqual(raster[0], 0)
+})

--- a/world-builder/core/colonization/colonizationPhaseTransitions.js
+++ b/world-builder/core/colonization/colonizationPhaseTransitions.js
@@ -37,9 +37,11 @@ export function backToTerrain() {
  */
 export function applyColonizationSliceToWorldDocument(doc, slice) {
   const colonization = cloneColonizationSlice(slice)
+  const raster = slice.populationCollapseRaster
   return {
     ...doc,
     ...colonization,
+    ...(raster instanceof Float32Array ? { populationCollapseRaster: raster } : {}),
   }
 }
 

--- a/world-builder/core/colonization/computeHaulShedIsochrone.js
+++ b/world-builder/core/colonization/computeHaulShedIsochrone.js
@@ -1,0 +1,212 @@
+/**
+ * @typedef {{ x: number, y: number }} GridCell
+ */
+
+/**
+ * @param {{
+ *   origin: GridCell,
+ *   budget: number,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   movementCost?: Float32Array | null,
+ *   roadMultiplier?: number,
+ * }} params
+ * @returns {Float32Array} travel time per cell; Infinity when unreachable within budget
+ */
+export function computeHaulShedTravelTimes(params) {
+  const { origin, budget, gridWidth, gridHeight, movementCost, roadMultiplier = 1 } = params
+  const cellCount = gridWidth * gridHeight
+  const travelTime = new Float32Array(cellCount).fill(Number.POSITIVE_INFINITY)
+
+  if (
+    !origin ||
+    !Number.isFinite(budget) ||
+    budget <= 0 ||
+    !Number.isInteger(gridWidth) ||
+    !Number.isInteger(gridHeight)
+  ) {
+    return travelTime
+  }
+
+  if (movementCost && movementCost.length === cellCount) {
+    fillIsochroneTravelTimes({
+      origin,
+      budget,
+      gridWidth,
+      gridHeight,
+      movementCost,
+      roadMultiplier,
+      travelTime,
+    })
+    return travelTime
+  }
+
+  fillCircleTravelTimes({
+    origin,
+    radius: budget,
+    gridWidth,
+    gridHeight,
+    travelTime,
+  })
+  return travelTime
+}
+
+/**
+ * Terrain-aware haul-shed: cells reachable within the travel-time budget.
+ * Uses movement-cost isochrone when present; circle fallback otherwise.
+ *
+ * @param {{
+ *   origin: GridCell,
+ *   budget: number,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   movementCost?: Float32Array | null,
+ *   roadMultiplier?: number,
+ * }} params
+ * @returns {GridCell[]}
+ */
+export function computeHaulShedIsochrone(params) {
+  const { gridWidth, gridHeight } = params
+  const travelTime = computeHaulShedTravelTimes(params)
+  /** @type {GridCell[]} */
+  const cells = []
+  for (let y = 0; y < gridHeight; y += 1) {
+    for (let x = 0; x < gridWidth; x += 1) {
+      if (travelTime[y * gridWidth + x] <= params.budget) {
+        cells.push({ x, y })
+      }
+    }
+  }
+  return cells
+}
+
+/**
+ * @param {{
+ *   origin: GridCell,
+ *   radius: number,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   travelTime: Float32Array,
+ * }} params
+ */
+function fillCircleTravelTimes({ origin, radius, gridWidth, gridHeight, travelTime }) {
+  const radiusSq = radius * radius
+  const minX = Math.max(0, Math.floor(origin.x - radius))
+  const maxX = Math.min(gridWidth - 1, Math.ceil(origin.x + radius))
+  const minY = Math.max(0, Math.floor(origin.y - radius))
+  const maxY = Math.min(gridHeight - 1, Math.ceil(origin.y + radius))
+
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      const dx = x - origin.x
+      const dy = y - origin.y
+      const distSq = dx * dx + dy * dy
+      if (distSq <= radiusSq) {
+        travelTime[y * gridWidth + x] = Math.sqrt(distSq)
+      }
+    }
+  }
+}
+
+/**
+ * @param {{
+ *   origin: GridCell,
+ *   budget: number,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   movementCost: Float32Array,
+ *   roadMultiplier: number,
+ *   travelTime: Float32Array,
+ * }} params
+ */
+function fillIsochroneTravelTimes({
+  origin,
+  budget,
+  gridWidth,
+  gridHeight,
+  movementCost,
+  roadMultiplier,
+  travelTime,
+}) {
+  const cellCount = gridWidth * gridHeight
+  const originIndex = origin.y * gridWidth + origin.x
+  if (originIndex < 0 || originIndex >= cellCount) {
+    return
+  }
+
+  const costScale = Number.isFinite(roadMultiplier) && roadMultiplier > 0 ? roadMultiplier : 1
+  travelTime[originIndex] = 0
+  /** @type {Array<{ x: number, y: number, time: number }>} */
+  const heap = [{ x: origin.x, y: origin.y, time: 0 }]
+
+  while (heap.length > 0) {
+    const current = popMinTravelTime(heap)
+    if (!current) break
+    const currentIndex = current.y * gridWidth + current.x
+    if (current.time > travelTime[currentIndex]) continue
+
+    for (let dy = -1; dy <= 1; dy += 1) {
+      for (let dx = -1; dx <= 1; dx += 1) {
+        if (dx === 0 && dy === 0) continue
+        const nx = current.x + dx
+        const ny = current.y + dy
+        if (nx < 0 || ny < 0 || nx >= gridWidth || ny >= gridHeight) continue
+        const nextIndex = ny * gridWidth + nx
+        const stepCost = movementCost[nextIndex] * costScale
+        if (!Number.isFinite(stepCost) || stepCost <= 0) continue
+        const diagonalScale = dx !== 0 && dy !== 0 ? Math.SQRT2 : 1
+        const nextTime = current.time + stepCost * diagonalScale
+        if (nextTime > budget || nextTime >= travelTime[nextIndex]) continue
+        travelTime[nextIndex] = nextTime
+        pushMinTravelTime(heap, { x: nx, y: ny, time: nextTime })
+      }
+    }
+  }
+}
+
+/**
+ * @param {Array<{ x: number, y: number, time: number }>} heap
+ * @param {{ x: number, y: number, time: number }} entry
+ */
+function pushMinTravelTime(heap, entry) {
+  heap.push(entry)
+  let index = heap.length - 1
+  while (index > 0) {
+    const parent = (index - 1) >> 1
+    if (heap[parent].time <= heap[index].time) break
+    const swap = heap[parent]
+    heap[parent] = heap[index]
+    heap[index] = swap
+    index = parent
+  }
+}
+
+/**
+ * @param {Array<{ x: number, y: number, time: number }>} heap
+ * @returns {{ x: number, y: number, time: number } | undefined}
+ */
+function popMinTravelTime(heap) {
+  if (heap.length === 0) return undefined
+  const min = heap[0]
+  const last = heap.pop()
+  if (heap.length === 0 || last === undefined) return min
+  heap[0] = last
+  let index = 0
+  while (true) {
+    const left = index * 2 + 1
+    const right = left + 1
+    let smallest = index
+    if (left < heap.length && heap[left].time < heap[smallest].time) {
+      smallest = left
+    }
+    if (right < heap.length && heap[right].time < heap[smallest].time) {
+      smallest = right
+    }
+    if (smallest === index) break
+    const swap = heap[index]
+    heap[index] = heap[smallest]
+    heap[smallest] = swap
+    index = smallest
+  }
+  return min
+}

--- a/world-builder/core/colonization/computeHaulShedIsochrone.test.js
+++ b/world-builder/core/colonization/computeHaulShedIsochrone.test.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { computeHaulShedIsochrone } from './computeHaulShedIsochrone.js'
+
+test('computeHaulShedIsochrone uses circle fallback when movement cost is absent', () => {
+  const cells = computeHaulShedIsochrone({
+    origin: { x: 5, y: 5 },
+    budget: 2,
+    gridWidth: 11,
+    gridHeight: 11,
+  })
+
+  assert.ok(cells.some((cell) => cell.x === 5 && cell.y === 5))
+  assert.ok(cells.some((cell) => cell.x === 7 && cell.y === 5))
+  assert.ok(!cells.some((cell) => cell.x === 8 && cell.y === 5))
+})
+
+test('computeHaulShedIsochrone uses circle fallback when movement cost length mismatches grid', () => {
+  const cells = computeHaulShedIsochrone({
+    origin: { x: 2, y: 2 },
+    budget: 1,
+    gridWidth: 5,
+    gridHeight: 5,
+    movementCost: new Float32Array(3).fill(1),
+  })
+
+  assert.ok(cells.some((cell) => cell.x === 2 && cell.y === 2))
+  assert.ok(cells.some((cell) => cell.x === 3 && cell.y === 2))
+  assert.ok(!cells.some((cell) => cell.x === 4 && cell.y === 2))
+})
+
+test('computeHaulShedIsochrone shrinks when uphill cost exhausts budget', () => {
+  const gridWidth = 5
+  const gridHeight = 1
+  const flat = new Float32Array(gridWidth).fill(1)
+  const uphill = new Float32Array(gridWidth).fill(1)
+  uphill[2] = 10
+  uphill[3] = 10
+  uphill[4] = 10
+
+  const flatCells = computeHaulShedIsochrone({
+    origin: { x: 0, y: 0 },
+    budget: 4,
+    gridWidth,
+    gridHeight,
+    movementCost: flat,
+  })
+  const uphillCells = computeHaulShedIsochrone({
+    origin: { x: 0, y: 0 },
+    budget: 4,
+    gridWidth,
+    gridHeight,
+    movementCost: uphill,
+  })
+
+  assert.ok(flatCells.length > uphillCells.length)
+  assert.ok(flatCells.some((cell) => cell.x === 4))
+  assert.ok(!uphillCells.some((cell) => cell.x === 4))
+})

--- a/world-builder/core/colonization/computeHaulShedReachPreview.js
+++ b/world-builder/core/colonization/computeHaulShedReachPreview.js
@@ -1,3 +1,5 @@
+import { computeHaulShedIsochrone } from './computeHaulShedIsochrone.js'
+
 /**
  * @typedef {{ x: number, y: number }} GridCell
  */
@@ -14,165 +16,11 @@
  */
 export function computeHaulShedReachPreview(params) {
   const { origin, threeDayHaulDistance, gridWidth, gridHeight, movementCost } = params
-  if (
-    !origin ||
-    !Number.isFinite(threeDayHaulDistance) ||
-    threeDayHaulDistance <= 0 ||
-    !Number.isInteger(gridWidth) ||
-    !Number.isInteger(gridHeight)
-  ) {
-    return []
-  }
-
-  if (movementCost && movementCost.length === gridWidth * gridHeight) {
-    return computeIsochroneReach({
-      origin,
-      budget: threeDayHaulDistance,
-      gridWidth,
-      gridHeight,
-      movementCost,
-    })
-  }
-
-  return computeCircleReach({
+  return computeHaulShedIsochrone({
     origin,
-    radius: threeDayHaulDistance,
+    budget: threeDayHaulDistance,
     gridWidth,
     gridHeight,
+    movementCost,
   })
-}
-
-/**
- * @param {{
- *   origin: GridCell,
- *   radius: number,
- *   gridWidth: number,
- *   gridHeight: number,
- * }} params
- * @returns {GridCell[]}
- */
-function computeCircleReach({ origin, radius, gridWidth, gridHeight }) {
-  /** @type {GridCell[]} */
-  const cells = []
-  const radiusSq = radius * radius
-  const minX = Math.max(0, Math.floor(origin.x - radius))
-  const maxX = Math.min(gridWidth - 1, Math.ceil(origin.x + radius))
-  const minY = Math.max(0, Math.floor(origin.y - radius))
-  const maxY = Math.min(gridHeight - 1, Math.ceil(origin.y + radius))
-
-  for (let y = minY; y <= maxY; y += 1) {
-    for (let x = minX; x <= maxX; x += 1) {
-      const dx = x - origin.x
-      const dy = y - origin.y
-      if (dx * dx + dy * dy <= radiusSq) {
-        cells.push({ x, y })
-      }
-    }
-  }
-  return cells
-}
-
-/**
- * @param {{
- *   origin: GridCell,
- *   budget: number,
- *   gridWidth: number,
- *   gridHeight: number,
- *   movementCost: Float32Array,
- * }} params
- * @returns {GridCell[]}
- */
-function computeIsochroneReach({ origin, budget, gridWidth, gridHeight, movementCost }) {
-  const cellCount = gridWidth * gridHeight
-  const travelTime = new Float32Array(cellCount).fill(Number.POSITIVE_INFINITY)
-  const originIndex = origin.y * gridWidth + origin.x
-  if (originIndex < 0 || originIndex >= cellCount) {
-    return []
-  }
-
-  travelTime[originIndex] = 0
-  /** @type {Array<{ x: number, y: number, time: number }>} */
-  const heap = [{ x: origin.x, y: origin.y, time: 0 }]
-
-  while (heap.length > 0) {
-    const current = popMinTravelTime(heap)
-    if (!current) break
-    const currentIndex = current.y * gridWidth + current.x
-    if (current.time > travelTime[currentIndex]) continue
-
-    for (let dy = -1; dy <= 1; dy += 1) {
-      for (let dx = -1; dx <= 1; dx += 1) {
-        if (dx === 0 && dy === 0) continue
-        const nx = current.x + dx
-        const ny = current.y + dy
-        if (nx < 0 || ny < 0 || nx >= gridWidth || ny >= gridHeight) continue
-        const nextIndex = ny * gridWidth + nx
-        const stepCost = movementCost[nextIndex]
-        if (!Number.isFinite(stepCost) || stepCost <= 0) continue
-        const diagonalScale = dx !== 0 && dy !== 0 ? Math.SQRT2 : 1
-        const nextTime = current.time + stepCost * diagonalScale
-        if (nextTime > budget || nextTime >= travelTime[nextIndex]) continue
-        travelTime[nextIndex] = nextTime
-        pushMinTravelTime(heap, { x: nx, y: ny, time: nextTime })
-      }
-    }
-  }
-
-  /** @type {GridCell[]} */
-  const cells = []
-  for (let y = 0; y < gridHeight; y += 1) {
-    for (let x = 0; x < gridWidth; x += 1) {
-      if (travelTime[y * gridWidth + x] <= budget) {
-        cells.push({ x, y })
-      }
-    }
-  }
-  return cells
-}
-
-/**
- * @param {Array<{ x: number, y: number, time: number }>} heap
- * @param {{ x: number, y: number, time: number }} entry
- */
-function pushMinTravelTime(heap, entry) {
-  heap.push(entry)
-  let index = heap.length - 1
-  while (index > 0) {
-    const parent = (index - 1) >> 1
-    if (heap[parent].time <= heap[index].time) break
-    const swap = heap[parent]
-    heap[parent] = heap[index]
-    heap[index] = swap
-    index = parent
-  }
-}
-
-/**
- * @param {Array<{ x: number, y: number, time: number }>} heap
- * @returns {{ x: number, y: number, time: number } | undefined}
- */
-function popMinTravelTime(heap) {
-  if (heap.length === 0) return undefined
-  const min = heap[0]
-  const last = heap.pop()
-  if (heap.length === 0 || last === undefined) return min
-  heap[0] = last
-  let index = 0
-  while (true) {
-    const left = index * 2 + 1
-    const right = left + 1
-    let smallest = index
-    if (left < heap.length && heap[left].time < heap[smallest].time) {
-      smallest = left
-    }
-    if (right < heap.length && heap[right].time < heap[smallest].time) {
-      smallest = right
-    }
-    if (smallest === index) break
-    const swap = heap[index]
-    heap[index] = heap[smallest]
-    heap[smallest] = swap
-    index = smallest
-  }
-  return min
 }

--- a/world-builder/core/colonization/computePrimaryClaimMap.js
+++ b/world-builder/core/colonization/computePrimaryClaimMap.js
@@ -1,0 +1,126 @@
+import { computeHaulShedTravelTimes } from './computeHaulShedIsochrone.js'
+
+/**
+ * @typedef {{ x: number, y: number }} GridCell
+ */
+
+/**
+ * @typedef {Object} ClaimPin
+ * @property {string} id
+ * @property {number} x
+ * @property {number} y
+ * @property {string} [status]
+ */
+
+/**
+ * @typedef {Object} PrimaryClaimMap
+ * @property {(string | null)[]} ownerByCell
+ * @property {Record<string, GridCell[]>} cellsBySettlementId
+ */
+
+/**
+ * Exclusive nearest-pin-by-travel-time ownership within each pin's haul-shed.
+ * Ruins and non-living pins are ignored.
+ *
+ * @param {{
+ *   pins: ClaimPin[],
+ *   budget: number,
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   movementCost?: Float32Array | null,
+ *   roadMultiplier?: number,
+ * }} params
+ * @returns {PrimaryClaimMap}
+ */
+export function computePrimaryClaimMap(params) {
+  const { pins, budget, gridWidth, gridHeight, movementCost, roadMultiplier } = params
+  const cellCount = gridWidth * gridHeight
+  /** @type {(string | null)[]} */
+  const ownerByCell = Array.from({ length: cellCount }, () => null)
+  const bestTime = new Float32Array(cellCount).fill(Number.POSITIVE_INFINITY)
+  /** @type {Record<string, GridCell[]>} */
+  const cellsBySettlementId = {}
+
+  const livingPins = pins.filter((pin) => pin.status !== 'ruin')
+  for (const pin of livingPins) {
+    cellsBySettlementId[pin.id] = []
+    const travelTime = computeHaulShedTravelTimes({
+      origin: { x: pin.x, y: pin.y },
+      budget,
+      gridWidth,
+      gridHeight,
+      movementCost,
+      roadMultiplier,
+    })
+
+    for (let i = 0; i < cellCount; i += 1) {
+      const time = travelTime[i]
+      if (!Number.isFinite(time) || time > budget) continue
+      if (time < bestTime[i] || (time === bestTime[i] && ownerByCell[i] == null)) {
+        bestTime[i] = time
+        ownerByCell[i] = pin.id
+      } else if (time === bestTime[i] && ownerByCell[i] != null && pin.id < ownerByCell[i]) {
+        // Stable tie-break: lexicographically smaller settlement id wins.
+        ownerByCell[i] = pin.id
+      }
+    }
+  }
+
+  for (let y = 0; y < gridHeight; y += 1) {
+    for (let x = 0; x < gridWidth; x += 1) {
+      const owner = ownerByCell[y * gridWidth + x]
+      if (owner == null) continue
+      cellsBySettlementId[owner].push({ x, y })
+    }
+  }
+
+  return { ownerByCell, cellsBySettlementId }
+}
+
+/**
+ * Recompute primary claims for living settlements on a colonization slice.
+ *
+ * @param {{
+ *   settlements: Array<{ id: string, x: number, y: number, status?: string }>,
+ *   colonistSettings: { threeDayHaulDistance: number },
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   movementCost?: Float32Array | null,
+ *   roadMultiplier?: number,
+ * }} params
+ * @returns {PrimaryClaimMap}
+ */
+export function recomputePrimaryClaims(params) {
+  const {
+    settlements,
+    colonistSettings,
+    gridWidth,
+    gridHeight,
+    movementCost,
+    roadMultiplier,
+  } = params
+
+  return computePrimaryClaimMap({
+    pins: settlements,
+    budget: colonistSettings.threeDayHaulDistance,
+    gridWidth,
+    gridHeight,
+    movementCost,
+    roadMultiplier,
+  })
+}
+
+/**
+ * Serialize claim map for tip / session storage (cells only).
+ *
+ * @param {PrimaryClaimMap} claimMap
+ * @returns {Record<string, GridCell[]>}
+ */
+export function serializeClaimMap(claimMap) {
+  /** @type {Record<string, GridCell[]>} */
+  const serialized = {}
+  for (const [settlementId, cells] of Object.entries(claimMap.cellsBySettlementId)) {
+    serialized[settlementId] = cells.map((cell) => ({ x: cell.x, y: cell.y }))
+  }
+  return serialized
+}

--- a/world-builder/core/colonization/computePrimaryClaimMap.test.js
+++ b/world-builder/core/colonization/computePrimaryClaimMap.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  computePrimaryClaimMap,
+  recomputePrimaryClaims,
+  serializeClaimMap,
+} from './computePrimaryClaimMap.js'
+
+test('computePrimaryClaimMap assigns exclusive ownership of isochrone cells to the founding pin', () => {
+  const claimMap = computePrimaryClaimMap({
+    pins: [{ id: 'settlement-a', x: 2, y: 2 }],
+    budget: 2,
+    gridWidth: 5,
+    gridHeight: 5,
+  })
+
+  assert.ok(claimMap.cellsBySettlementId['settlement-a'].length > 0)
+  assert.ok(
+    claimMap.cellsBySettlementId['settlement-a'].every(
+      (cell) => claimMap.ownerByCell[cell.y * 5 + cell.x] === 'settlement-a',
+    ),
+  )
+  assert.ok(!claimMap.cellsBySettlementId['settlement-a'].some((cell) => cell.x === 0 && cell.y === 0))
+})
+
+test('computePrimaryClaimMap does not expand beyond the haul-shed budget', () => {
+  const claimMap = computePrimaryClaimMap({
+    pins: [{ id: 'settlement-a', x: 0, y: 0 }],
+    budget: 1,
+    gridWidth: 5,
+    gridHeight: 5,
+  })
+
+  assert.ok(!claimMap.cellsBySettlementId['settlement-a'].some((cell) => cell.x === 4))
+})
+
+test('computePrimaryClaimMap ignores ruin pins', () => {
+  const claimMap = computePrimaryClaimMap({
+    pins: [
+      { id: 'living', x: 1, y: 1, status: 'living' },
+      { id: 'ruined', x: 3, y: 3, status: 'ruin' },
+    ],
+    budget: 2,
+    gridWidth: 5,
+    gridHeight: 5,
+  })
+
+  assert.ok(claimMap.cellsBySettlementId.living.length > 0)
+  assert.deepStrictEqual(claimMap.cellsBySettlementId.ruined, undefined)
+  assert.ok(!claimMap.ownerByCell.includes('ruined'))
+})
+
+test('recomputePrimaryClaims uses colonist haul distance and living settlements', () => {
+  const claimMap = recomputePrimaryClaims({
+    settlements: [{ id: 's1', x: 2, y: 2, status: 'living' }],
+    colonistSettings: { threeDayHaulDistance: 1 },
+    gridWidth: 5,
+    gridHeight: 5,
+  })
+
+  assert.ok(claimMap.cellsBySettlementId.s1.some((cell) => cell.x === 2 && cell.y === 2))
+  assert.ok(!claimMap.cellsBySettlementId.s1.some((cell) => cell.x === 4))
+})
+
+test('serializeClaimMap clones cell lists for tip storage', () => {
+  const claimMap = computePrimaryClaimMap({
+    pins: [{ id: 's1', x: 1, y: 1 }],
+    budget: 1,
+    gridWidth: 3,
+    gridHeight: 3,
+  })
+  const serialized = serializeClaimMap(claimMap)
+  serialized.s1[0].x = 99
+  assert.notStrictEqual(claimMap.cellsBySettlementId.s1[0].x, 99)
+})

--- a/world-builder/core/colonization/createCommittedTip.js
+++ b/world-builder/core/colonization/createCommittedTip.js
@@ -1,0 +1,32 @@
+/**
+ * Immutable snapshot of colonization state at a tip epoch.
+ *
+ * @param {import('./createDefaultColonizationSlice.js').ColonizationSlice} slice
+ * @param {object} [event]
+ * @returns {object}
+ */
+export function createCommittedTip(slice, event) {
+  const claimMap = event?.claimMap
+    ? Object.fromEntries(
+        Object.entries(event.claimMap).map(([settlementId, cells]) => [
+          settlementId,
+          cells.map((cell) => ({ x: cell.x, y: cell.y })),
+        ]),
+      )
+    : Object.fromEntries(
+        Object.entries(slice.primaryClaim).map(([settlementId, cells]) => [
+          settlementId,
+          cells.map((cell) => ({ x: cell.x, y: cell.y })),
+        ]),
+      )
+
+  return {
+    epoch: slice.epoch,
+    settlements: slice.settlements.map((row) => ({ ...row })),
+    foundingLanding: slice.foundingLanding ? { ...slice.foundingLanding } : null,
+    colonistSettings: { ...slice.colonistSettings },
+    historyLog: slice.historyLog.map((row) => ({ ...row })),
+    claimMap,
+    ...(event?.kind ? { eventKind: event.kind } : {}),
+  }
+}

--- a/world-builder/core/colonization/createCommittedTip.test.js
+++ b/world-builder/core/colonization/createCommittedTip.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createCommittedTip } from './createCommittedTip.js'
+import { createDefaultColonizationSlice } from './createDefaultColonizationSlice.js'
+
+test('createCommittedTip deep-clones claimMap cells from slice.primaryClaim', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.epoch = 2
+  slice.primaryClaim = {
+    s1: [{ x: 1, y: 2 }, { x: 3, y: 4 }],
+  }
+
+  const tip = createCommittedTip(slice)
+  const settlementId = 's1'
+
+  assert.notStrictEqual(tip.claimMap[settlementId], slice.primaryClaim[settlementId])
+  assert.notStrictEqual(tip.claimMap[settlementId][0], slice.primaryClaim[settlementId][0])
+  assert.deepStrictEqual(tip.claimMap[settlementId], slice.primaryClaim[settlementId])
+})
+
+test('createCommittedTip uses event claimMap when provided', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.primaryClaim = { s1: [{ x: 0, y: 0 }] }
+
+  const eventClaim = { s1: [{ x: 5, y: 6 }] }
+  const tip = createCommittedTip(slice, {
+    kind: 'settlement_abandoned',
+    claimMap: eventClaim,
+  })
+
+  assert.strictEqual(tip.eventKind, 'settlement_abandoned')
+  assert.deepStrictEqual(tip.claimMap, eventClaim)
+  assert.notStrictEqual(tip.claimMap.s1, eventClaim.s1)
+})

--- a/world-builder/core/colonization/createDefaultColonizationSlice.js
+++ b/world-builder/core/colonization/createDefaultColonizationSlice.js
@@ -26,7 +26,7 @@
  * @property {object[]} committedTips
  * @property {string | null} realmId
  * @property {Record<string, Array<{ x: number, y: number }>>} primaryClaim
- * @property {Float32Array | null} populationCollapseRaster
+ * @property {Float32Array | null} populationCollapseRaster Derived in-memory overlay raster; never persisted.
  * @property {object[]} notableFigures
  */
 
@@ -34,7 +34,7 @@ export const COLONIZATION_PHASE_TERRAIN = /** @type {const} */ ('terrain')
 export const COLONIZATION_PHASE_SETUP = /** @type {const} */ ('setup')
 export const COLONIZATION_PHASE_RUNNING = /** @type {const} */ ('running')
 
-/** Document / session field names owned by the colonization slice. */
+/** Persisted colonization slice fields (excludes derived collapse raster). */
 export const COLONIZATION_SLICE_KEYS = /** @type {const} */ ([
   'colonizationPhase',
   'epoch',
@@ -45,8 +45,12 @@ export const COLONIZATION_SLICE_KEYS = /** @type {const} */ ([
   'committedTips',
   'realmId',
   'primaryClaim',
-  'populationCollapseRaster',
   'notableFigures',
+])
+
+/** Derived world-document fields produced at runtime, not stored in session caches. */
+export const COLONIZATION_DERIVED_WORLD_DOCUMENT_KEYS = /** @type {const} */ ([
+  'populationCollapseRaster',
 ])
 
 export const DEFAULT_THREE_DAY_HAUL_DISTANCE = 50
@@ -119,7 +123,7 @@ export function resolveColonizationSlice(value) {
     realmId: typeof incoming.realmId === 'string' ? incoming.realmId : null,
     epoch: Number.isFinite(incoming.epoch) ? /** @type {number} */ (incoming.epoch) : 0,
     primaryClaim: resolvePrimaryClaim(incoming.primaryClaim),
-    populationCollapseRaster: resolvePopulationCollapseRaster(incoming.populationCollapseRaster),
+    populationCollapseRaster: null,
     notableFigures: Array.isArray(incoming.notableFigures)
       ? incoming.notableFigures.map((row) => ({ ...row }))
       : [],
@@ -143,45 +147,6 @@ function resolvePrimaryClaim(value) {
       .map((cell) => ({ x: /** @type {number} */ (cell.x), y: /** @type {number} */ (cell.y) }))
   }
   return resolved
-}
-
-/**
- * Revive collapse raster from memory or session JSON.
- * Pinia persist JSON.stringifies Float32Array as an index map ({"0":n,...}), not an array.
- *
- * @param {unknown} value
- * @returns {Float32Array | null}
- */
-function resolvePopulationCollapseRaster(value) {
-  if (value instanceof Float32Array) {
-    return new Float32Array(value)
-  }
-  if (Array.isArray(value)) {
-    return Float32Array.from(value)
-  }
-  if (!value || typeof value !== 'object') {
-    return null
-  }
-  const record = /** @type {Record<string, unknown>} */ (value)
-  if (typeof record.length === 'number' && Number.isFinite(record.length) && record.length >= 0) {
-    return Float32Array.from({ length: record.length }, (_, i) => {
-      const entry = record[i]
-      return typeof entry === 'number' && Number.isFinite(entry) ? entry : 0
-    })
-  }
-  const indexes = Object.keys(record)
-    .map((key) => Number(key))
-    .filter((index) => Number.isInteger(index) && index >= 0)
-  if (indexes.length === 0) {
-    return null
-  }
-  const length = Math.max(...indexes) + 1
-  const raster = new Float32Array(length)
-  for (const index of indexes) {
-    const entry = record[index]
-    raster[index] = typeof entry === 'number' && Number.isFinite(entry) ? entry : 0
-  }
-  return raster
 }
 
 /**
@@ -252,11 +217,65 @@ function clampPositiveNumber(value, fallback, max) {
 }
 
 /**
+ * @param {ColonizationPhase} phase
+ * @returns {number}
+ */
+function colonizationPhaseRank(phase) {
+  if (phase === COLONIZATION_PHASE_RUNNING) {
+    return 2
+  }
+  if (phase === COLONIZATION_PHASE_SETUP) {
+    return 1
+  }
+  return 0
+}
+
+/**
+ * Pick the furthest-along colonization session among candidates (running beats setup).
+ *
+ * @param {...(ColonizationSlice | null | undefined)} candidates
+ * @returns {ColonizationSlice}
+ */
+export function mergeColonizationSessions(...candidates) {
+  let best = createDefaultColonizationSlice()
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+    const resolved = resolveColonizationSlice(candidate)
+    const resolvedRank = colonizationPhaseRank(resolved.colonizationPhase)
+    const bestRank = colonizationPhaseRank(best.colonizationPhase)
+    if (resolvedRank > bestRank || (resolvedRank === bestRank && resolved.epoch > best.epoch)) {
+      best = resolved
+    }
+  }
+  return best
+}
+
+/**
  * @param {ColonizationSlice} slice
  * @returns {ColonizationSlice}
  */
 export function cloneColonizationSlice(slice) {
-  return resolveColonizationSlice(slice)
+  const resolved = resolveColonizationSlice(slice)
+  const raster = slice?.populationCollapseRaster
+  if (raster instanceof Float32Array) {
+    resolved.populationCollapseRaster = new Float32Array(raster)
+  }
+  return resolved
+}
+
+/**
+ * Persistable colonization session (collapse raster is always derived on hydrate).
+ *
+ * @param {ColonizationSlice} slice
+ * @returns {Omit<ColonizationSlice, 'populationCollapseRaster'>}
+ */
+export function serializeColonizationSessionForStorage(slice) {
+  const resolved = resolveColonizationSlice(slice)
+  const { populationCollapseRaster, ...persisted } = resolved
+  void populationCollapseRaster
+  return persisted
 }
 
 /**

--- a/world-builder/core/colonization/createDefaultColonizationSlice.js
+++ b/world-builder/core/colonization/createDefaultColonizationSlice.js
@@ -25,6 +25,9 @@
  * @property {object[]} settlements
  * @property {object[]} committedTips
  * @property {string | null} realmId
+ * @property {Record<string, Array<{ x: number, y: number }>>} primaryClaim
+ * @property {Float32Array | null} populationCollapseRaster
+ * @property {object[]} notableFigures
  */
 
 export const COLONIZATION_PHASE_TERRAIN = /** @type {const} */ ('terrain')
@@ -41,6 +44,9 @@ export const COLONIZATION_SLICE_KEYS = /** @type {const} */ ([
   'settlements',
   'committedTips',
   'realmId',
+  'primaryClaim',
+  'populationCollapseRaster',
+  'notableFigures',
 ])
 
 export const DEFAULT_THREE_DAY_HAUL_DISTANCE = 50
@@ -75,6 +81,9 @@ export function createDefaultColonizationSlice() {
     settlements: [],
     committedTips: [],
     realmId: null,
+    primaryClaim: {},
+    populationCollapseRaster: null,
+    notableFigures: [],
   }
 }
 
@@ -109,7 +118,70 @@ export function resolveColonizationSlice(value) {
       : [],
     realmId: typeof incoming.realmId === 'string' ? incoming.realmId : null,
     epoch: Number.isFinite(incoming.epoch) ? /** @type {number} */ (incoming.epoch) : 0,
+    primaryClaim: resolvePrimaryClaim(incoming.primaryClaim),
+    populationCollapseRaster: resolvePopulationCollapseRaster(incoming.populationCollapseRaster),
+    notableFigures: Array.isArray(incoming.notableFigures)
+      ? incoming.notableFigures.map((row) => ({ ...row }))
+      : [],
   }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Record<string, Array<{ x: number, y: number }>>}
+ */
+function resolvePrimaryClaim(value) {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+  /** @type {Record<string, Array<{ x: number, y: number }>>} */
+  const resolved = {}
+  for (const [settlementId, cells] of Object.entries(value)) {
+    if (!Array.isArray(cells)) continue
+    resolved[settlementId] = cells
+      .filter((cell) => cell && Number.isFinite(cell.x) && Number.isFinite(cell.y))
+      .map((cell) => ({ x: /** @type {number} */ (cell.x), y: /** @type {number} */ (cell.y) }))
+  }
+  return resolved
+}
+
+/**
+ * Revive collapse raster from memory or session JSON.
+ * Pinia persist JSON.stringifies Float32Array as an index map ({"0":n,...}), not an array.
+ *
+ * @param {unknown} value
+ * @returns {Float32Array | null}
+ */
+function resolvePopulationCollapseRaster(value) {
+  if (value instanceof Float32Array) {
+    return new Float32Array(value)
+  }
+  if (Array.isArray(value)) {
+    return Float32Array.from(value)
+  }
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const record = /** @type {Record<string, unknown>} */ (value)
+  if (typeof record.length === 'number' && Number.isFinite(record.length) && record.length >= 0) {
+    return Float32Array.from({ length: record.length }, (_, i) => {
+      const entry = record[i]
+      return typeof entry === 'number' && Number.isFinite(entry) ? entry : 0
+    })
+  }
+  const indexes = Object.keys(record)
+    .map((key) => Number(key))
+    .filter((index) => Number.isInteger(index) && index >= 0)
+  if (indexes.length === 0) {
+    return null
+  }
+  const length = Math.max(...indexes) + 1
+  const raster = new Float32Array(length)
+  for (const index of indexes) {
+    const entry = record[index]
+    raster[index] = typeof entry === 'number' && Number.isFinite(entry) ? entry : 0
+  }
+  return raster
 }
 
 /**

--- a/world-builder/core/colonization/createDefaultColonizationSlice.test.js
+++ b/world-builder/core/colonization/createDefaultColonizationSlice.test.js
@@ -7,6 +7,7 @@ import {
   createDefaultColonistSettings,
   createDefaultColonizationSlice,
   resolveColonistSettings,
+  resolveColonizationSlice,
 } from './createDefaultColonizationSlice.js'
 
 test('createDefaultColonizationSlice starts in terrain with empty scaffolding', () => {
@@ -19,6 +20,9 @@ test('createDefaultColonizationSlice starts in terrain with empty scaffolding', 
   assert.deepStrictEqual(slice.settlements, [])
   assert.deepStrictEqual(slice.historyLog, [])
   assert.deepStrictEqual(slice.committedTips, [])
+  assert.deepStrictEqual(slice.primaryClaim, {})
+  assert.strictEqual(slice.populationCollapseRaster, null)
+  assert.deepStrictEqual(slice.notableFigures, [])
   assert.deepStrictEqual(slice.colonistSettings, createDefaultColonistSettings())
 })
 
@@ -37,6 +41,21 @@ test('createDefaultColonistSettings provides concrete defaults for every field',
 test('resolveColonistSettings clamps three-day haul distance to the scale calibration max', () => {
   const settings = resolveColonistSettings({ threeDayHaulDistance: MAX_THREE_DAY_HAUL_DISTANCE + 50 })
   assert.strictEqual(settings.threeDayHaulDistance, MAX_THREE_DAY_HAUL_DISTANCE)
+})
+
+test('resolveColonizationSlice revives populationCollapseRaster from session JSON forms', () => {
+  const fromArray = resolveColonizationSlice({
+    populationCollapseRaster: [0, 12, 3],
+  })
+  assert.ok(fromArray.populationCollapseRaster instanceof Float32Array)
+  assert.deepStrictEqual([...fromArray.populationCollapseRaster], [0, 12, 3])
+
+  // JSON.stringify(Float32Array) shape
+  const fromIndexMap = resolveColonizationSlice({
+    populationCollapseRaster: { 0: 0, 1: 12, 2: 3 },
+  })
+  assert.ok(fromIndexMap.populationCollapseRaster instanceof Float32Array)
+  assert.deepStrictEqual([...fromIndexMap.populationCollapseRaster], [0, 12, 3])
 })
 
 test('cloneWorldDocument copies colonization slice independently', () => {

--- a/world-builder/core/colonization/createDefaultColonizationSlice.test.js
+++ b/world-builder/core/colonization/createDefaultColonizationSlice.test.js
@@ -2,12 +2,17 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { cloneWorldDocument } from '../cloneWorldDocument.js'
 import {
+  COLONIZATION_PHASE_RUNNING,
+  COLONIZATION_PHASE_SETUP,
   COLONIZATION_PHASE_TERRAIN,
   MAX_THREE_DAY_HAUL_DISTANCE,
+  cloneColonizationSlice,
   createDefaultColonistSettings,
   createDefaultColonizationSlice,
+  mergeColonizationSessions,
   resolveColonistSettings,
   resolveColonizationSlice,
+  serializeColonizationSessionForStorage,
 } from './createDefaultColonizationSlice.js'
 
 test('createDefaultColonizationSlice starts in terrain with empty scaffolding', () => {
@@ -43,19 +48,57 @@ test('resolveColonistSettings clamps three-day haul distance to the scale calibr
   assert.strictEqual(settings.threeDayHaulDistance, MAX_THREE_DAY_HAUL_DISTANCE)
 })
 
-test('resolveColonizationSlice revives populationCollapseRaster from session JSON forms', () => {
+test('serializeColonizationSessionForStorage omits derived collapse raster', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_RUNNING
+  slice.populationCollapseRaster = new Float32Array([0, 12, 3])
+
+  const serialized = serializeColonizationSessionForStorage(slice)
+  assert.strictEqual('populationCollapseRaster' in serialized, false)
+
+  const revived = resolveColonizationSlice(serialized)
+  assert.strictEqual(revived.populationCollapseRaster, null)
+})
+
+test('mergeColonizationSessions prefers running over setup', () => {
+  const setup = createDefaultColonizationSlice()
+  setup.colonizationPhase = COLONIZATION_PHASE_SETUP
+  setup.foundingLanding = { x: 1, y: 2 }
+
+  const running = createDefaultColonizationSlice()
+  running.colonizationPhase = COLONIZATION_PHASE_RUNNING
+  running.epoch = 50
+  running.settlements = [{ id: 's1', population: 100 }]
+
+  assert.strictEqual(
+    mergeColonizationSessions(setup, running).colonizationPhase,
+    COLONIZATION_PHASE_RUNNING,
+  )
+  assert.strictEqual(
+    mergeColonizationSessions(running, setup).colonizationPhase,
+    COLONIZATION_PHASE_RUNNING,
+  )
+})
+
+test('cloneColonizationSlice preserves in-memory collapse raster', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.populationCollapseRaster = new Float32Array([0, 12, 3])
+  const cloned = cloneColonizationSlice(slice)
+  assert.ok(cloned.populationCollapseRaster instanceof Float32Array)
+  assert.deepStrictEqual([...cloned.populationCollapseRaster], [0, 12, 3])
+  assert.notStrictEqual(cloned.populationCollapseRaster, slice.populationCollapseRaster)
+})
+
+test('resolveColonizationSlice ignores persisted collapse raster payloads', () => {
   const fromArray = resolveColonizationSlice({
     populationCollapseRaster: [0, 12, 3],
   })
-  assert.ok(fromArray.populationCollapseRaster instanceof Float32Array)
-  assert.deepStrictEqual([...fromArray.populationCollapseRaster], [0, 12, 3])
+  assert.strictEqual(fromArray.populationCollapseRaster, null)
 
-  // JSON.stringify(Float32Array) shape
   const fromIndexMap = resolveColonizationSlice({
     populationCollapseRaster: { 0: 0, 1: 12, 2: 3 },
   })
-  assert.ok(fromIndexMap.populationCollapseRaster instanceof Float32Array)
-  assert.deepStrictEqual([...fromIndexMap.populationCollapseRaster], [0, 12, 3])
+  assert.strictEqual(fromIndexMap.populationCollapseRaster, null)
 })
 
 test('cloneWorldDocument copies colonization slice independently', () => {

--- a/world-builder/core/colonization/createFoundingDynasty.js
+++ b/world-builder/core/colonization/createFoundingDynasty.js
@@ -1,0 +1,71 @@
+import { BIOMES } from '../biomeIds.js'
+
+/** @type {Readonly<Record<number, string>>} */
+const BIOME_LABEL_KEYS = Object.freeze({
+  [BIOMES.OCEAN]: 'ocean',
+  [BIOMES.COAST]: 'coast',
+  [BIOMES.GRASSLAND]: 'grassland',
+  [BIOMES.SAVANNA]: 'savanna',
+  [BIOMES.TEMPERATE_FOREST]: 'temperate_forest',
+  [BIOMES.TROPICAL_RAINFOREST]: 'tropical_rainforest',
+  [BIOMES.TAIGA]: 'taiga',
+  [BIOMES.TUNDRA]: 'tundra',
+  [BIOMES.DESERT]: 'desert',
+  [BIOMES.SCRUBLAND]: 'scrubland',
+  [BIOMES.SWAMP]: 'swamp',
+  [BIOMES.HILLS]: 'hills',
+  [BIOMES.MOUNTAIN]: 'mountain',
+  [BIOMES.GLACIER]: 'glacier',
+  [BIOMES.FRESHWATER_LAKE]: 'freshwater_lake',
+  [BIOMES.RIVER_CORRIDOR]: 'river_corridor',
+})
+
+/**
+ * Landing geography heuristic key for dynasty labeling (not display prose).
+ *
+ * @param {{ x: number, y: number }} landing
+ * @param {import('../types.js').WorldDocument} worldDocument
+ * @returns {string}
+ */
+export function landingGeographyHeuristicKey(landing, worldDocument) {
+  const index = landing.y * worldDocument.gridWidth + landing.x
+  const biome = worldDocument.biomes?.[index]
+  if (biome != null && BIOME_LABEL_KEYS[biome]) {
+    return BIOME_LABEL_KEYS[biome]
+  }
+  if (worldDocument.riverCorridorMask?.[index]) {
+    return 'river_corridor'
+  }
+  if (worldDocument.lakeMask?.[index]) {
+    return 'freshwater_lake'
+  }
+  return 'land'
+}
+
+/**
+ * Founding dynasty notable-figure seat (flavor only; no per-epoch mechanics).
+ *
+ * @param {{
+ *   settlementId: string,
+ *   landing: { x: number, y: number },
+ *   worldDocument: import('../types.js').WorldDocument,
+ * }} params
+ * @returns {{
+ *   id: string,
+ *   kind: 'dynasty',
+ *   settlementId: string,
+ *   role: 'founder',
+ *   labelKey: string,
+ * }}
+ */
+export function createFoundingDynasty(params) {
+  const { settlementId, landing, worldDocument } = params
+  const geographyKey = landingGeographyHeuristicKey(landing, worldDocument)
+  return {
+    id: `dynasty-${settlementId}`,
+    kind: 'dynasty',
+    settlementId,
+    role: 'founder',
+    labelKey: `${geographyKey}_dynasty`,
+  }
+}

--- a/world-builder/core/colonization/createFoundingDynasty.test.js
+++ b/world-builder/core/colonization/createFoundingDynasty.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { beginColonizationCommit } from './beginColonizationCommit.js'
+import {
+  COLONIZATION_PHASE_SETUP,
+  createDefaultColonizationSlice,
+  resolveColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+import {
+  createFoundingDynasty,
+  landingGeographyHeuristicKey,
+} from './createFoundingDynasty.js'
+
+test('landingGeographyHeuristicKey derives from landing biome', () => {
+  const key = landingGeographyHeuristicKey(
+    { x: 1, y: 0 },
+    {
+      gridWidth: 2,
+      biomes: Uint8Array.from([BIOMES.DESERT, BIOMES.COAST]),
+    },
+  )
+  assert.strictEqual(key, 'coast')
+})
+
+test('createFoundingDynasty records dynasty seat with geography-derived label key', () => {
+  const dynasty = createFoundingDynasty({
+    settlementId: 'settlement-founding-1-2',
+    landing: { x: 1, y: 2 },
+    worldDocument: {
+      gridWidth: 4,
+      biomes: new Uint8Array(16).fill(BIOMES.GRASSLAND),
+    },
+  })
+
+  assert.strictEqual(dynasty.kind, 'dynasty')
+  assert.strictEqual(dynasty.role, 'founder')
+  assert.strictEqual(dynasty.settlementId, 'settlement-founding-1-2')
+  assert.ok(dynasty.labelKey.endsWith('_dynasty'))
+  assert.ok(dynasty.labelKey.startsWith('grassland'))
+})
+
+test('beginColonizationCommit seeds founding dynasty on the world document slice', () => {
+  const slice = createDefaultColonizationSlice()
+  slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+  slice.foundingLanding = { x: 1, y: 2 }
+  slice.colonistSettings.threeDayHaulDistance = 1
+
+  const cellCount = 16
+  const doc = {
+    geographySeed: 3,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(1),
+    timberRaster: new Float32Array(cellCount).fill(1),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.SWAMP),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: Uint8Array.from({ length: cellCount }, (_, i) => (i === 9 ? 1 : 0)),
+  }
+
+  const next = beginColonizationCommit(slice, doc)
+  assert.strictEqual(next.notableFigures.length, 1)
+  assert.strictEqual(next.notableFigures[0].kind, 'dynasty')
+  assert.strictEqual(next.notableFigures[0].role, 'founder')
+  assert.strictEqual(next.notableFigures[0].settlementId, next.settlements[0].id)
+  assert.ok(next.notableFigures[0].labelKey.endsWith('_dynasty'))
+
+  const resolved = resolveColonizationSlice(next)
+  assert.strictEqual(resolved.notableFigures.length, 1)
+  assert.strictEqual(resolved.notableFigures[0].kind, 'dynasty')
+})

--- a/world-builder/core/colonization/freshwater/deriveFreshwaterAvailability.js
+++ b/world-builder/core/colonization/freshwater/deriveFreshwaterAvailability.js
@@ -1,0 +1,163 @@
+import { BIOMES, SEA_LEVEL } from '../../biomeIds.js'
+
+/** No drinkable water access. */
+export const FRESHWATER_NONE = 0
+/** Surface freshwater: river, lake, or coast. */
+export const FRESHWATER_SURFACE = 1
+/** Well-viable land (groundwater heuristic). */
+export const FRESHWATER_WELL_VIABLE = 2
+
+/** Minimum rainfall for well-viable land (implementation tuning). */
+export const WELL_VIABLE_MIN_RAINFALL = 0.4
+/** Maximum drainage for well-viable land (implementation tuning). */
+export const WELL_VIABLE_MAX_DRAINAGE = 0.45
+/** Maximum salinity for well-viable land (implementation tuning). */
+export const WELL_VIABLE_MAX_SALINITY = 0.35
+
+/** Biomes that never count as well-viable. */
+export const WELL_VIABLE_EXCLUDED_BIOMES = new Set([
+  BIOMES.OCEAN,
+  BIOMES.DESERT,
+  BIOMES.SCRUBLAND,
+  BIOMES.GLACIER,
+  BIOMES.MOUNTAIN,
+])
+
+/**
+ * @typedef {Object} FreshwaterCellSample
+ * @property {number} rainfall
+ * @property {number} drainage
+ * @property {number} salinity
+ * @property {number} biome
+ * @property {number} elevation
+ * @property {boolean} lake
+ * @property {boolean} river
+ * @property {number} [seaLevel]
+ */
+
+/**
+ * @param {FreshwaterCellSample} sample
+ * @returns {typeof FRESHWATER_NONE | typeof FRESHWATER_SURFACE | typeof FRESHWATER_WELL_VIABLE}
+ */
+export function classifyFreshwaterCell(sample) {
+  const seaLevel = sample.seaLevel ?? SEA_LEVEL
+  if (sample.biome === BIOMES.OCEAN || sample.elevation < seaLevel) {
+    return FRESHWATER_NONE
+  }
+
+  if (
+    sample.river ||
+    sample.lake ||
+    sample.biome === BIOMES.COAST ||
+    sample.biome === BIOMES.FRESHWATER_LAKE ||
+    sample.biome === BIOMES.RIVER_CORRIDOR ||
+    sample.biome === BIOMES.SWAMP
+  ) {
+    return FRESHWATER_SURFACE
+  }
+
+  if (WELL_VIABLE_EXCLUDED_BIOMES.has(sample.biome)) {
+    return FRESHWATER_NONE
+  }
+
+  if (
+    sample.rainfall >= WELL_VIABLE_MIN_RAINFALL &&
+    sample.drainage <= WELL_VIABLE_MAX_DRAINAGE &&
+    sample.salinity <= WELL_VIABLE_MAX_SALINITY
+  ) {
+    return FRESHWATER_WELL_VIABLE
+  }
+
+  return FRESHWATER_NONE
+}
+
+/**
+ * On-demand freshwater classification raster (not persisted on the world document).
+ *
+ * @param {{
+ *   gridWidth: number,
+ *   gridHeight: number,
+ *   rainfall: Float32Array,
+ *   drainage: Float32Array,
+ *   salinity: Float32Array,
+ *   biomes: Uint8Array,
+ *   elevation: Float32Array,
+ *   lakeMask?: Uint8Array | null,
+ *   riverCorridorMask?: Uint8Array | null,
+ *   seaLevel?: number,
+ * }} params
+ * @returns {Uint8Array}
+ */
+export function deriveFreshwaterAvailability(params) {
+  const {
+    gridWidth,
+    gridHeight,
+    rainfall,
+    drainage,
+    salinity,
+    biomes,
+    elevation,
+    lakeMask,
+    riverCorridorMask,
+    seaLevel = SEA_LEVEL,
+  } = params
+  const cellCount = gridWidth * gridHeight
+  const classification = new Uint8Array(cellCount)
+
+  for (let i = 0; i < cellCount; i += 1) {
+    classification[i] = classifyFreshwaterCell({
+      rainfall: rainfall[i] ?? 0,
+      drainage: drainage[i] ?? 0,
+      salinity: salinity[i] ?? 0,
+      biome: biomes[i] ?? BIOMES.OCEAN,
+      elevation: elevation[i] ?? 0,
+      lake: Boolean(lakeMask?.[i]),
+      river: Boolean(riverCorridorMask?.[i]),
+      seaLevel,
+    })
+  }
+
+  return classification
+}
+
+/**
+ * Shared freshwater gate for colonization survival triad.
+ *
+ * @param {Uint8Array} classification
+ * @param {ReadonlyArray<{ x: number, y: number }>} claimCells
+ * @param {number} gridWidth
+ * @returns {boolean}
+ */
+export function claimedCellsHaveFreshwater(classification, claimCells, gridWidth) {
+  for (const cell of claimCells) {
+    const index = cell.y * gridWidth + cell.x
+    const value = classification[index]
+    if (value === FRESHWATER_SURFACE || value === FRESHWATER_WELL_VIABLE) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * @param {import('../../types.js').WorldDocument} worldDocument
+ * @returns {Uint8Array | null}
+ */
+export function deriveFreshwaterAvailabilityFromDocument(worldDocument) {
+  const { gridWidth, gridHeight, fields, biomes, lakeMask, riverCorridorMask } = worldDocument
+  if (!fields?.rainfall || !fields?.drainage || !fields?.salinity || !fields?.elevation || !biomes) {
+    return null
+  }
+
+  return deriveFreshwaterAvailability({
+    gridWidth,
+    gridHeight,
+    rainfall: fields.rainfall,
+    drainage: fields.drainage,
+    salinity: fields.salinity,
+    biomes,
+    elevation: fields.elevation,
+    lakeMask,
+    riverCorridorMask,
+  })
+}

--- a/world-builder/core/colonization/freshwater/deriveFreshwaterAvailability.test.js
+++ b/world-builder/core/colonization/freshwater/deriveFreshwaterAvailability.test.js
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../../biomeIds.js'
+import {
+  FRESHWATER_NONE,
+  FRESHWATER_SURFACE,
+  FRESHWATER_WELL_VIABLE,
+  claimedCellsHaveFreshwater,
+  classifyFreshwaterCell,
+  deriveFreshwaterAvailability,
+} from './deriveFreshwaterAvailability.js'
+
+/**
+ * @param {Partial<{
+ *   rainfall: number,
+ *   drainage: number,
+ *   salinity: number,
+ *   biome: number,
+ *   elevation: number,
+ *   lake: boolean,
+ *   river: boolean,
+ * }>} overrides
+ */
+function cellSample(overrides = {}) {
+  return {
+    rainfall: overrides.rainfall ?? 0.5,
+    drainage: overrides.drainage ?? 0.3,
+    salinity: overrides.salinity ?? 0.2,
+    biome: overrides.biome ?? BIOMES.GRASSLAND,
+    elevation: overrides.elevation ?? 0.5,
+    lake: overrides.lake ?? false,
+    river: overrides.river ?? false,
+  }
+}
+
+test('classifyFreshwaterCell marks river corridor as surface', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(cellSample({ river: true, rainfall: 0, drainage: 1, salinity: 1 })),
+    FRESHWATER_SURFACE,
+  )
+})
+
+test('classifyFreshwaterCell marks lake as surface', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(cellSample({ lake: true, rainfall: 0, drainage: 1, salinity: 1 })),
+    FRESHWATER_SURFACE,
+  )
+})
+
+test('classifyFreshwaterCell marks coast biome as surface', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(cellSample({ biome: BIOMES.COAST, rainfall: 0, drainage: 1, salinity: 1 })),
+    FRESHWATER_SURFACE,
+  )
+})
+
+test('classifyFreshwaterCell marks ocean as none', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(cellSample({ biome: BIOMES.OCEAN, elevation: 0.2 })),
+    FRESHWATER_NONE,
+  )
+})
+
+test('classifyFreshwaterCell marks well-viable land when fields pass thresholds', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(
+      cellSample({
+        rainfall: 0.55,
+        drainage: 0.25,
+        salinity: 0.15,
+        biome: BIOMES.GRASSLAND,
+      }),
+    ),
+    FRESHWATER_WELL_VIABLE,
+  )
+})
+
+test('classifyFreshwaterCell excludes desert from well-viable', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(
+      cellSample({
+        rainfall: 0.55,
+        drainage: 0.25,
+        salinity: 0.15,
+        biome: BIOMES.DESERT,
+      }),
+    ),
+    FRESHWATER_NONE,
+  )
+})
+
+test('classifyFreshwaterCell excludes scrubland from well-viable', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(
+      cellSample({
+        rainfall: 0.55,
+        drainage: 0.25,
+        salinity: 0.15,
+        biome: BIOMES.SCRUBLAND,
+      }),
+    ),
+    FRESHWATER_NONE,
+  )
+})
+
+test('classifyFreshwaterCell rejects low rainfall for well-viable', () => {
+  assert.strictEqual(
+    classifyFreshwaterCell(
+      cellSample({
+        rainfall: 0.1,
+        drainage: 0.25,
+        salinity: 0.15,
+        biome: BIOMES.GRASSLAND,
+      }),
+    ),
+    FRESHWATER_NONE,
+  )
+})
+
+test('deriveFreshwaterAvailability raster dimensions match the geography grid', () => {
+  const gridWidth = 4
+  const gridHeight = 3
+  const cellCount = gridWidth * gridHeight
+  const classification = deriveFreshwaterAvailability({
+    gridWidth,
+    gridHeight,
+    rainfall: new Float32Array(cellCount).fill(0.6),
+    drainage: new Float32Array(cellCount).fill(0.2),
+    salinity: new Float32Array(cellCount).fill(0.1),
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    elevation: new Float32Array(cellCount).fill(0.5),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: new Uint8Array(cellCount),
+  })
+
+  assert.strictEqual(classification.length, cellCount)
+  assert.ok(classification.every((value) => value === FRESHWATER_WELL_VIABLE))
+})
+
+test('deriveFreshwaterAvailability prefers surface over well-viable on river cells', () => {
+  const gridWidth = 2
+  const gridHeight = 1
+  const riverCorridorMask = new Uint8Array([1, 0])
+  const classification = deriveFreshwaterAvailability({
+    gridWidth,
+    gridHeight,
+    rainfall: new Float32Array([0.6, 0.6]),
+    drainage: new Float32Array([0.2, 0.2]),
+    salinity: new Float32Array([0.1, 0.1]),
+    biomes: new Uint8Array([BIOMES.GRASSLAND, BIOMES.GRASSLAND]),
+    elevation: new Float32Array([0.5, 0.5]),
+    lakeMask: new Uint8Array(2),
+    riverCorridorMask,
+  })
+
+  assert.strictEqual(classification[0], FRESHWATER_SURFACE)
+  assert.strictEqual(classification[1], FRESHWATER_WELL_VIABLE)
+})
+
+test('claimedCellsHaveFreshwater uses the same classification as the derive', () => {
+  const classification = new Uint8Array([FRESHWATER_NONE, FRESHWATER_WELL_VIABLE, FRESHWATER_NONE])
+  assert.strictEqual(
+    claimedCellsHaveFreshwater(classification, [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ], 3),
+    true,
+  )
+  assert.strictEqual(
+    claimedCellsHaveFreshwater(classification, [{ x: 0, y: 0 }, { x: 2, y: 0 }], 3),
+    false,
+  )
+})

--- a/world-builder/core/colonization/resolveSurvivalTriad.js
+++ b/world-builder/core/colonization/resolveSurvivalTriad.js
@@ -1,0 +1,164 @@
+import {
+  claimedCellsHaveFreshwater,
+  deriveFreshwaterAvailabilityFromDocument,
+} from './freshwater/deriveFreshwaterAvailability.js'
+import { settlementTierFromPopulation } from './settlementTierFromPopulation.js'
+
+/** People supported per unit of arable productivity (implementation tuning). */
+export const PEOPLE_PER_ARABLE_UNIT = 100
+/** People supported per unit of timber productivity when timber binds (implementation tuning). */
+export const PEOPLE_PER_TIMBER_UNIT = 80
+
+/** @type {Readonly<Record<string, number>>} */
+export const YIELD_MODIFIER_MULTIPLIERS = Object.freeze({
+  marginal: 0.7,
+  typical: 1,
+  bountiful: 1.3,
+})
+
+/**
+ * @typedef {Object} SurvivalTriadResult
+ * @property {number} foodProduction
+ * @property {number} timberSum
+ * @property {boolean} hasFreshwater
+ * @property {number} populationCeiling
+ * @property {number} foodConsumption
+ * @property {number} foodSurplus
+ * @property {number} population
+ * @property {string | null} tier
+ * @property {boolean} canSustain
+ */
+
+/**
+ * @param {string} yieldModifier
+ * @returns {number}
+ */
+export function yieldModifierMultiplier(yieldModifier) {
+  return YIELD_MODIFIER_MULTIPLIERS[yieldModifier] ?? YIELD_MODIFIER_MULTIPLIERS.typical
+}
+
+/**
+ * @param {Float32Array | null | undefined} raster
+ * @param {ReadonlyArray<{ x: number, y: number }>} cells
+ * @param {number} gridWidth
+ * @returns {number}
+ */
+export function sumRasterOnCells(raster, cells, gridWidth) {
+  if (!raster) return 0
+  let sum = 0
+  for (const cell of cells) {
+    const index = cell.y * gridWidth + cell.x
+    const value = raster[index]
+    if (Number.isFinite(value) && value > 0) {
+      sum += value
+    }
+  }
+  return sum
+}
+
+/**
+ * @param {{
+ *   claimedCells: ReadonlyArray<{ x: number, y: number }>,
+ *   gridWidth: number,
+ *   arableRaster?: Float32Array | null,
+ *   timberRaster?: Float32Array | null,
+ *   yieldModifier: string,
+ *   freshwaterClassification: Uint8Array | null,
+ *   population: number,
+ *   saltSpoilageMultiplier?: number,
+ * }} params
+ * @returns {SurvivalTriadResult}
+ */
+export function resolveSurvivalTriad(params) {
+  const {
+    claimedCells,
+    gridWidth,
+    arableRaster,
+    timberRaster,
+    yieldModifier,
+    freshwaterClassification,
+    population,
+    saltSpoilageMultiplier = 1,
+  } = params
+
+  const yieldMult = yieldModifierMultiplier(yieldModifier)
+  const arableSum = sumRasterOnCells(arableRaster, claimedCells, gridWidth)
+  const foodProduction = arableSum * yieldMult
+  const timberSum = sumRasterOnCells(timberRaster, claimedCells, gridWidth)
+
+  const hasFreshwater =
+    freshwaterClassification != null &&
+    claimedCellsHaveFreshwater(freshwaterClassification, claimedCells, gridWidth)
+
+  const foodCap = Math.floor(foodProduction * PEOPLE_PER_ARABLE_UNIT)
+  const timberCap = Math.floor(timberSum * PEOPLE_PER_TIMBER_UNIT)
+  let populationCeiling = Math.min(foodCap, timberCap)
+  if (!hasFreshwater) {
+    populationCeiling = 0
+  }
+
+  const canSustain = hasFreshwater && populationCeiling > 0
+  const clampedPopulation = Math.max(0, Math.min(Math.floor(population), populationCeiling))
+  const effectiveFoodCapacity =
+    foodProduction * PEOPLE_PER_ARABLE_UNIT * clampSpoilage(saltSpoilageMultiplier)
+  const foodConsumption = clampedPopulation
+  const foodSurplus = effectiveFoodCapacity - foodConsumption
+
+  return {
+    foodProduction,
+    timberSum,
+    hasFreshwater,
+    populationCeiling,
+    foodConsumption,
+    foodSurplus,
+    population: clampedPopulation,
+    tier: settlementTierFromPopulation(clampedPopulation),
+    canSustain,
+  }
+}
+
+/**
+ * Apply one survival triad resolve to a living settlement using claim cells.
+ *
+ * @param {{
+ *   settlement: { id: string, x: number, y: number, population: number, status?: string },
+ *   claimedCells: ReadonlyArray<{ x: number, y: number }>,
+ *   colonistSettings: { yieldModifier: string },
+ *   worldDocument: import('../types.js').WorldDocument,
+ *   saltSpoilageMultiplier?: number,
+ * }} params
+ * @returns {{ settlement: object, survival: SurvivalTriadResult }}
+ */
+export function applySurvivalResolveToSettlement(params) {
+  const { settlement, claimedCells, colonistSettings, worldDocument, saltSpoilageMultiplier } =
+    params
+  const freshwaterClassification = deriveFreshwaterAvailabilityFromDocument(worldDocument)
+  const survival = resolveSurvivalTriad({
+    claimedCells,
+    gridWidth: worldDocument.gridWidth,
+    arableRaster: worldDocument.arableRaster,
+    timberRaster: worldDocument.timberRaster,
+    yieldModifier: colonistSettings.yieldModifier,
+    freshwaterClassification,
+    population: settlement.population,
+    saltSpoilageMultiplier,
+  })
+
+  return {
+    settlement: {
+      ...settlement,
+      population: survival.population,
+      tier: survival.tier,
+    },
+    survival,
+  }
+}
+
+/**
+ * @param {number} multiplier
+ * @returns {number}
+ */
+function clampSpoilage(multiplier) {
+  if (!Number.isFinite(multiplier)) return 1
+  return Math.max(0, Math.min(1, multiplier))
+}

--- a/world-builder/core/colonization/resolveSurvivalTriad.test.js
+++ b/world-builder/core/colonization/resolveSurvivalTriad.test.js
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import {
+  PEOPLE_PER_ARABLE_UNIT,
+  PEOPLE_PER_TIMBER_UNIT,
+  applySurvivalResolveToSettlement,
+  resolveSurvivalTriad,
+  sumRasterOnCells,
+} from './resolveSurvivalTriad.js'
+import {
+  FRESHWATER_NONE,
+  FRESHWATER_SURFACE,
+  FRESHWATER_WELL_VIABLE,
+} from './freshwater/deriveFreshwaterAvailability.js'
+
+/**
+ * @param {Partial<{
+ *   claimedCells: Array<{ x: number, y: number }>,
+ *   arable: number[],
+ *   timber: number[],
+ *   freshwater: number[],
+ *   yieldModifier: string,
+ *   population: number,
+ *   saltSpoilageMultiplier: number,
+ * }>} overrides
+ */
+function triadParams(overrides = {}) {
+  const gridWidth = 3
+  const claimedCells = overrides.claimedCells ?? [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+  ]
+  return {
+    claimedCells,
+    gridWidth,
+    arableRaster: Float32Array.from(overrides.arable ?? [1, 1, 0]),
+    timberRaster: Float32Array.from(overrides.timber ?? [1, 1, 0]),
+    yieldModifier: overrides.yieldModifier ?? 'typical',
+    freshwaterClassification: Uint8Array.from(
+      overrides.freshwater ?? [FRESHWATER_SURFACE, FRESHWATER_NONE, FRESHWATER_NONE],
+    ),
+    population: overrides.population ?? 50,
+    saltSpoilageMultiplier: overrides.saltSpoilageMultiplier ?? 1,
+  }
+}
+
+test('sumRasterOnCells sums only claimed cells', () => {
+  const raster = Float32Array.from([2, 3, 4])
+  assert.strictEqual(sumRasterOnCells(raster, [{ x: 0, y: 0 }, { x: 2, y: 0 }], 3), 6)
+})
+
+test('resolveSurvivalTriad food production equals arable sum times yield modifier', () => {
+  const result = resolveSurvivalTriad(triadParams({ arable: [2, 1, 0], yieldModifier: 'typical' }))
+  assert.strictEqual(result.foodProduction, 3)
+  assert.strictEqual(result.populationCeiling, Math.min(3 * PEOPLE_PER_ARABLE_UNIT, 2 * PEOPLE_PER_TIMBER_UNIT))
+})
+
+test('resolveSurvivalTriad applies yield modifier to food production and ceiling input', () => {
+  const typical = resolveSurvivalTriad(
+    triadParams({ arable: [2, 0, 0], timber: [10, 0, 0], yieldModifier: 'typical' }),
+  )
+  const bountiful = resolveSurvivalTriad(
+    triadParams({ arable: [2, 0, 0], timber: [10, 0, 0], yieldModifier: 'bountiful' }),
+  )
+  assert.ok(bountiful.foodProduction > typical.foodProduction)
+  assert.ok(bountiful.populationCeiling > typical.populationCeiling)
+})
+
+test('resolveSurvivalTriad freshwater gate uses shared classification', () => {
+  const watered = resolveSurvivalTriad(
+    triadParams({ freshwater: [FRESHWATER_WELL_VIABLE, FRESHWATER_NONE, FRESHWATER_NONE] }),
+  )
+  const dry = resolveSurvivalTriad(
+    triadParams({ freshwater: [FRESHWATER_NONE, FRESHWATER_NONE, FRESHWATER_NONE] }),
+  )
+  assert.strictEqual(watered.hasFreshwater, true)
+  assert.strictEqual(dry.hasFreshwater, false)
+  assert.strictEqual(dry.populationCeiling, 0)
+  assert.strictEqual(dry.canSustain, false)
+  assert.strictEqual(dry.population, 0)
+})
+
+test('resolveSurvivalTriad timber scarcity binds ceiling below food', () => {
+  const result = resolveSurvivalTriad(
+    triadParams({
+      arable: [10, 10, 0],
+      timber: [0.1, 0, 0],
+      population: 1000,
+    }),
+  )
+  const foodCap = 20 * PEOPLE_PER_ARABLE_UNIT
+  const timberCap = 0.1 * PEOPLE_PER_TIMBER_UNIT
+  assert.ok(timberCap < foodCap)
+  assert.strictEqual(result.populationCeiling, Math.floor(timberCap))
+  assert.strictEqual(result.population, Math.floor(timberCap))
+})
+
+test('resolveSurvivalTriad clamps starting population and sets tier from absolute bands', () => {
+  const result = resolveSurvivalTriad(
+    triadParams({ population: 10_000, arable: [0.2, 0, 0], timber: [0.2, 0, 0] }),
+  )
+  assert.ok(result.population <= result.populationCeiling)
+  assert.ok(result.population < 10_000)
+  assert.strictEqual(result.tier, 'outpost')
+  assert.ok(result.population >= 1)
+})
+
+test('resolveSurvivalTriad is deterministic for identical inputs', () => {
+  const a = resolveSurvivalTriad(triadParams({ population: 80 }))
+  const b = resolveSurvivalTriad(triadParams({ population: 80 }))
+  assert.deepStrictEqual(a, b)
+})
+
+test('applySurvivalResolveToSettlement uses document rasters and freshwater derive', () => {
+  const cellCount = 4
+  const worldDocument = {
+    gridWidth: 2,
+    gridHeight: 2,
+    arableRaster: Float32Array.from([1, 1, 0, 0]),
+    timberRaster: Float32Array.from([1, 1, 0, 0]),
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array([BIOMES.GRASSLAND, BIOMES.GRASSLAND, BIOMES.GRASSLAND, BIOMES.GRASSLAND]),
+    riverCorridorMask: Uint8Array.from([1, 0, 0, 0]),
+    lakeMask: new Uint8Array(cellCount),
+  }
+
+  const { settlement, survival } = applySurvivalResolveToSettlement({
+    settlement: { id: 's1', x: 0, y: 0, population: 500, status: 'living' },
+    claimedCells: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ],
+    colonistSettings: { yieldModifier: 'typical' },
+    worldDocument,
+  })
+
+  assert.strictEqual(survival.hasFreshwater, true)
+  assert.ok(settlement.population <= survival.populationCeiling)
+  assert.ok(settlement.tier != null)
+})

--- a/world-builder/core/colonization/saltSpoilageMultiplier.js
+++ b/world-builder/core/colonization/saltSpoilageMultiplier.js
@@ -1,0 +1,45 @@
+/** Effective surplus scale with no salt access on claimed cells (implementation tuning). */
+export const MIN_SALT_SPOILAGE_MULTIPLIER = 0.35
+/** How quickly claimed salt node scores restore surplus toward full (implementation tuning). */
+export const SALT_ACCESS_SCALE = 0.4
+
+/**
+ * Salt spoilage tax on effective food surplus — not a population-ceiling min() leg.
+ *
+ * @param {ReadonlyArray<{ x: number, y: number }>} claimedCells
+ * @param {ReadonlyArray<{ x: number, y: number, score?: number }> | null | undefined} saltNodes
+ * @returns {number} multiplier in [MIN_SALT_SPOILAGE_MULTIPLIER, 1]
+ */
+export function saltSpoilageMultiplier(claimedCells, saltNodes) {
+  if (!saltNodes?.length || claimedCells.length === 0) {
+    return MIN_SALT_SPOILAGE_MULTIPLIER
+  }
+
+  const claimed = new Set(claimedCells.map((cell) => `${cell.x},${cell.y}`))
+  let access = 0
+  for (const node of saltNodes) {
+    if (!claimed.has(`${node.x},${node.y}`)) continue
+    const score = Number.isFinite(node.score) ? /** @type {number} */ (node.score) : 1
+    if (score > 0) {
+      access += score
+    }
+  }
+
+  if (access <= 0) {
+    return MIN_SALT_SPOILAGE_MULTIPLIER
+  }
+
+  return Math.min(1, MIN_SALT_SPOILAGE_MULTIPLIER + access * SALT_ACCESS_SCALE)
+}
+
+/**
+ * Default salt spoilage resolver for colonization ticks.
+ *
+ * @param {object} _settlement
+ * @param {ReadonlyArray<{ x: number, y: number }>} claimedCells
+ * @param {import('../types.js').WorldDocument} worldDocument
+ * @returns {number}
+ */
+export function saltSpoilageMultiplierForSettlement(_settlement, claimedCells, worldDocument) {
+  return saltSpoilageMultiplier(claimedCells, worldDocument.saltNodes)
+}

--- a/world-builder/core/colonization/saltSpoilageMultiplier.test.js
+++ b/world-builder/core/colonization/saltSpoilageMultiplier.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { BIOMES } from '../biomeIds.js'
+import { applyColonizationEpoch } from './applyColonizationEpoch.js'
+import { beginColonizationCommit } from './beginColonizationCommit.js'
+import {
+  COLONIZATION_PHASE_SETUP,
+  createDefaultColonizationSlice,
+} from './createDefaultColonizationSlice.js'
+import {
+  MIN_SALT_SPOILAGE_MULTIPLIER,
+  saltSpoilageMultiplier,
+} from './saltSpoilageMultiplier.js'
+import { resolveSurvivalTriad } from './resolveSurvivalTriad.js'
+import { FRESHWATER_SURFACE } from './freshwater/deriveFreshwaterAvailability.js'
+
+test('saltSpoilageMultiplier is minimal without salt on claimed cells', () => {
+  assert.strictEqual(
+    saltSpoilageMultiplier([{ x: 0, y: 0 }], [{ x: 5, y: 5, score: 1 }]),
+    MIN_SALT_SPOILAGE_MULTIPLIER,
+  )
+})
+
+test('saltSpoilageMultiplier rises with claimed salt access', () => {
+  const poor = saltSpoilageMultiplier([{ x: 0, y: 0 }], [])
+  const rich = saltSpoilageMultiplier([{ x: 0, y: 0 }], [{ x: 0, y: 0, score: 1 }])
+  assert.ok(rich > poor)
+  assert.ok(rich <= 1)
+})
+
+test('salt spoilage reduces effective surplus vs salt-rich control', () => {
+  const base = {
+    claimedCells: [{ x: 0, y: 0 }],
+    gridWidth: 1,
+    arableRaster: Float32Array.from([2]),
+    timberRaster: Float32Array.from([2]),
+    yieldModifier: 'typical',
+    freshwaterClassification: Uint8Array.from([FRESHWATER_SURFACE]),
+    population: 50,
+  }
+  const poor = resolveSurvivalTriad({ ...base, saltSpoilageMultiplier: MIN_SALT_SPOILAGE_MULTIPLIER })
+  const rich = resolveSurvivalTriad({ ...base, saltSpoilageMultiplier: 1 })
+  assert.ok(poor.foodSurplus < rich.foodSurplus)
+  assert.strictEqual(poor.populationCeiling, rich.populationCeiling)
+})
+
+function geographyWithSalt(saltNodes) {
+  const cellCount = 16
+  return {
+    geographySeed: 9,
+    gridWidth: 4,
+    gridHeight: 4,
+    arableRaster: new Float32Array(cellCount).fill(2),
+    timberRaster: new Float32Array(cellCount).fill(2),
+    saltNodes,
+    fields: {
+      elevation: new Float32Array(cellCount).fill(0.5),
+      temperature: new Float32Array(cellCount).fill(0.5),
+      rainfall: new Float32Array(cellCount).fill(0.6),
+      drainage: new Float32Array(cellCount).fill(0.2),
+      salinity: new Float32Array(cellCount).fill(0.1),
+    },
+    biomes: new Uint8Array(cellCount).fill(BIOMES.GRASSLAND),
+    lakeMask: new Uint8Array(cellCount),
+    riverCorridorMask: Uint8Array.from({ length: cellCount }, (_, i) => (i === 5 ? 1 : 0)),
+  }
+}
+
+test('salt-poor fixture grows slower than salt-rich control', () => {
+  const build = (saltNodes) => {
+    const slice = createDefaultColonizationSlice()
+    slice.colonizationPhase = COLONIZATION_PHASE_SETUP
+    slice.foundingLanding = { x: 1, y: 1 }
+    slice.colonistSettings.startingPopulation = 40
+    slice.colonistSettings.threeDayHaulDistance = 2
+    const doc = geographyWithSalt(saltNodes)
+    let running = beginColonizationCommit(slice, doc)
+    for (let i = 0; i < 5; i += 1) {
+      running = applyColonizationEpoch(running, doc).slice
+    }
+    return running.settlements[0].population
+  }
+
+  const poorPop = build([])
+  const richPop = build([{ id: 'salt-0', x: 1, y: 1, score: 1 }])
+  assert.ok(richPop > poorPop)
+})

--- a/world-builder/core/colonization/settlementTierFromPopulation.js
+++ b/world-builder/core/colonization/settlementTierFromPopulation.js
@@ -1,0 +1,31 @@
+/**
+ * Absolute headcount bands for settlement tier keys (not display labels).
+ * Population 0 is not a living tier seat.
+ *
+ * @type {ReadonlyArray<{ tier: string, min: number }>}
+ */
+export const SETTLEMENT_TIER_THRESHOLDS = Object.freeze([
+  { tier: 'outpost', min: 1 },
+  { tier: 'hamlet', min: 50 },
+  { tier: 'village', min: 200 },
+  { tier: 'town', min: 1000 },
+  { tier: 'city', min: 5000 },
+])
+
+/**
+ * @param {number} population
+ * @returns {string | null}
+ */
+export function settlementTierFromPopulation(population) {
+  if (!Number.isFinite(population) || population < 1) {
+    return null
+  }
+
+  let tier = SETTLEMENT_TIER_THRESHOLDS[0].tier
+  for (const band of SETTLEMENT_TIER_THRESHOLDS) {
+    if (population >= band.min) {
+      tier = band.tier
+    }
+  }
+  return tier
+}

--- a/world-builder/core/colonization/settlementTierFromPopulation.test.js
+++ b/world-builder/core/colonization/settlementTierFromPopulation.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  SETTLEMENT_TIER_THRESHOLDS,
+  settlementTierFromPopulation,
+} from './settlementTierFromPopulation.js'
+
+test('settlementTierFromPopulation returns null below living headcount', () => {
+  assert.strictEqual(settlementTierFromPopulation(0), null)
+  assert.strictEqual(settlementTierFromPopulation(-1), null)
+})
+
+test('settlementTierFromPopulation maps absolute headcount bands', () => {
+  for (let i = 0; i < SETTLEMENT_TIER_THRESHOLDS.length; i += 1) {
+    const band = SETTLEMENT_TIER_THRESHOLDS[i]
+    const nextMin = SETTLEMENT_TIER_THRESHOLDS[i + 1]?.min
+    assert.strictEqual(settlementTierFromPopulation(band.min), band.tier)
+    if (nextMin != null) {
+      assert.strictEqual(settlementTierFromPopulation(nextMin - 1), band.tier)
+    }
+  }
+})

--- a/world-builder/core/terrainCacheFingerprint.js
+++ b/world-builder/core/terrainCacheFingerprint.js
@@ -1,4 +1,7 @@
-import { omitColonizationSliceFields } from './colonization/createDefaultColonizationSlice.js'
+import {
+  COLONIZATION_DERIVED_WORLD_DOCUMENT_KEYS,
+  omitColonizationSliceFields,
+} from './colonization/createDefaultColonizationSlice.js'
 
 /**
  * Stable identity for a generated landmass (seed + generation controls).
@@ -23,5 +26,9 @@ export function buildTerrainCacheFingerprint(input) {
  * @returns {import('./types.js').WorldDocument}
  */
 export function stripColonizationFromWorldDocument(doc) {
-  return omitColonizationSliceFields(doc)
+  const stripped = omitColonizationSliceFields(doc)
+  for (const key of COLONIZATION_DERIVED_WORLD_DOCUMENT_KEYS) {
+    delete stripped[key]
+  }
+  return stripped
 }

--- a/world-builder/docs/SEAM-TEST-CATALOG.md
+++ b/world-builder/docs/SEAM-TEST-CATALOG.md
@@ -54,7 +54,7 @@
 |------|------|-----------|------------------|
 | `useWorldBuilderGeneration.test.js` | `generation-composable` | Pipeline cancellation semantics | None — runs under npm run test:world-builder |
 | `useWorldBuilderOverlayState.test.js` | `overlay-composable` | toggleVisibility updates owner state and syncs viewport; +5 additional cases | None — runs under npm run test:world-builder |
-| `useWorldBuilderPageController.test.js` | `page-controller` | Pipeline cancellation semantics; Seed determinism | None — runs under npm run test:world-builder |
+| `useWorldBuilderPageController.test.js` | `page-controller` | Pipeline cancellation semantics; Seed determinism; colonization phase machine; epoch step wiring | None — runs under npm run test:world-builder |
 
 ### `world-builder/core/`
 
@@ -70,6 +70,20 @@
 | `coast/computeCoastNavigability.test.js` | `core-unit` | computeCoastNavigability is zero on interior land cells; +3 additional cases | None — runs under npm run test:world-builder |
 | `coast/computeCoastalProximity.test.js` | `core-unit` | computeCoastalProximityOnLand is zero on ocean cells; +3 additional cases | None — runs under npm run test:world-builder |
 | `coast/deriveCoastalNodes.test.js` | `core-unit` | deriveCoastalNodes excludes river mouths within the map edge margin | None — runs under npm run test:world-builder |
+| `colonization/applyColonizationEpoch.test.js` | `core-unit` | Annual tick order; surplus-driven population; ceiling clamp; no auto-stop | None — runs under npm run test:world-builder |
+| `colonization/applyEpochStep.test.js` | `core-unit` | Epoch batch advance; present-day tip retention; quiet intra-batch years omitted | None — runs under npm run test:world-builder |
+| `colonization/applyRuin.test.js` | `core-unit` | Population 0 → ruin; claim release; abandonment tip with claim map | None — runs under npm run test:world-builder |
+| `colonization/beginColonizationCommit.test.js` | `core-unit` | Commit resolve; founding tip; survival clamp; dynasty; claim map | None — runs under npm run test:world-builder |
+| `colonization/collapsePopulation.test.js` | `core-unit` | Core + hinterland collapse; claimed cells only; determinism | None — runs under npm run test:world-builder |
+| `colonization/computeHaulShedIsochrone.test.js` | `core-unit` | Movement-cost isochrone; circle fallback; uphill budget shrink | None — runs under npm run test:world-builder |
+| `colonization/computeHaulShedReachPreview.test.js` | `core-unit` | Setup haul-shed preview shares isochrone seam | None — runs under npm run test:world-builder |
+| `colonization/computePrimaryClaimMap.test.js` | `core-unit` | Exclusive primary claim; ruin pins ignored; tip serialization | None — runs under npm run test:world-builder |
+| `colonization/createDefaultColonizationSlice.test.js` | `core-unit` | Colonization slice defaults and clone independence | None — runs under npm run test:world-builder |
+| `colonization/createFoundingDynasty.test.js` | `core-unit` | Dynasty labelKey shape from landing geography heuristic | None — runs under npm run test:world-builder |
+| `colonization/freshwater/deriveFreshwaterAvailability.test.js` | `core-unit` | Surface vs well-viable classification; shared freshwater gate | None — runs under npm run test:world-builder |
+| `colonization/resolveSurvivalTriad.test.js` | `core-unit` | Food/timber/freshwater triad; ceiling; commit clamp | None — runs under npm run test:world-builder |
+| `colonization/saltSpoilageMultiplier.test.js` | `core-unit` | Salt spoilage tax on surplus (not ceiling min) | None — runs under npm run test:world-builder |
+| `colonization/settlementTierFromPopulation.test.js` | `core-unit` | Absolute headcount tier bands | None — runs under npm run test:world-builder |
 | `derivePrevailingWindFromSeed.test.js` | `core-unit` | Seed determinism | None — runs under npm run test:world-builder |
 | `derivedGeographyPipeline.arable.test.js` | `landmass-pipeline` | Seed determinism | None — runs under npm run test:world-builder |
 | `derivedGeographyPipeline.metals.test.js` | `landmass-pipeline` | Seed determinism | None — runs under npm run test:world-builder |

--- a/world-builder/renderer/buildFreshwaterOverlayRgba.js
+++ b/world-builder/renderer/buildFreshwaterOverlayRgba.js
@@ -1,0 +1,64 @@
+import {
+  FRESHWATER_NONE,
+  deriveFreshwaterAvailabilityFromDocument,
+} from '../core/colonization/freshwater/deriveFreshwaterAvailability.js'
+import {
+  incrementResourceRasterOverlayRgbaBuildCount,
+  resourceRasterOverlayCanvasFromRgba,
+} from './buildResourceRasterOverlayRgba.js'
+
+/** Cyan freshwater overlay tint. */
+export const FRESHWATER_OVERLAY_RGB = [0, 200, 255]
+
+/** Freshwater overlay fill alpha on available cells. */
+export const FRESHWATER_OVERLAY_ALPHA = 0.65
+
+/**
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {Uint8ClampedArray | null}
+ */
+export function buildFreshwaterOverlayRgba(worldDocument) {
+  incrementResourceRasterOverlayRgbaBuildCount()
+  const classification = deriveFreshwaterAvailabilityFromDocument(worldDocument)
+  if (!classification) {
+    return null
+  }
+
+  let hasSetCell = false
+  for (let i = 0; i < classification.length; i += 1) {
+    if (classification[i] !== FRESHWATER_NONE) {
+      hasSetCell = true
+      break
+    }
+  }
+  if (!hasSetCell) {
+    return null
+  }
+
+  const { gridWidth, gridHeight } = worldDocument
+  const rgba = new Uint8ClampedArray(gridWidth * gridHeight * 4)
+  const alphaByte = Math.round(FRESHWATER_OVERLAY_ALPHA * 255)
+  for (let i = 0; i < classification.length; i += 1) {
+    if (classification[i] === FRESHWATER_NONE) continue
+    const base = i * 4
+    rgba[base] = FRESHWATER_OVERLAY_RGB[0]
+    rgba[base + 1] = FRESHWATER_OVERLAY_RGB[1]
+    rgba[base + 2] = FRESHWATER_OVERLAY_RGB[2]
+    rgba[base + 3] = alphaByte
+  }
+  return rgba
+}
+
+/**
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {HTMLCanvasElement | null}
+ */
+export function buildFreshwaterOverlayCanvas(worldDocument) {
+  const rgba = buildFreshwaterOverlayRgba(worldDocument)
+  if (!rgba) {
+    return null
+  }
+
+  const { gridWidth, gridHeight } = worldDocument
+  return resourceRasterOverlayCanvasFromRgba(rgba, gridWidth, gridHeight)
+}

--- a/world-builder/renderer/buildPopulationOverlayRgba.js
+++ b/world-builder/renderer/buildPopulationOverlayRgba.js
@@ -6,11 +6,11 @@ import {
 /** Magenta population overlay tint. */
 export const POPULATION_OVERLAY_RGB = [255, 64, 160]
 
-/** Floor alpha for the sparsest occupied cell (still readable, not a solid disc). */
-export const POPULATION_OVERLAY_MIN_ALPHA = 0.14
+/** Alpha for the sparsest occupied cell (count >= 1). */
+export const POPULATION_OVERLAY_MIN_ALPHA = 0.35
 
 /** Max alpha for the densest population cell. */
-export const POPULATION_OVERLAY_MAX_ALPHA = 0.9
+export const POPULATION_OVERLAY_MAX_ALPHA = 0.95
 
 /**
  * @param {number} value
@@ -18,7 +18,7 @@ export const POPULATION_OVERLAY_MAX_ALPHA = 0.9
  * @returns {number} alpha in 0..1
  */
 export function populationOverlayAlphaForValue(value, maxValue) {
-  if (!(value > 0) || !(maxValue > 0)) {
+  if (!(value >= 1) || !(maxValue > 0)) {
     return 0
   }
   const t = Math.min(1, value / maxValue)
@@ -29,6 +29,8 @@ export function populationOverlayAlphaForValue(value, maxValue) {
 }
 
 /**
+ * Scatter paint: only cells with integer count >= 1.
+ *
  * @param {import('../core/types.js').WorldDocument} worldDocument
  * @returns {Uint8ClampedArray | null}
  */
@@ -45,14 +47,14 @@ export function buildPopulationOverlayRgba(worldDocument) {
       maxValue = populationCollapseRaster[i]
     }
   }
-  if (maxValue <= 0) {
+  if (maxValue < 1) {
     return null
   }
 
   const rgba = new Uint8ClampedArray(gridWidth * gridHeight * 4)
   for (let i = 0; i < populationCollapseRaster.length; i += 1) {
     const value = populationCollapseRaster[i]
-    if (value <= 0) continue
+    if (value < 1) continue
     const alphaByte = Math.round(populationOverlayAlphaForValue(value, maxValue) * 255)
     const base = i * 4
     rgba[base] = POPULATION_OVERLAY_RGB[0]

--- a/world-builder/renderer/buildPopulationOverlayRgba.js
+++ b/world-builder/renderer/buildPopulationOverlayRgba.js
@@ -1,0 +1,76 @@
+import {
+  incrementResourceRasterOverlayRgbaBuildCount,
+  resourceRasterOverlayCanvasFromRgba,
+} from './buildResourceRasterOverlayRgba.js'
+
+/** Magenta population overlay tint. */
+export const POPULATION_OVERLAY_RGB = [255, 64, 160]
+
+/** Floor alpha for the sparsest occupied cell (still readable, not a solid disc). */
+export const POPULATION_OVERLAY_MIN_ALPHA = 0.14
+
+/** Max alpha for the densest population cell. */
+export const POPULATION_OVERLAY_MAX_ALPHA = 0.9
+
+/**
+ * @param {number} value
+ * @param {number} maxValue
+ * @returns {number} alpha in 0..1
+ */
+export function populationOverlayAlphaForValue(value, maxValue) {
+  if (!(value > 0) || !(maxValue > 0)) {
+    return 0
+  }
+  const t = Math.min(1, value / maxValue)
+  return (
+    POPULATION_OVERLAY_MIN_ALPHA +
+    (POPULATION_OVERLAY_MAX_ALPHA - POPULATION_OVERLAY_MIN_ALPHA) * Math.sqrt(t)
+  )
+}
+
+/**
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {Uint8ClampedArray | null}
+ */
+export function buildPopulationOverlayRgba(worldDocument) {
+  incrementResourceRasterOverlayRgbaBuildCount()
+  const { gridWidth, gridHeight, populationCollapseRaster } = worldDocument
+  if (!populationCollapseRaster || populationCollapseRaster.length !== gridWidth * gridHeight) {
+    return null
+  }
+
+  let maxValue = 0
+  for (let i = 0; i < populationCollapseRaster.length; i += 1) {
+    if (populationCollapseRaster[i] > maxValue) {
+      maxValue = populationCollapseRaster[i]
+    }
+  }
+  if (maxValue <= 0) {
+    return null
+  }
+
+  const rgba = new Uint8ClampedArray(gridWidth * gridHeight * 4)
+  for (let i = 0; i < populationCollapseRaster.length; i += 1) {
+    const value = populationCollapseRaster[i]
+    if (value <= 0) continue
+    const alphaByte = Math.round(populationOverlayAlphaForValue(value, maxValue) * 255)
+    const base = i * 4
+    rgba[base] = POPULATION_OVERLAY_RGB[0]
+    rgba[base + 1] = POPULATION_OVERLAY_RGB[1]
+    rgba[base + 2] = POPULATION_OVERLAY_RGB[2]
+    rgba[base + 3] = alphaByte
+  }
+  return rgba
+}
+
+/**
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {HTMLCanvasElement | null}
+ */
+export function buildPopulationOverlayCanvas(worldDocument) {
+  const rgba = buildPopulationOverlayRgba(worldDocument)
+  if (!rgba) {
+    return null
+  }
+  return resourceRasterOverlayCanvasFromRgba(rgba, worldDocument.gridWidth, worldDocument.gridHeight)
+}

--- a/world-builder/renderer/buildPopulationOverlayRgba.js
+++ b/world-builder/renderer/buildPopulationOverlayRgba.js
@@ -3,14 +3,14 @@ import {
   resourceRasterOverlayCanvasFromRgba,
 } from './buildResourceRasterOverlayRgba.js'
 
-/** Magenta population overlay tint. */
-export const POPULATION_OVERLAY_RGB = [255, 64, 160]
+/** Red population overlay tint. */
+export const POPULATION_OVERLAY_RGB = [220, 40, 40]
 
 /** Alpha for the sparsest occupied cell (count >= 1). */
-export const POPULATION_OVERLAY_MIN_ALPHA = 0.35
+export const POPULATION_OVERLAY_MIN_ALPHA = 0.62
 
 /** Max alpha for the densest population cell. */
-export const POPULATION_OVERLAY_MAX_ALPHA = 0.95
+export const POPULATION_OVERLAY_MAX_ALPHA = 1
 
 /**
  * @param {number} value

--- a/world-builder/renderer/buildPopulationOverlayRgba.test.js
+++ b/world-builder/renderer/buildPopulationOverlayRgba.test.js
@@ -12,7 +12,9 @@ import {
   populationOverlayAlphaForValue,
 } from './buildPopulationOverlayRgba.js'
 
-test('populationOverlayAlphaForValue keeps hinterland cells readable vs core', () => {
+test('populationOverlayAlphaForValue only paints integer counts', () => {
+  assert.strictEqual(populationOverlayAlphaForValue(0, 10), 0)
+  assert.strictEqual(populationOverlayAlphaForValue(0.5, 10), 0)
   const coreAlpha = populationOverlayAlphaForValue(35, 35)
   const hinterlandAlpha = populationOverlayAlphaForValue(1, 35)
   assert.ok(coreAlpha >= POPULATION_OVERLAY_MIN_ALPHA)
@@ -21,11 +23,12 @@ test('populationOverlayAlphaForValue keeps hinterland cells readable vs core', (
   assert.ok(hinterlandAlpha < coreAlpha)
 })
 
-test('buildPopulationOverlayRgba paints low-density hinterland above the min alpha floor', () => {
+test('buildPopulationOverlayRgba paints only occupied cells as a scatter', () => {
   resetResourceRasterOverlayRgbaBuildCount()
   const populationCollapseRaster = new Float32Array(9)
   populationCollapseRaster[4] = 35
   populationCollapseRaster[5] = 1
+  populationCollapseRaster[0] = 0.4
 
   const rgba = buildPopulationOverlayRgba({
     gridWidth: 3,
@@ -43,11 +46,19 @@ test('buildPopulationOverlayRgba paints low-density hinterland above the min alp
   assert.strictEqual(rgba[0 + 3], 0)
 })
 
-test('buildPopulationOverlayRgba returns null without a collapse raster', () => {
+test('buildPopulationOverlayRgba returns null without occupied cells', () => {
   resetResourceRasterOverlayRgbaBuildCount()
   assert.strictEqual(
     buildPopulationOverlayRgba({ gridWidth: 2, gridHeight: 2 }),
     null,
   )
-  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 1)
+  assert.strictEqual(
+    buildPopulationOverlayRgba({
+      gridWidth: 2,
+      gridHeight: 2,
+      populationCollapseRaster: new Float32Array(4),
+    }),
+    null,
+  )
+  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 2)
 })

--- a/world-builder/renderer/buildPopulationOverlayRgba.test.js
+++ b/world-builder/renderer/buildPopulationOverlayRgba.test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  getResourceRasterOverlayRgbaBuildCount,
+  resetResourceRasterOverlayRgbaBuildCount,
+} from './buildResourceRasterOverlayRgba.js'
+import {
+  POPULATION_OVERLAY_MAX_ALPHA,
+  POPULATION_OVERLAY_MIN_ALPHA,
+  POPULATION_OVERLAY_RGB,
+  buildPopulationOverlayRgba,
+  populationOverlayAlphaForValue,
+} from './buildPopulationOverlayRgba.js'
+
+test('populationOverlayAlphaForValue keeps hinterland cells readable vs core', () => {
+  const coreAlpha = populationOverlayAlphaForValue(35, 35)
+  const hinterlandAlpha = populationOverlayAlphaForValue(1, 35)
+  assert.ok(coreAlpha >= POPULATION_OVERLAY_MIN_ALPHA)
+  assert.ok(coreAlpha <= POPULATION_OVERLAY_MAX_ALPHA)
+  assert.ok(hinterlandAlpha >= POPULATION_OVERLAY_MIN_ALPHA)
+  assert.ok(hinterlandAlpha < coreAlpha)
+})
+
+test('buildPopulationOverlayRgba paints low-density hinterland above the min alpha floor', () => {
+  resetResourceRasterOverlayRgbaBuildCount()
+  const populationCollapseRaster = new Float32Array(9)
+  populationCollapseRaster[4] = 35
+  populationCollapseRaster[5] = 1
+
+  const rgba = buildPopulationOverlayRgba({
+    gridWidth: 3,
+    gridHeight: 3,
+    populationCollapseRaster,
+  })
+  assert.ok(rgba)
+  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 1)
+
+  const coreBase = 4 * 4
+  const hinterlandBase = 5 * 4
+  assert.strictEqual(rgba[coreBase], POPULATION_OVERLAY_RGB[0])
+  assert.ok(rgba[coreBase + 3] > rgba[hinterlandBase + 3])
+  assert.ok(rgba[hinterlandBase + 3] >= Math.round(POPULATION_OVERLAY_MIN_ALPHA * 255) - 1)
+  assert.strictEqual(rgba[0 + 3], 0)
+})
+
+test('buildPopulationOverlayRgba returns null without a collapse raster', () => {
+  resetResourceRasterOverlayRgbaBuildCount()
+  assert.strictEqual(
+    buildPopulationOverlayRgba({ gridWidth: 2, gridHeight: 2 }),
+    null,
+  )
+  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 1)
+})

--- a/world-builder/renderer/createWorldBuilderMapViewport.js
+++ b/world-builder/renderer/createWorldBuilderMapViewport.js
@@ -70,6 +70,10 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
   let riverTexture = null
   const sail = new Sprite(Texture.EMPTY)
   sail.visible = false
+  const freshwater = new Sprite(Texture.EMPTY)
+  freshwater.visible = false
+  const population = new Sprite(Texture.EMPTY)
+  population.visible = false
   const coastalOverlay = new Graphics()
   const metalOverlay = new Graphics()
   const saltOverlay = new Graphics()
@@ -96,6 +100,8 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
     timber: null,
     metals: null,
     sail: null,
+    freshwater: null,
+    population: null,
   }
 
   /** @type {Record<import('./resourceRasterOverlayRefresh.js').ResourceRasterOverlayLayerId, import('pixi.js').Sprite>} */
@@ -104,6 +110,8 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
     timber,
     metals,
     sail,
+    freshwater,
+    population,
   }
 
   const viewport = new Viewport({
@@ -123,6 +131,8 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
   viewport.addChild(lakes)
   viewport.addChild(rivers)
   viewport.addChild(sail)
+  viewport.addChild(freshwater)
+  viewport.addChild(population)
   viewport.addChild(coastalOverlay)
   viewport.addChild(metalOverlay)
   viewport.addChild(saltOverlay)
@@ -166,6 +176,12 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
       case 'sail':
         sail.visible = false
         break
+      case 'freshwater':
+        freshwater.visible = false
+        break
+      case 'population':
+        population.visible = false
+        break
       case 'rivers':
         rivers.visible = false
         break
@@ -194,6 +210,8 @@ export async function createWorldBuilderMapViewport(hostEl, worldDocument) {
       timber: () => refreshResourceRasterOverlay('timber', currentWorldDocument),
       metals: () => refreshResourceRasterOverlay('metals', currentWorldDocument),
       sail: () => refreshResourceRasterOverlay('sail', currentWorldDocument),
+      freshwater: () => refreshResourceRasterOverlay('freshwater', currentWorldDocument),
+      population: () => refreshResourceRasterOverlay('population', currentWorldDocument),
       rivers: () => refreshRiverOverlay(currentWorldDocument),
       lakes: () => refreshLakeOverlay(currentWorldDocument),
       coastalNodes: () => drawCoastalNodes(coastalOverlay, currentWorldDocument),

--- a/world-builder/renderer/diffWorldDocumentMapLayers.js
+++ b/world-builder/renderer/diffWorldDocumentMapLayers.js
@@ -173,6 +173,14 @@ export function diffWorldDocumentMapLayers(previous, next) {
   if (typedArrayContentChanged(previous.metalsRaster, next.metalsRaster)) {
     changedLayers.push('metals')
   }
+  if (
+    typedArrayContentChanged(
+      previous.populationCollapseRaster,
+      next.populationCollapseRaster,
+    )
+  ) {
+    changedLayers.push('population')
+  }
   if (riverLayerInputsChanged(previous, next)) {
     changedLayers.push('rivers')
   }

--- a/world-builder/renderer/diffWorldDocumentMapLayers.test.js
+++ b/world-builder/renderer/diffWorldDocumentMapLayers.test.js
@@ -94,6 +94,21 @@ test('diffWorldDocumentMapLayers detects resource raster changes only for affect
   assert.deepStrictEqual(diffWorldDocumentMapLayers(previous, nextTimber), ['timber'])
 })
 
+test('diffWorldDocumentMapLayers detects population collapse raster changes', () => {
+  const previous = baseDocument({
+    populationCollapseRaster: new Float32Array(16),
+  })
+  const next = baseDocument({
+    populationCollapseRaster: Float32Array.from({ length: 16 }, (_, i) => (i === 5 ? 12 : 0)),
+  })
+
+  assert.deepStrictEqual(diffWorldDocumentMapLayers(previous, next), ['population'])
+  assert.deepStrictEqual(
+    diffWorldDocumentMapLayers(previous, baseDocument({ populationCollapseRaster: null })),
+    ['population'],
+  )
+})
+
 test('diffWorldDocumentMapLayers detects hydrology and lake mask changes', () => {
   const previous = baseDocument()
   const nextLakes = baseDocument({

--- a/world-builder/renderer/mapLayerRefresh.js
+++ b/world-builder/renderer/mapLayerRefresh.js
@@ -1,4 +1,4 @@
-/** @typedef {'terrain' | 'contours' | 'arable' | 'timber' | 'metals' | 'sail' | 'rivers' | 'lakes' | 'coastalNodes' | 'metalNodes' | 'saltNodes'} MapLayerId */
+/** @typedef {'terrain' | 'contours' | 'arable' | 'timber' | 'metals' | 'sail' | 'freshwater' | 'population' | 'rivers' | 'lakes' | 'coastalNodes' | 'metalNodes' | 'saltNodes'} MapLayerId */
 
 /** @type {readonly MapLayerId[]} */
 export const ALL_MAP_LAYER_IDS = [
@@ -8,6 +8,8 @@ export const ALL_MAP_LAYER_IDS = [
   'timber',
   'metals',
   'sail',
+  'freshwater',
+  'population',
   'rivers',
   'lakes',
   'coastalNodes',

--- a/world-builder/renderer/resourceRasterOverlayRefresh.js
+++ b/world-builder/renderer/resourceRasterOverlayRefresh.js
@@ -155,6 +155,8 @@ export function refreshAllResourceRasterOverlayCanvases(context) {
     timber: null,
     metals: null,
     sail: null,
+    freshwater: null,
+    population: null,
   }
 
   for (const resourceId of RESOURCE_RASTER_OVERLAY_LAYER_IDS) {

--- a/world-builder/renderer/resourceRasterOverlayRefresh.js
+++ b/world-builder/renderer/resourceRasterOverlayRefresh.js
@@ -1,16 +1,20 @@
 import { buildArableOverlayRgba } from './buildArableOverlayCanvas.js'
+import { buildFreshwaterOverlayRgba } from './buildFreshwaterOverlayRgba.js'
 import { buildMetalsOverlayRgba } from './buildMetalsOverlayCanvas.js'
+import { buildPopulationOverlayRgba } from './buildPopulationOverlayRgba.js'
 import { buildSailOverlayRgba } from './buildSailOverlayRgba.js'
 import { buildTimberOverlayRgba } from './buildTimberOverlayCanvas.js'
 import { resourceRasterOverlayCanvasFromRgba } from './buildResourceRasterOverlayRgba.js'
 import { createResourceOverlayDefinitions } from '../resourceOverlays.js'
 import {
   resolveArableRasterLayerVisible,
+  resolveFreshwaterRasterLayerVisible,
+  resolvePopulationRasterLayerVisible,
   resolveResourceRasterLayerVisible,
   resolveSailRasterLayerVisible,
 } from './worldBuilderMapViewportModel.js'
 
-/** @typedef {'arable' | 'timber' | 'metals' | 'sail'} ResourceRasterOverlayLayerId */
+/** @typedef {'arable' | 'timber' | 'metals' | 'sail' | 'freshwater' | 'population'} ResourceRasterOverlayLayerId */
 
 /**
  * @typedef {Object} ResourceRasterOverlayRefreshContext
@@ -52,6 +56,18 @@ export const RESOURCE_RASTER_OVERLAY_REGISTRY = {
     resolveVisible: (visibility, worldDocument) =>
       resolveSailRasterLayerVisible(visibility, worldDocument),
     buildRgba: (worldDocument) => buildSailOverlayRgba(worldDocument),
+  },
+  freshwater: {
+    id: 'freshwater',
+    resolveVisible: (visibility, worldDocument) =>
+      resolveFreshwaterRasterLayerVisible(visibility, worldDocument),
+    buildRgba: (worldDocument) => buildFreshwaterOverlayRgba(worldDocument),
+  },
+  population: {
+    id: 'population',
+    resolveVisible: (visibility, worldDocument) =>
+      resolvePopulationRasterLayerVisible(visibility, worldDocument),
+    buildRgba: (worldDocument) => buildPopulationOverlayRgba(worldDocument),
   },
 }
 

--- a/world-builder/renderer/resourceRasterOverlayRefresh.test.js
+++ b/world-builder/renderer/resourceRasterOverlayRefresh.test.js
@@ -67,6 +67,34 @@ function createSailFixture() {
   }
 }
 
+function createFreshwaterFixture() {
+  const cellCount = 64
+  const rainfall = new Float32Array(cellCount).fill(0.6)
+  const drainage = new Float32Array(cellCount).fill(0.2)
+  const salinity = new Float32Array(cellCount).fill(0.1)
+  const elevation = new Float32Array(cellCount).fill(0.5)
+  const biomes = new Uint8Array(cellCount).fill(2)
+  const riverCorridorMask = new Uint8Array(cellCount)
+  riverCorridorMask[36] = 1
+  return {
+    gridWidth: 8,
+    gridHeight: 8,
+    fields: { rainfall, drainage, salinity, elevation },
+    biomes,
+    riverCorridorMask,
+  }
+}
+
+function createPopulationFixture() {
+  const populationCollapseRaster = new Float32Array(64)
+  populationCollapseRaster[36] = 20
+  return {
+    gridWidth: 8,
+    gridHeight: 8,
+    populationCollapseRaster,
+  }
+}
+
 function createUnifiedRasterFixture() {
   const cellCount = 64
   const arableRaster = new Float32Array(cellCount)
@@ -76,21 +104,36 @@ function createUnifiedRasterFixture() {
   const metalsRaster = new Float32Array(cellCount)
   metalsRaster[36] = 0.85
   const elevation = new Float32Array(cellCount).fill(0.5)
+  const rainfall = new Float32Array(cellCount).fill(0.6)
+  const drainage = new Float32Array(cellCount).fill(0.2)
+  const salinity = new Float32Array(cellCount).fill(0.1)
+  const biomes = new Uint8Array(cellCount).fill(2)
   const riverCorridorMask = new Uint8Array(cellCount)
   riverCorridorMask[36] = 1
+  const populationCollapseRaster = new Float32Array(cellCount)
+  populationCollapseRaster[36] = 20
   return {
     gridWidth: 8,
     gridHeight: 8,
     arableRaster,
     timberRaster,
     metalsRaster,
-    fields: { elevation },
+    fields: { elevation, rainfall, drainage, salinity },
+    biomes,
     riverCorridorMask,
+    populationCollapseRaster,
   }
 }
 
 test('RESOURCE_RASTER_OVERLAY_LAYER_IDS lists raster overlay layers from definitions', () => {
-  assert.deepStrictEqual(RESOURCE_RASTER_OVERLAY_LAYER_IDS, ['arable', 'timber', 'metals', 'sail'])
+  assert.deepStrictEqual(RESOURCE_RASTER_OVERLAY_LAYER_IDS, [
+    'arable',
+    'timber',
+    'metals',
+    'sail',
+    'freshwater',
+    'population',
+  ])
 })
 
 test('isResourceRasterOverlayLayerId identifies raster layers only', () => {
@@ -98,6 +141,8 @@ test('isResourceRasterOverlayLayerId identifies raster layers only', () => {
   assert.strictEqual(isResourceRasterOverlayLayerId('timber'), true)
   assert.strictEqual(isResourceRasterOverlayLayerId('metals'), true)
   assert.strictEqual(isResourceRasterOverlayLayerId('sail'), true)
+  assert.strictEqual(isResourceRasterOverlayLayerId('freshwater'), true)
+  assert.strictEqual(isResourceRasterOverlayLayerId('population'), true)
   assert.strictEqual(isResourceRasterOverlayLayerId('salt'), false)
 })
 
@@ -174,7 +219,11 @@ test('refreshResourceRasterOverlayCanvas performs at most one RGBA build per lay
           ? createTimberFixture()
           : resourceId === 'metals'
             ? createMetalsFixture()
-            : createSailFixture()
+            : resourceId === 'freshwater'
+              ? createFreshwaterFixture()
+              : resourceId === 'population'
+                ? createPopulationFixture()
+                : createSailFixture()
     const visibility = applyResourceOverlayVisibility(
       createDefaultResourceOverlayVisibility(),
       resourceId,
@@ -232,6 +281,8 @@ test('refreshAllResourceRasterOverlayCanvases rasterizes only visible layers onc
   assert.strictEqual(hiddenCanvases.timber, null)
   assert.strictEqual(hiddenCanvases.metals, null)
   assert.strictEqual(hiddenCanvases.sail, null)
+  assert.strictEqual(hiddenCanvases.freshwater, null)
+  assert.strictEqual(hiddenCanvases.population, null)
   assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 0)
 
   let visibility = createDefaultResourceOverlayVisibility()
@@ -239,6 +290,8 @@ test('refreshAllResourceRasterOverlayCanvases rasterizes only visible layers onc
   visibility = applyResourceOverlayVisibility(visibility, 'timber', true)
   visibility = applyResourceOverlayVisibility(visibility, 'metals', true)
   visibility = applyResourceOverlayVisibility(visibility, 'sail', true)
+  visibility = applyResourceOverlayVisibility(visibility, 'freshwater', true)
+  visibility = applyResourceOverlayVisibility(visibility, 'population', true)
 
   resetResourceRasterOverlayRgbaBuildCount()
   const visibleCanvases = refreshAllResourceRasterOverlayCanvases({
@@ -250,7 +303,9 @@ test('refreshAllResourceRasterOverlayCanvases rasterizes only visible layers onc
   assert.ok(visibleCanvases.timber)
   assert.ok(visibleCanvases.metals)
   assert.ok(visibleCanvases.sail)
-  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 4)
+  assert.ok(visibleCanvases.freshwater)
+  assert.ok(visibleCanvases.population)
+  assert.strictEqual(getResourceRasterOverlayRgbaBuildCount(), 6)
 
   delete globalThis.document
   delete globalThis.ImageData

--- a/world-builder/renderer/resourceRasterOverlaySeamContract.test.js
+++ b/world-builder/renderer/resourceRasterOverlaySeamContract.test.js
@@ -39,6 +39,34 @@ function visibleRasterFixture(resourceId) {
     }
   }
 
+  if (resourceId === 'freshwater') {
+    const cellCount = 16
+    const rainfall = new Float32Array(cellCount).fill(0.6)
+    const drainage = new Float32Array(cellCount).fill(0.2)
+    const salinity = new Float32Array(cellCount).fill(0.1)
+    const elevation = new Float32Array(cellCount).fill(0.5)
+    const biomes = new Uint8Array(cellCount).fill(2)
+    const riverCorridorMask = new Uint8Array(cellCount)
+    riverCorridorMask[5] = 1
+    return {
+      gridWidth: 4,
+      gridHeight: 4,
+      fields: { rainfall, drainage, salinity, elevation },
+      biomes,
+      riverCorridorMask,
+    }
+  }
+
+  if (resourceId === 'population') {
+    const populationCollapseRaster = new Float32Array(16)
+    populationCollapseRaster[5] = 12
+    return {
+      gridWidth: 4,
+      gridHeight: 4,
+      populationCollapseRaster,
+    }
+  }
+
   const raster = new Float32Array(16)
   raster[5] = 0.8
   return {

--- a/world-builder/renderer/worldBuilderMapViewportModel.js
+++ b/world-builder/renderer/worldBuilderMapViewportModel.js
@@ -1,6 +1,10 @@
 import { hasDrawableResourceRasterOverlayPixels } from './buildResourceRasterOverlayRgba.js'
 import { RESOURCE_RASTER_OVERLAY_STYLES } from './resourceRasterOverlayStyles.js'
 import { DEFAULT_WORLD_GENERATION_OPTIONS } from '../core/worldGenerationOptions.js'
+import {
+  FRESHWATER_NONE,
+  deriveFreshwaterAvailabilityFromDocument,
+} from '../core/colonization/freshwater/deriveFreshwaterAvailability.js'
 import { deriveSailOverlayMask } from '../core/sail/deriveSailOverlayMask.js'
 import {
   isResourceOverlayVisible,
@@ -102,4 +106,36 @@ export function resolveSailRasterLayerVisible(visibility, worldDocument) {
     seaLevel: DEFAULT_WORLD_GENERATION_OPTIONS.seaLevel,
   })
   return mask.some((value) => value === 1)
+}
+
+/**
+ * @param {Record<string, boolean>} visibility
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {boolean}
+ */
+export function resolveFreshwaterRasterLayerVisible(visibility, worldDocument) {
+  if (!isResourceOverlayVisible(visibility, 'freshwater')) {
+    return false
+  }
+  const classification = deriveFreshwaterAvailabilityFromDocument(worldDocument)
+  if (!classification) {
+    return false
+  }
+  return classification.some((value) => value !== FRESHWATER_NONE)
+}
+
+/**
+ * @param {Record<string, boolean>} visibility
+ * @param {import('../core/types.js').WorldDocument} worldDocument
+ * @returns {boolean}
+ */
+export function resolvePopulationRasterLayerVisible(visibility, worldDocument) {
+  if (!isResourceOverlayVisible(visibility, 'population')) {
+    return false
+  }
+  const raster = worldDocument.populationCollapseRaster
+  if (!raster || raster.length !== worldDocument.gridWidth * worldDocument.gridHeight) {
+    return false
+  }
+  return raster.some((value) => value > 0)
 }

--- a/world-builder/resourceOverlayState.test.js
+++ b/world-builder/resourceOverlayState.test.js
@@ -35,6 +35,8 @@ test('createResourceOverlayPageState defaults visibility off and uses persisted 
     metals: false,
     salt: false,
     sail: false,
+    freshwater: false,
+    population: false,
   })
   assert.strictEqual(state.displaySettings.arableMinimumProductivity, 0.25)
 })
@@ -158,6 +160,8 @@ test('normalizeResourceOverlayVisibility coerces null and undefined to false', (
       metals: false,
       salt: false,
       sail: false,
+      freshwater: false,
+      population: false,
     },
   )
 })
@@ -169,6 +173,8 @@ test('normalizeResourceOverlayVisibility fills missing overlay ids with false', 
     metals: false,
     salt: false,
     sail: false,
+    freshwater: false,
+    population: false,
   })
 })
 
@@ -197,6 +203,8 @@ test('commitResourceOverlayState normalizes visibility before sync', () => {
     metals: false,
     salt: false,
     sail: false,
+    freshwater: false,
+    population: false,
   })
   assert.deepStrictEqual(viewport.syncedStates[0].visibility, committed.visibility)
 })

--- a/world-builder/resourceOverlays.js
+++ b/world-builder/resourceOverlays.js
@@ -21,6 +21,8 @@ export function createResourceOverlayDefinitions() {
     { id: 'metals', kind: 'rasterAndNodes', label: 'Metals', vectorLayerId: 'metalNodes' },
     { id: 'salt', kind: 'nodes', label: 'Salt', vectorLayerId: 'saltNodes' },
     { id: 'sail', kind: 'raster', label: 'Sail' },
+    { id: 'freshwater', kind: 'raster', label: 'Freshwater' },
+    { id: 'population', kind: 'raster', label: 'Population' },
   ]
 }
 

--- a/world-builder/resourceOverlays.test.js
+++ b/world-builder/resourceOverlays.test.js
@@ -15,7 +15,7 @@ import {
 
 test('createResourceOverlayDefinitions lists canonical overlay ids and kinds', () => {
   const definitions = createResourceOverlayDefinitions()
-  assert.strictEqual(definitions.length, 5)
+  assert.strictEqual(definitions.length, 7)
   assert.deepStrictEqual(
     definitions.map((definition) => ({
       id: definition.id,
@@ -28,12 +28,22 @@ test('createResourceOverlayDefinitions lists canonical overlay ids and kinds', (
       { id: 'metals', kind: 'rasterAndNodes', vectorLayerId: 'metalNodes' },
       { id: 'salt', kind: 'nodes', vectorLayerId: 'saltNodes' },
       { id: 'sail', kind: 'raster', vectorLayerId: undefined },
+      { id: 'freshwater', kind: 'raster', vectorLayerId: undefined },
+      { id: 'population', kind: 'raster', vectorLayerId: undefined },
     ],
   )
 })
 
 test('createResourceOverlayIds returns canonical overlay ids in order', () => {
-  assert.deepStrictEqual(createResourceOverlayIds(), ['arable', 'timber', 'metals', 'salt', 'sail'])
+  assert.deepStrictEqual(createResourceOverlayIds(), [
+    'arable',
+    'timber',
+    'metals',
+    'salt',
+    'sail',
+    'freshwater',
+    'population',
+  ])
 })
 
 test('createDefaultResourceOverlayVisibility defaults every canonical overlay off', () => {
@@ -43,6 +53,8 @@ test('createDefaultResourceOverlayVisibility defaults every canonical overlay of
     metals: false,
     salt: false,
     sail: false,
+    freshwater: false,
+    population: false,
   })
 })
 

--- a/world-builder/worldBuilderPageModel.test.js
+++ b/world-builder/worldBuilderPageModel.test.js
@@ -290,7 +290,7 @@ test('formatHydrologyMetricValue renders null as n/a', () => {
 
 test('createResourceOverlayDefinitions lists canonical overlay ids and kinds', () => {
   const definitions = createResourceOverlayDefinitions()
-  assert.strictEqual(definitions.length, 5)
+  assert.strictEqual(definitions.length, 7)
   assert.deepStrictEqual(
     definitions.map((definition) => ({ id: definition.id, kind: definition.kind })),
     [
@@ -299,6 +299,8 @@ test('createResourceOverlayDefinitions lists canonical overlay ids and kinds', (
       { id: 'metals', kind: 'rasterAndNodes' },
       { id: 'salt', kind: 'nodes' },
       { id: 'sail', kind: 'raster' },
+      { id: 'freshwater', kind: 'raster' },
+      { id: 'population', kind: 'raster' },
     ],
   )
 })
@@ -310,6 +312,8 @@ test('createDefaultResourceOverlayVisibility defaults every overlay off', () => 
     metals: false,
     salt: false,
     sail: false,
+    freshwater: false,
+    population: false,
   })
 })
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #392 (Increment 1 — single-colony survival) on top of the #390 colonization epic branch.

- **Colonization commit & epoch loop**: `beginColonizationCommit` now resolves founding survival, primary claims, population collapse, and founding dynasty; `applyEpochStep` / `applyColonizationEpoch` advance time with survival triad caps, ruin transitions, and committed tips.
- **Domain modules**: freshwater availability + overlay, primary claim map, haul-shed isochrone extraction, survival triad, salt spoilage, settlement tiers, founding dynasty, and WFC-style seeded integer population collapse (urban core + arable hinterland scatter on legal land only).
- **Map & UI**: freshwater and population raster overlays; population overlay is red, more opaque, and auto-enabled when colonization begins; founding pin / haul-shed preview hidden in `running`; epoch step control wired through the page controller.

Closes #401, #402, #403, #404, #405, #406, #407, #408. Leaves #392 open for manual close after playtesting.

## Test plan

- [x] `npm test` — colonization, overlay, and page controller suites pass
- [x] `npx eslint --max-warnings 0` on touched files
- [x] World Builder: generate terrain → enter colonization setup → pick landing → **Begin colonization**
- [x] Confirm population overlay turns on automatically (red scatter on land, not water)
- [x] **Epoch step** advances epoch by `epochBatch`; settlement population/tier update; map refreshes
- [x] Toggle freshwater overlay; verify it aligns with claimed freshwater cells
- [x] Reload page mid-run; population overlay restores on session hydrate
- [x] Reset colonization returns to terrain authoring